### PR TITLE
Complete transfer from `envoy-perf/nighthawk`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,6 @@
+import %workspace%/nighthawk/envoy/.bazelrc
+build:asan --action_env="CC=clang"
+build:asan --action_env="CXX=clang++"
+
+build:tsan --action_env="CC=clang"
+build:tsan --action_env="CXX=clang++"

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-import %workspace%/nighthawk/envoy/.bazelrc
+import %workspace%/envoy/.bazelrc
 build:asan --action_env="CC=clang"
 build:asan --action_env="CXX=clang++"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,70 @@
+references:
+  envoy-build-image: &envoy-build-image
+    envoyproxy/envoy-build:b3995b7c5e3846f80f6f09436043ec4c8c8f762a
+
+version: 2
+jobs:
+  build:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh build
+  test:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh test
+  clang_tidy:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh clang_tidy
+  test_with_valgrind:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh test_with_valgrind
+  coverage:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh coverage
+      - store_artifacts:
+          path: /root/project/generated
+          destination: /      
+  asan:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh asan
+  tsan:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh tsan
+
+workflows:
+  version: 2
+  all:
+    jobs:
+      - build
+      - test
+      - clang_tidy
+#      - test_with_valgrind
+      - coverage
+      - asan
+      - tsan

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+ColumnLimit: 100
+DerivePointerAlignment: false
+PointerAlignment: Left
+SortIncludes: true
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,13 @@
+Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements'
+
+WarningsAsErrors: 'bugprone-assert-side-effect,modernize-make-shared,modernize-make-unique,readability-redundant-smartptr-get,readability-braces-around-statements,readability-redundant-string-cstr,bugprone-use-after-move'
+
+CheckOptions:
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           'ASSERT'
+
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view;absl::string_view'
+
+  - key:             modernize-use-auto.MinTypeNameLength
+    value:           '10'

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ generated/
 .local
 .cmake
 .rnd
+.vscode/
 bazel.output.txt
-measurements/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+bazel-*
+.DS_Store
+._.DS_Store
+res.txt
+compile_commands.json
+.cache
+generated/
+.local
+.cmake
+.rnd
+bazel.output.txt
+measurements/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "envoy"]
+	path = envoy
+	url = https://github.com/envoyproxy/envoy.git

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,5 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_basic_cc_library",
     "envoy_cc_binary",
 )
 
@@ -10,6 +9,6 @@ envoy_cc_binary(
     name = "nighthawk_client",
     repository = "@envoy",
     deps = [
-        "//nighthawk/source/exe:nighthawk_client_entry_lib",
+        "//source/exe:nighthawk_client_entry_lib",
     ],
 )

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ First, follow steps 1 and 2 over at [Quick start Bazel build for developers](htt
 ## Building and testing Nighthawk
 ```bash
 # test it
-bazel test -c fastbuild //nighthawk/test:nighthawk_test
+bazel test -c fastbuild //test:nighthawk_test
 ```
 # build it. for best accuracy it is important to specify -c opt.
-bazel build -c opt //nighthawk:nighthawk_client
+bazel build -c opt //:nighthawk_client
 
 ## Using the Nighthawk client
 
 ```
-➜ bazel-bin/nighthawk/nighthawk_client --help
+➜ bazel-bin/nighthawk_client --help
 
 USAGE: 
 
-   bazel-bin/nighthawk/nighthawk_client  [--output-format <human|yaml
+   bazel-bin/nighthawk_client  [--output-format <human|yaml
                                         |json>] [-v <trace|debug|info|warn
                                         |error|critical>] [--concurrency
                                         <string>] [--h2] [--timeout
@@ -99,7 +99,7 @@ Where:
 $ taskset -c 3 /path/to/envoy --config-path nighthawk/tools/envoy.yaml
 
 # run a quick benchmark using cpu cores 4 and 5.
-$ taskset -c 4-5 bazel-bin/nighthawk/nighthawk_client --rps 1000 --concurrency auto http://127.0.0.1:10000/
+$ taskset -c 4-5 bazel-bin/nighthawk_client --rps 1000 --concurrency auto http://127.0.0.1:10000/
 Nighthawk - A layer 7 protocol benchmarking tool.
 
 benchmark_http_client.queue_to_connect: 9997 samples, mean: 0.000010513s, pstdev: 0.000007883s

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,68 @@
+workspace(name = "nighthawk")
+
+local_repository(
+    name = "envoy",
+    path = "nighthawk/envoy",
+)
+
+load("@envoy//bazel:repositories.bzl", "GO_VERSION", "envoy_dependencies")
+load("@envoy//bazel:cc_configure.bzl", "cc_configure")
+
+envoy_dependencies()
+
+load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "dep_hdrhistogram_c",
+    build_file_content = """
+cc_library(
+    name = "hdrhistogram_c",
+    srcs = [
+        "src/hdr_encoding.c",
+        "src/hdr_histogram.c",
+        "src/hdr_histogram_log.c",
+        "src/hdr_interval_recorder.c",
+        "src/hdr_thread.c",
+        "src/hdr_time.c",
+        "src/hdr_writer_reader_phaser.c",
+    ],
+    hdrs = [
+        "src/hdr_atomic.h",
+        "src/hdr_encoding.h",
+        "src/hdr_endian.h",
+        "src/hdr_histogram.h",
+        "src/hdr_histogram_log.h",
+        "src/hdr_interval_recorder.h",
+        "src/hdr_tests.h",
+        "src/hdr_thread.h",
+        "src/hdr_time.h",
+        "src/hdr_writer_reader_phaser.h",
+    ],
+    copts = [
+        "-std=gnu99",
+        "-Wno-implicit-function-declaration",
+        "-Wno-error",
+    ],
+    visibility = ["//visibility:public"],
+)        
+""",
+    sha256 = "6928ba22634d9a5b2752227309c9097708e790db6a285fa5c3f40a219bf7ee98",
+    strip_prefix = "HdrHistogram_c-0.9.8",
+    url = "https://github.com/HdrHistogram/HdrHistogram_c/archive/0.9.8.tar.gz",
+)
+
+cc_configure()
+
+load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
+
+api_dependencies()
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(go_version = GO_VERSION)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "nighthawk")
 
 local_repository(
     name = "envoy",
-    path = "nighthawk/envoy",
+    path = "envoy",
 )
 
 load("@envoy//bazel:repositories.bzl", "GO_VERSION", "envoy_dependencies")

--- a/bazel/gen_compilation_database.sh
+++ b/bazel/gen_compilation_database.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+RELEASE_VERSION=0.3.1
+
+if [[ ! -d bazel-compilation-database-${RELEASE_VERSION} ]]; then
+  curl -L https://github.com/grailbio/bazel-compilation-database/archive/${RELEASE_VERSION}.tar.gz | tar -xz
+fi
+
+bazel-compilation-database-${RELEASE_VERSION}/generate.sh $@

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -1,0 +1,1 @@
+# TODO(oschaaf): this is a stub. symlinking to envoy's copy fails here.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -1,0 +1,152 @@
+#!/bin/bash -e
+
+function do_build () {
+    bazel build $BAZEL_BUILD_OPTIONS --verbose_failures=true //nighthawk:nighthawk_client
+}
+
+function do_test() {
+    bazel test $BAZEL_BUILD_OPTIONS $BAZEL_TEST_OPTIONS --test_output=all \
+    //nighthawk/test:nighthawk_test
+}
+
+function do_test_with_valgrind() {
+    apt-get update && apt-get install valgrind && \
+    bazel build $BAZEL_BUILD_OPTIONS -c dbg //nighthawk/test:nighthawk_test && \
+    nighthawk/tools/valgrind-tests.sh
+}
+
+function do_clang_tidy() {
+    ci/run_clang_tidy.sh
+}
+
+function do_coverage() {
+    ci/run_coverage.sh
+}
+
+function setup_gcc_toolchain() {
+    export CC=gcc
+    export CXX=g++
+    echo "$CC/$CXX toolchain configured"
+}
+
+function setup_clang_toolchain() {
+    export PATH=/usr/lib/llvm-7/bin:$PATH
+    export CC=clang
+    export CXX=clang++
+    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-7/bin/llvm-symbolizer
+    echo "$CC/$CXX toolchain configured"
+}
+
+# TODO(oschaaf): This is quite the hack, we want to revisit this and back it out
+# once we figure out why bazel coverage isn't working as expected without doing
+# this. Once we do figure that out, this hack *could* be rewritten to assert that the linker
+# that gets used is the actual one we requested.
+# Overrides both ld and ld.gold with llvm's ld.lld.
+function override_linker_with_lld() {
+    WORK_DIR=`mktemp -d -p "$DIR"`
+    export PATH="$WORK_DIR:$PATH"
+    ln -s "$(which ld.lld)" "$WORK_DIR/ld"
+    # We write a script to call ld.lld as 'ld' because it objects to being
+    # called `ld.gold` on some systems.
+    script="#!/bin/bash
+$WORK_DIR/ld \$@
+"
+    echo "$script" > "$WORK_DIR/ld.gold"
+    chmod +x "$WORK_DIR/ld.gold"
+    echo "lld linker override in place:"
+    # As a test, we output the version of ld.lld, which has some diagnostic value as well.
+    $WORK_DIR/ld.gold -v
+}
+
+function run_bazel() {
+    declare -r BAZEL_OUTPUT="${SRCDIR}"/bazel.output.txt
+    bazel $* | tee "${BAZEL_OUTPUT}"
+    declare BAZEL_STATUS="${PIPESTATUS[0]}"
+    if [ "${BAZEL_STATUS}" != "0" ]
+    then
+        declare -r FAILED_TEST_LOGS="$(grep "  /build.*test.log" "${BAZEL_OUTPUT}" | sed -e 's/  \/build.*\/testlogs\/\(.*\)/\1/')"
+        cd bazel-testlogs
+        for f in ${FAILED_TEST_LOGS}
+        do
+            echo "Failed test log ${f}"
+            cp --parents -f $f "${ENVOY_FAILED_TEST_LOGS}"
+        done
+        exit "${BAZEL_STATUS}"
+    fi
+}
+
+function do_asan() {
+    echo "bazel ASAN/UBSAN debug build with tests"
+    echo "Building and testing envoy tests..."
+    override_linker_with_lld
+    cd "${SRCDIR}"
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan //nighthawk/test:nighthawk_test
+}
+
+function do_tsan() {
+    echo "bazel TSAN debug build with tests"
+    echo "Building and testing envoy tests..."
+    override_linker_with_lld
+    cd "${SRCDIR}"
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan //nighthawk/test:nighthawk_test
+}
+
+[ -z "${NUM_CPUS}" ] && NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
+
+if [ -n "$CIRCLECI" ]; then
+    # TODO(oschaaf): hack, this should be done in .circleci/config.yml
+    git submodule update --init --recursive
+    if [[ -f "${HOME:-/root}/.gitconfig" ]]; then
+        mv "${HOME:-/root}/.gitconfig" "${HOME:-/root}/.gitconfig_save"
+        echo 1
+    fi
+
+    NUM_CPUS=8
+    if [ "$1" == "coverage" ]; then
+        NUM_CPUS=6
+    fi
+fi
+
+export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"
+export BAZEL_BUILD_OPTIONS=" \
+--verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
+--jobs=${NUM_CPUS} --show_task_finish --experimental_generate_json_trace_profile ${BAZEL_BUILD_EXTRA_OPTIONS}"
+export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
+--test_env=UBSAN_OPTIONS=print_stacktrace=1 \
+--cache_test_results=no --test_output=all ${BAZEL_EXTRA_TEST_OPTIONS}"
+[[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"
+
+setup_clang_toolchain
+
+if [ "$1" == "coverage" ]; then
+    setup_gcc_toolchain
+fi
+
+case "$1" in
+    build)
+        do_build
+    ;;
+    test)
+        do_test
+    ;;
+    test_with_valgrind)
+        do_test_with_valgrind
+    ;;
+    clang_tidy)
+        export RUN_FULL_CLANG_TIDY=1
+        do_clang_tidy
+    ;;
+    coverage)
+        do_coverage
+    ;;
+    asan)
+        do_asan
+    ;;
+    tsan)
+        do_tsan
+    ;;
+    *)
+        echo "must be one of [build,test,clang_tidy,test_with_valgrind,coverage,asan,tsan]"
+        exit 1
+    ;;
+esac

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -1,17 +1,17 @@
 #!/bin/bash -e
 
 function do_build () {
-    bazel build $BAZEL_BUILD_OPTIONS --verbose_failures=true //nighthawk:nighthawk_client
+    bazel build $BAZEL_BUILD_OPTIONS --verbose_failures=true //:nighthawk_client
 }
 
 function do_test() {
     bazel test $BAZEL_BUILD_OPTIONS $BAZEL_TEST_OPTIONS --test_output=all \
-    //nighthawk/test:nighthawk_test
+    //test:nighthawk_test
 }
 
 function do_test_with_valgrind() {
     apt-get update && apt-get install valgrind && \
-    bazel build $BAZEL_BUILD_OPTIONS -c dbg //nighthawk/test:nighthawk_test && \
+    bazel build $BAZEL_BUILD_OPTIONS -c dbg //test:nighthawk_test && \
     nighthawk/tools/valgrind-tests.sh
 }
 
@@ -80,7 +80,7 @@ function do_asan() {
     echo "Building and testing envoy tests..."
     override_linker_with_lld
     cd "${SRCDIR}"
-    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan //nighthawk/test:nighthawk_test
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan //test:nighthawk_test
 }
 
 function do_tsan() {
@@ -88,7 +88,7 @@ function do_tsan() {
     echo "Building and testing envoy tests..."
     override_linker_with_lld
     cd "${SRCDIR}"
-    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan //nighthawk/test:nighthawk_test
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan //test:nighthawk_test
 }
 
 [ -z "${NUM_CPUS}" ] && NUM_CPUS=`grep -c ^processor /proc/cpuinfo`

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+echo "Generating compilation database..."
+# The compilation database generate script doesn't support passing build options via CLI.
+# Writing them into bazelrc
+echo "build ${BAZEL_BUILD_OPTIONS}" >> .bazelrc
+
+# bazel build need to be run to setup virtual includes, generating files which are consumed
+# by clang-tidy
+tools/gen_compilation_database.py --run_bazel_build --include_headers
+
+if [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
+    echo "Running full clang-tidy..."
+    run-clang-tidy-7 -extra-arg-before=-xc++
+    elif [[ -z "${CIRCLE_PR_NUMBER}" && "$CIRCLE_BRANCH" == "master" ]]; then
+    echo "On master branch, running clang-tidy-diff against previous commit..."
+    git diff HEAD^ | clang-tidy-diff-7.py -p 1
+else
+    echo "Running clang-tidy-diff against master branch..."
+    git fetch https://github.com/envoyproxy/envoy-perf.git master
+    git diff $(git merge-base HEAD FETCH_HEAD)..HEAD | clang-tidy-diff-7.py -p 1
+fi

--- a/ci/run_coverage.sh
+++ b/ci/run_coverage.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+[[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"
+[[ -z "${BAZEL_COVERAGE}" ]] && BAZEL_COVERAGE=bazel
+[[ -z "${VALIDATE_COVERAGE}" ]] && VALIDATE_COVERAGE=true
+
+# This is the target that will be run to generate coverage data. It can be overridden by consumer
+# projects that want to run coverage on a different/combined target.
+[[ -z "${COVERAGE_TARGET}" ]] && COVERAGE_TARGET="//nighthawk/test/..."
+
+bazel clean
+
+# Generate coverage data.
+"${BAZEL_COVERAGE}" coverage ${BAZEL_TEST_OPTIONS} \
+"${COVERAGE_TARGET}"  \
+--experimental_cc_coverage \
+--instrumentation_filter=//nighthawk/source/...,//nighthawk/include/... \
+--coverage_report_generator=@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main \
+--combined_report=lcov
+
+# Generate HTML
+declare -r COVERAGE_DIR="${SRCDIR}"/generated/coverage
+declare -r COVERAGE_SUMMARY="${COVERAGE_DIR}/coverage_summary.txt"
+mkdir -p "${COVERAGE_DIR}"
+genhtml bazel-out/_coverage/_coverage_report.dat --output-directory="${COVERAGE_DIR}" | tee "${COVERAGE_SUMMARY}"
+
+[[ -z "${ENVOY_COVERAGE_DIR}" ]] || rsync -av "${COVERAGE_DIR}"/ "${ENVOY_COVERAGE_DIR}"
+
+if [ "$VALIDATE_COVERAGE" == "true" ]
+then
+    COVERAGE_VALUE=$(grep -Po '.*lines[.]*: \K(\d|\.)*' "${COVERAGE_SUMMARY}")
+    # TODO(oschaaf): The target is 97.5%, so up this whenever possible in follow ups.
+    COVERAGE_THRESHOLD=96.6
+    COVERAGE_FAILED=$(echo "${COVERAGE_VALUE}<${COVERAGE_THRESHOLD}" | bc)
+    
+    echo "HTML coverage report is in ${COVERAGE_DIR}/coverage.html"
+    
+    if test ${COVERAGE_FAILED} -eq 1; then
+        echo Code coverage ${COVERAGE_VALUE} is lower than limit of ${COVERAGE_THRESHOLD}
+        exit 1
+    else
+        echo Code coverage ${COVERAGE_VALUE} is good and higher than limit of ${COVERAGE_THRESHOLD}
+    fi
+fi

--- a/ci/run_coverage.sh
+++ b/ci/run_coverage.sh
@@ -8,7 +8,7 @@ set -e
 
 # This is the target that will be run to generate coverage data. It can be overridden by consumer
 # projects that want to run coverage on a different/combined target.
-[[ -z "${COVERAGE_TARGET}" ]] && COVERAGE_TARGET="//nighthawk/test/..."
+[[ -z "${COVERAGE_TARGET}" ]] && COVERAGE_TARGET="//test/..."
 
 bazel clean
 
@@ -16,7 +16,7 @@ bazel clean
 "${BAZEL_COVERAGE}" coverage ${BAZEL_TEST_OPTIONS} \
 "${COVERAGE_TARGET}"  \
 --experimental_cc_coverage \
---instrumentation_filter=//nighthawk/source/...,//nighthawk/include/... \
+--instrumentation_filter=//source/...,//include/... \
 --coverage_report_generator=@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main \
 --combined_report=lcov
 

--- a/include/nighthawk/client/BUILD
+++ b/include/nighthawk/client/BUILD
@@ -19,7 +19,7 @@ envoy_basic_cc_library(
     ],
     include_prefix = "nighthawk/client",
     deps = [
-        "//nighthawk/include/nighthawk/common:base_includes",
+        "//include/nighthawk/common:base_includes",
         "@envoy//include/envoy/common:base_includes",
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/common/common:non_copyable",

--- a/include/nighthawk/client/factories.h
+++ b/include/nighthawk/client/factories.h
@@ -10,13 +10,13 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/stats/store.h"
 
+#include "common/utility.h"
 #include "nighthawk/client/benchmark_client.h"
 #include "nighthawk/client/options.h"
 #include "nighthawk/client/output_formatter.h"
 #include "nighthawk/common/platform_util.h"
 #include "nighthawk/common/sequencer.h"
 #include "nighthawk/common/statistic.h"
-#include "nighthawk/source/common/utility.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -5,7 +5,8 @@
 #include <string>
 
 #include "envoy/common/pure.h"
-#include "nighthawk/source/client/options.pb.h"
+
+#include "source/client/options.pb.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/include/nighthawk/common/statistic.h
+++ b/include/nighthawk/common/statistic.h
@@ -8,7 +8,7 @@
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
 
-#include "nighthawk/source/client/output.pb.h"
+#include "source/client/output.pb.h"
 
 namespace Nighthawk {
 

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -39,9 +39,9 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":benchmark_options_cc",
-        "//nighthawk/include/nighthawk/client:client_includes",
-        "//nighthawk/include/nighthawk/common:base_includes",
-        "//nighthawk/source/common:nighthawk_common_lib",
+        "//include/nighthawk/client:client_includes",
+        "//include/nighthawk/common:base_includes",
+        "//source/common:nighthawk_common_lib",
         "@envoy//source/common/common:compiler_requirements_lib",
         "@envoy//source/common/common:thread_impl_lib_posix",
         "@envoy//source/common/filesystem:filesystem_lib",

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/client/benchmark_client_impl.h"
+#include "client/benchmark_client_impl.h"
 
 #include "absl/strings/str_split.h"
 
@@ -21,7 +21,7 @@
 
 #include "nighthawk/common/statistic.h"
 
-#include "nighthawk/source/client/stream_decoder.h"
+#include "client/stream_decoder.h"
 
 using namespace std::chrono_literals;
 

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -19,9 +19,9 @@
 #include "common/http/header_map_impl.h"
 #include "common/runtime/runtime_impl.h"
 
-#include "nighthawk/source/client/stream_decoder.h"
-#include "nighthawk/source/common/ssl.h"
-#include "nighthawk/source/common/utility.h"
+#include "client/stream_decoder.h"
+#include "common/ssl.h"
+#include "common/utility.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/source/client/client.cc
+++ b/source/client/client.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/client/client.h"
+#include "client/client.h"
 
 #include <chrono>
 #include <fstream>
@@ -20,13 +20,13 @@
 #include "common/runtime/runtime_impl.h"
 #include "common/thread_local/thread_local_impl.h"
 
+#include "client/client_worker_impl.h"
+#include "client/factories_impl.h"
+#include "client/options_impl.h"
+#include "common/frequency.h"
+#include "common/utility.h"
 #include "nighthawk/client/output_formatter.h"
-#include "nighthawk/source/client/client_worker_impl.h"
-#include "nighthawk/source/client/factories_impl.h"
-#include "nighthawk/source/client/options_impl.h"
-#include "nighthawk/source/client/output.pb.h"
-#include "nighthawk/source/common/frequency.h"
-#include "nighthawk/source/common/utility.h"
+#include "source/client/output.pb.h"
 
 using namespace std::chrono_literals;
 

--- a/source/client/client_worker_impl.cc
+++ b/source/client/client_worker_impl.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/client/client_worker_impl.h"
+#include "client/client_worker_impl.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/source/client/client_worker_impl.h
+++ b/source/client/client_worker_impl.h
@@ -7,8 +7,8 @@
 #include "nighthawk/client/factories.h"
 #include "nighthawk/common/sequencer.h"
 
-#include "nighthawk/source/common/utility.h"
-#include "nighthawk/source/common/worker_impl.h"
+#include "common/utility.h"
+#include "common/worker_impl.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -1,14 +1,14 @@
-#include "nighthawk/source/client/factories_impl.h"
+#include "client/factories_impl.h"
 
 #include "common/stats/isolated_store_impl.h"
 
-#include "nighthawk/source/client/benchmark_client_impl.h"
-#include "nighthawk/source/client/output_formatter_impl.h"
-#include "nighthawk/source/common/platform_util_impl.h"
-#include "nighthawk/source/common/rate_limiter_impl.h"
-#include "nighthawk/source/common/sequencer_impl.h"
-#include "nighthawk/source/common/statistic_impl.h"
-#include "nighthawk/source/common/utility.h"
+#include "client/benchmark_client_impl.h"
+#include "client/output_formatter_impl.h"
+#include "common/platform_util_impl.h"
+#include "common/rate_limiter_impl.h"
+#include "common/sequencer_impl.h"
+#include "common/statistic_impl.h"
+#include "common/utility.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/source/client/factories_impl.h
+++ b/source/client/factories_impl.h
@@ -6,7 +6,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/stats/store.h"
 
-#include "nighthawk/source/common/platform_util_impl.h"
+#include "common/platform_util_impl.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -1,10 +1,10 @@
-#include "nighthawk/source/client/options_impl.h"
+#include "client/options_impl.h"
 
 #include <cmath>
 
 #include "tclap/CmdLine.h"
 
-#include "nighthawk/source/common/utility.h"
+#include "common/utility.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -7,7 +7,7 @@
 #include "nighthawk/client/options.h"
 #include "nighthawk/common/exception.h"
 
-#include "nighthawk/source/client/options.pb.h"
+#include "source/client/options.pb.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/source/client/output.proto
+++ b/source/client/output.proto
@@ -5,7 +5,7 @@ package nighthawk.client;
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-import "nighthawk/source/client/options.proto";
+import "source/client/options.proto";
 
 message Counter {
   string name = 1;

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/client/output_formatter_impl.h"
+#include "client/output_formatter_impl.h"
 
 #include <chrono>
 #include <sstream>

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/client/stream_decoder.h"
+#include "client/stream_decoder.h"
 
 #include <memory>
 

--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -27,9 +27,9 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
-        "//nighthawk/include/nighthawk/client:client_includes",
-        "//nighthawk/include/nighthawk/common:base_includes",
-        "//nighthawk/source/client:benchmark_options_cc",
+        "//include/nighthawk/client:client_includes",
+        "//include/nighthawk/common:base_includes",
+        "//source/client:benchmark_options_cc",
         "@dep_hdrhistogram_c//:hdrhistogram_c",
         "@envoy//source/common/common:compiler_requirements_lib",
         "@envoy//source/common/common:minimal_logger_lib",

--- a/source/common/rate_limiter_impl.cc
+++ b/source/common/rate_limiter_impl.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/common/rate_limiter_impl.h"
+#include "common/rate_limiter_impl.h"
 
 #include "common/common/assert.h"
 

--- a/source/common/sequencer_impl.cc
+++ b/source/common/sequencer_impl.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/common/sequencer_impl.h"
+#include "common/sequencer_impl.h"
 
 #include "common/common/assert.h"
 

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -1,5 +1,5 @@
 
-#include "nighthawk/source/common/statistic_impl.h"
+#include "common/statistic_impl.h"
 
 #include <cmath>
 #include <sstream>

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -7,8 +7,8 @@
 
 #include "common/common/logger.h"
 
+#include "common/frequency.h"
 #include "nighthawk/common/statistic.h"
-#include "nighthawk/source/common/frequency.h"
 
 namespace Nighthawk {
 

--- a/source/common/utility.cc
+++ b/source/common/utility.cc
@@ -6,7 +6,7 @@
 #include "common/http/utility.h"
 #include "common/network/utility.h"
 
-#include "nighthawk/source/common/utility.h"
+#include "common/utility.h"
 
 namespace Nighthawk {
 

--- a/source/common/worker_impl.cc
+++ b/source/common/worker_impl.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/common/worker_impl.h"
+#include "common/worker_impl.h"
 
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -14,7 +14,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
-        "//nighthawk/source/client:nighthawk_client_lib",
+        "//source/client:nighthawk_client_lib",
         "@envoy//source/common/common:thread_lib",
     ],
 )

--- a/source/exe/client_main_entry.cc
+++ b/source/exe/client_main_entry.cc
@@ -1,4 +1,4 @@
-#include "nighthawk/source/client/client.h"
+#include "client/client.h"
 
 #include "absl/debugging/symbolize.h"
 

--- a/support/hooks/prepare-commit-msg
+++ b/support/hooks/prepare-commit-msg
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# A git commit hook that will automatically append a DCO signoff to the bottom
+# of any commit message that doesn't have one. This append happens after the git
+# default message is generated, but before the user is dropped into the commit
+# message editor.
+#
+# To enable this hook, run `bootstrap`, or run the following from the root of
+# the repo. (Note that `bootstrap` will correctly install this even if this code
+# is located in a submodule, while the following won't.)
+#
+# $ ln -s ../../support/hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+
+COMMIT_MESSAGE_FILE="$1"
+AUTHOR=$(git var GIT_AUTHOR_IDENT)
+SIGNOFF=$(echo $AUTHOR | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+
+# Check for DCO signoff message. If one doesn't exist, append one and then warn
+# the user that you did so.
+if ! $(grep -qs "^$SIGNOFF" "$COMMIT_MESSAGE_FILE") ; then
+  echo -e "\n$SIGNOFF" >> "$COMMIT_MESSAGE_FILE"
+  echo -e "Appended the following signoff to the end of the commit message:\n  $SIGNOFF\n"
+fi

--- a/test/BUILD
+++ b/test/BUILD
@@ -12,8 +12,8 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     repository = "@envoy",
     deps = [
-        "//nighthawk/include/nighthawk/common:base_includes",
-        "//nighthawk/source/client:nighthawk_client_lib",
+        "//include/nighthawk/common:base_includes",
+        "//source/client:nighthawk_client_lib",
         "@envoy//test/test_common:simulated_time_system_lib",
     ],
 )
@@ -47,9 +47,9 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
-        "//nighthawk/source/client:nighthawk_client_lib",
-        "//nighthawk/test:nighthawk_mocks",
-        "//nighthawk/test/test_common:environment_lib",
+        "//source/client:nighthawk_client_lib",
+        "//test:nighthawk_mocks",
+        "//test/test_common:environment_lib",
         "@envoy//source/common/filesystem:filesystem_lib",
         "@envoy//source/common/network:dns_lib",
         "@envoy//source/common/protobuf:utility_lib",

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -16,12 +16,12 @@
 #include "common/stats/isolated_store_impl.h"
 #include "common/thread_local/thread_local_impl.h"
 
-#include "nighthawk/source/client/benchmark_client_impl.h"
-#include "nighthawk/source/common/platform_util_impl.h"
-#include "nighthawk/source/common/rate_limiter_impl.h"
-#include "nighthawk/source/common/sequencer_impl.h"
-#include "nighthawk/source/common/statistic_impl.h"
-#include "nighthawk/source/common/utility.h"
+#include "client/benchmark_client_impl.h"
+#include "common/platform_util_impl.h"
+#include "common/rate_limiter_impl.h"
+#include "common/sequencer_impl.h"
+#include "common/statistic_impl.h"
+#include "common/utility.h"
 
 #include "envoy/thread_local/thread_local.h"
 #include "test/mocks/runtime/mocks.h"
@@ -49,7 +49,7 @@ public:
   static void SetUpTestCase() {
     Envoy::Filesystem::InstanceImplPosix file_system;
     envoy_config = file_system.fileReadToEnd(Envoy::TestEnvironment::runfilesPath(
-        "nighthawk/test/test_data/benchmark_http_client_test_envoy.yaml"));
+        "test/test_data/benchmark_http_client_test_envoy.yaml"));
     envoy_config = Envoy::TestEnvironment::substitute(envoy_config);
   }
 

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -15,11 +15,11 @@
 #include "common/common/thread_impl.h"
 #include "common/filesystem/filesystem_impl.h"
 
-#include "nighthawk/test/mocks.h"
+#include "test/mocks.h"
 
-#include "nighthawk/source/client/client.h"
-#include "nighthawk/source/client/factories_impl.h"
-#include "nighthawk/source/client/options_impl.h"
+#include "client/client.h"
+#include "client/factories_impl.h"
+#include "client/options_impl.h"
 
 using namespace std::chrono_literals;
 
@@ -33,9 +33,9 @@ public:
 
   std::string readEnvoyConfiguration() {
     Envoy::Filesystem::InstanceImplPosix file_system;
-    const std::string config = file_system.fileReadToEnd(Envoy::TestEnvironment::runfilesPath(
-        "nighthawk/test/test_data/benchmark_http_client_test_envoy.yaml"));
-    return Envoy::TestEnvironment::substitute(config);
+    std::string envoy_config = file_system.fileReadToEnd(Envoy::TestEnvironment::runfilesPath(
+        "test/test_data/benchmark_http_client_test_envoy.yaml"));
+    return Envoy::TestEnvironment::substitute(envoy_config);
   }
 
   void SetUp() override {

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -11,10 +11,10 @@
 
 #include "test/mocks/thread_local/mocks.h"
 
-#include "nighthawk/test/mocks.h"
+#include "test/mocks.h"
 
-#include "nighthawk/source/client/client_worker_impl.h"
-#include "nighthawk/source/common/statistic_impl.h"
+#include "client/client_worker_impl.h"
+#include "common/statistic_impl.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -9,9 +9,9 @@
 
 #include "common/api/api_impl.h"
 
-#include "nighthawk/test/mocks.h"
+#include "test/mocks.h"
 
-#include "nighthawk/source/client/factories_impl.h"
+#include "client/factories_impl.h"
 
 using namespace std::chrono_literals;
 

--- a/test/frequency_test.cc
+++ b/test/frequency_test.cc
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
-#include "nighthawk/source/common/frequency.h"
+#include "common/frequency.h"
 
 namespace Nighthawk {
 

--- a/test/mocks.cc
+++ b/test/mocks.cc
@@ -3,7 +3,7 @@
 
 #include "gmock/gmock.h"
 
-#include "nighthawk/test/mocks.h"
+#include "test/mocks.h"
 
 using namespace std::chrono_literals;
 

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -20,7 +20,7 @@
 #include "nighthawk/common/sequencer.h"
 #include "nighthawk/common/statistic.h"
 
-#include "nighthawk/source/common/utility.h"
+#include "common/utility.h"
 
 using namespace std::chrono_literals;
 

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -2,7 +2,7 @@
 
 #include "test/test_common/utility.h"
 
-#include "nighthawk/source/client/options_impl.h"
+#include "client/options_impl.h"
 
 using namespace std::chrono_literals;
 

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -2,16 +2,16 @@
 
 #include "gtest/gtest.h"
 
-#include "nighthawk/source/client/output_formatter_impl.h"
+#include "client/output_formatter_impl.h"
 
 #include "test/test_common/simulated_time_system.h"
 
 #include "common/filesystem/filesystem_impl.h"
 
-#include "nighthawk/source/client/options.pb.h"
-#include "nighthawk/source/common/statistic_impl.h"
-#include "nighthawk/test/mocks.h"
-#include "nighthawk/test/test_common/environment.h"
+#include "common/statistic_impl.h"
+#include "source/client/options.pb.h"
+#include "test/mocks.h"
+#include "test/test_common/environment.h"
 
 using namespace std::chrono_literals;
 using namespace testing;
@@ -56,17 +56,17 @@ public:
 
 TEST_F(OutputFormatterTest, CliFormatter) {
   ConsoleOutputFormatterImpl formatter(time_system_, options_);
-  expectEqualToGoldFile(formatter, "nighthawk/test/test_data/output_formatter.txt.gold");
+  expectEqualToGoldFile(formatter, "test/test_data/output_formatter.txt.gold");
 }
 
 TEST_F(OutputFormatterTest, JsonFormatter) {
   JsonOutputFormatterImpl formatter(time_system_, options_);
-  expectEqualToGoldFile(formatter, "nighthawk/test/test_data/output_formatter.json.gold");
+  expectEqualToGoldFile(formatter, "test/test_data/output_formatter.json.gold");
 }
 
 TEST_F(OutputFormatterTest, YamlFormatter) {
   YamlOutputFormatterImpl formatter(time_system_, options_);
-  expectEqualToGoldFile(formatter, "nighthawk/test/test_data/output_formatter.yaml.gold");
+  expectEqualToGoldFile(formatter, "test/test_data/output_formatter.yaml.gold");
 }
 
 } // namespace Client

--- a/test/platform_util_test.cc
+++ b/test/platform_util_test.cc
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
-#include "nighthawk/source/common/platform_util_impl.h"
+#include "common/platform_util_impl.h"
 
 namespace Nighthawk {
 

--- a/test/rate_limiter_test.cc
+++ b/test/rate_limiter_test.cc
@@ -6,8 +6,8 @@
 
 #include "nighthawk/common/exception.h"
 
-#include "nighthawk/source/common/frequency.h"
-#include "nighthawk/source/common/rate_limiter_impl.h"
+#include "common/frequency.h"
+#include "common/rate_limiter_impl.h"
 
 using namespace std::chrono_literals;
 

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -13,14 +13,14 @@
 #include "test/mocks/event/mocks.h"
 #include "test/test_common/simulated_time_system.h"
 
-#include "nighthawk/test/mocks.h"
+#include "test/mocks.h"
 
 #include "nighthawk/common/exception.h"
 #include "nighthawk/common/platform_util.h"
 
-#include "nighthawk/source/common/rate_limiter_impl.h"
-#include "nighthawk/source/common/sequencer_impl.h"
-#include "nighthawk/source/common/statistic_impl.h"
+#include "common/rate_limiter_impl.h"
+#include "common/sequencer_impl.h"
+#include "common/statistic_impl.h"
 
 using namespace std::chrono_literals;
 

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -12,9 +12,8 @@
 
 #include "test/test_common/utility.h"
 
-#include "nighthawk/common/statistic.h"
-#include "nighthawk/source/common/statistic_impl.h"
-#include "nighthawk/test/test_common/environment.h"
+#include "common/statistic_impl.h"
+#include "test/test_common/environment.h"
 
 using namespace std::chrono_literals;
 
@@ -257,9 +256,9 @@ TEST(StatisticTest, HdrStatisticPercentilesProto) {
   }
 
   Envoy::MessageUtil util;
-  util.loadFromJson(filesystem.fileReadToEnd(TestEnvironment::runfilesPath(
-                        "nighthawk/test/test_data/hdr_proto_json.gold")),
-                    parsed_json_proto);
+  util.loadFromJson(
+      filesystem.fileReadToEnd(TestEnvironment::runfilesPath("test/test_data/hdr_proto_json.gold")),
+      parsed_json_proto);
   EXPECT_TRUE(util(parsed_json_proto, statistic.toProto()));
 }
 

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -13,10 +13,10 @@
 
 #include "test/mocks/http/mocks.h"
 
-#include "nighthawk/test/mocks.h"
+#include "test/mocks.h"
 
-#include "nighthawk/source/client/stream_decoder.h"
-#include "nighthawk/source/common/statistic_impl.h"
+#include "client/stream_decoder.h"
+#include "common/statistic_impl.h"
 
 using namespace std::chrono_literals;
 

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "test/test_common/environment.h"
+#include "external/envoy/test/test_common/environment.h"
 
 namespace Nighthawk {
 

--- a/test/test_data/benchmark_http_client_test_envoy.yaml
+++ b/test/test_data/benchmark_http_client_test_envoy.yaml
@@ -36,13 +36,13 @@ static_resources:
                   direct_response:
                     status: 200
                     body:
-                      filename: {{ test_rundir }}/nighthawk/test/test_data/lorem_ipsum.txt
+                      filename: {{ test_rundir }}/test/test_data/lorem_ipsum.txt
                 - match:
                     prefix: /404
                   direct_response:
                     status: 404
                     body:
-                      filename: {{ test_rundir }}/nighthawk/test/test_data/lorem_ipsum.txt
+                      filename: {{ test_rundir }}/test/test_data/lorem_ipsum.txt
             http_filters:
             - name: envoy.router
               config:

--- a/test/utility_test.cc
+++ b/test/utility_test.cc
@@ -6,7 +6,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
-#include "nighthawk/source/common/utility.h"
+#include "common/utility.h"
 
 namespace Nighthawk {
 
@@ -94,7 +94,7 @@ public:
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, UtilityAddressResolutionTest,
-                         testing::ValuesIn(Envoy::TestEnvironment::getIpVersionsForTest()),
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          Envoy::TestUtility::ipTestParamsToString);
 
 TEST_P(UtilityAddressResolutionTest, AddressResolution) {

--- a/test/worker_test.cc
+++ b/test/worker_test.cc
@@ -9,9 +9,9 @@
 
 #include "test/mocks/thread_local/mocks.h"
 
-#include "nighthawk/test/mocks.h"
+#include "test/mocks.h"
 
-#include "nighthawk/source/common/worker_impl.h"
+#include "common/worker_impl.h"
 
 namespace Nighthawk {
 

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import json
+import subprocess
+
+
+def generateCompilationDatabase(args):
+    if args.run_bazel_build:
+        subprocess.check_call(["bazel", "build"] + args.bazel_targets)
+
+    gen_compilation_database_sh = os.path.join(
+        os.path.realpath(os.path.dirname(__file__)), "../bazel/gen_compilation_database.sh")
+    subprocess.check_call([gen_compilation_database_sh] + args.bazel_targets)
+
+
+def isHeader(filename):
+    for ext in (".h", ".hh", ".hpp", ".hxx"):
+        if filename.endswith(ext):
+            return True
+    return False
+
+
+def isCompileTarget(target, args):
+    filename = target["file"]
+    if not args.include_headers and isHeader(filename):
+        return False
+
+    if not args.include_genfiles:
+        if filename.startswith("bazel-out/"):
+            return False
+
+    if not args.include_external:
+        if filename.startswith("external/"):
+            return False
+
+    if filename.startswith("google/protobuf"):
+        return False
+
+    if filename.startswith("hdrhistogram_c"):
+        return False
+
+    return True
+
+
+def modifyCompileCommand(target):
+    cxx, options = target["command"].split(" ", 1)
+
+    # Workaround for bazel added C++11 options, those doesn't affect build itself but
+    # clang-tidy will misinterpret them.
+    options = options.replace("-std=c++0x ", "")
+    options = options.replace("-std=c++11 ", "")
+
+    if isHeader(target["file"]):
+        options += " -Wno-pragma-once-outside-header -Wno-unused-const-variable"
+        options += " -Wno-unused-function"
+
+    target["command"] = " ".join(["clang++", options])
+    return target
+
+
+def fixCompilationDatabase(args):
+    with open("compile_commands.json", "r") as db_file:
+        db = json.load(db_file)
+
+    db = [modifyCompileCommand(target)
+          for target in db if isCompileTarget(target, args)]
+
+    # Remove to avoid writing into symlink
+    os.remove("compile_commands.json")
+    with open("compile_commands.json", "w") as db_file:
+        json.dump(db, db_file, indent=2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Generate JSON compilation database')
+    parser.add_argument('--run_bazel_build', action='store_true')
+    parser.add_argument('--include_external', action='store_true')
+    parser.add_argument('--include_genfiles', action='store_true')
+    parser.add_argument('--include_headers', action='store_true')
+    parser.add_argument(
+        'bazel_targets', nargs='*', default=["//nighthawk/source/exe/...", "//nighthawk/test/..."])
+    args = parser.parse_args()
+    generateCompilationDatabase(args)
+    fixCompilationDatabase(args)

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     parser.add_argument('--include_genfiles', action='store_true')
     parser.add_argument('--include_headers', action='store_true')
     parser.add_argument(
-        'bazel_targets', nargs='*', default=["//nighthawk/source/exe/...", "//nighthawk/test/..."])
+        'bazel_targets', nargs='*', default=["//source/exe/...", "//test/..."])
     args = parser.parse_args()
     generateCompilationDatabase(args)
     fixCompilationDatabase(args)

--- a/tools/valgrind-tests.sh
+++ b/tools/valgrind-tests.sh
@@ -1,4 +1,4 @@
 export TEST_WORKSPACE=.
 export TEST_SRCDIR="$(pwd)"
 export ENVOY_IP_TEST_VERSIONS="v4only"
-valgrind --leak-check=full --track-origins=yes --gen-suppressions=all --suppressions=nighthawk/envoy/tools/valgrind-suppressions.txt --suppressions=nighthawk/tools/valgrind-suppressions.txt bazel-bin/nighthawk/test/nighthawk_test
+valgrind --leak-check=full --track-origins=yes --gen-suppressions=all --suppressions=nighthawk/envoy/tools/valgrind-suppressions.txt --suppressions=nighthawk/tools/valgrind-suppressions.txt bazel-bin/test/nighthawk_test

--- a/tools/valgrind.sh
+++ b/tools/valgrind.sh
@@ -1,1 +1,1 @@
-valgrind --leak-check=full --track-origins=yes --gen-suppressions=all --suppressions=nighthawk/envoy/tools/valgrind-suppressions.txt --suppressions=nighthawk/tools/valgrind-suppressions.txt bazel-bin/nighthawk/nighthawk_client --rps 2 http://127.0.0.1:10000/
+valgrind --leak-check=full --track-origins=yes --gen-suppressions=all --suppressions=nighthawk/envoy/tools/valgrind-suppressions.txt --suppressions=nighthawk/tools/valgrind-suppressions.txt bazel-bin/nighthawk_client --rps 2 http://127.0.0.1:10000/


### PR DESCRIPTION
This PR completes the transfer of `envoy-perf/nighthawk` this repo, by fixing the build, tests, and CI.

Needs https://github.com/envoyproxy/nighthawk/pull/4 to go in first, this adds three distinct steps (commits):
- Move over things we need from `envoy-perf` that live outside of `nighthawk/`
- Adds the Envoy submodule
- Amendments to compensate the source-code moving from `nighthawk/` to `/`
