### PR TITLE
Simple test origin

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,3 +12,12 @@ envoy_cc_binary(
         "//source/exe:nighthawk_client_entry_lib",
     ],
 )
+
+envoy_cc_binary(
+    name = "nighthawk_test_server",
+    repository = "@envoy",
+    deps = [
+        "//source/server:http_test_server_filter_config",
+        "@envoy//source/exe:envoy_main_entry_lib",
+    ],
+)

--- a/api/server/BUILD
+++ b/api/server/BUILD
@@ -1,0 +1,9 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+api_proto_library(
+    name = "response_options_proto",
+    srcs = ["response_options.proto"],
+    deps = ["@envoy_api//envoy/api/v2/core:base_export"],
+)

--- a/api/server/response_options.proto
+++ b/api/server/response_options.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package nighthawk.server;
+
+import "google/protobuf/wrappers.proto";
+import "validate/validate.proto";
+import "envoy/api/v2/core/base.proto";
+
+message ResponseOptions {
+    repeated envoy.api.v2.core.HeaderValueOption response_headers = 1;
+    oneof oneof_response_size { 
+      uint32 response_size = 2 [(validate.rules).uint32 = {gte: 0, lte: 4194304}];
+    }
+}

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 
 function do_build () {
-    bazel build $BAZEL_BUILD_OPTIONS --verbose_failures=true //:nighthawk_client
+    bazel build $BAZEL_BUILD_OPTIONS --verbose_failures=true //:nighthawk_client //:nighthawk_test_server
 }
 
 function do_test() {
     bazel test $BAZEL_BUILD_OPTIONS $BAZEL_TEST_OPTIONS --test_output=all \
-    //test:nighthawk_test
+    //test:nighthawk_test //test/server:http_test_server_filter_integration_test
 }
 
 function do_test_with_valgrind() {
@@ -80,7 +80,7 @@ function do_asan() {
     echo "Building and testing envoy tests..."
     override_linker_with_lld
     cd "${SRCDIR}"
-    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan //test:nighthawk_test
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan //test:nighthawk_test //test/server:http_test_server_filter_integration_test
 }
 
 function do_tsan() {
@@ -88,7 +88,7 @@ function do_tsan() {
     echo "Building and testing envoy tests..."
     override_linker_with_lld
     cd "${SRCDIR}"
-    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan //test:nighthawk_test
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan //test:nighthawk_test //test/server:http_test_server_filter_integration_test
 }
 
 [ -z "${NUM_CPUS}" ] && NUM_CPUS=`grep -c ^processor /proc/cpuinfo`

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -1,0 +1,27 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+envoy_cc_library(
+    name = "http_test_server_filter_lib",
+    srcs = ["http_test_server_filter.cc"],
+    hdrs = ["http_test_server_filter.h"],
+    repository = "@envoy",
+    deps = [
+        "//api/server:response_options_proto_cc",
+        "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "http_test_server_filter_config",
+    srcs = ["http_test_server_filter_config.cc"],
+    repository = "@envoy",
+    deps = [
+        ":http_test_server_filter_lib",
+        "@envoy//include/envoy/server:filter_config_interface",
+    ],
+)

--- a/source/server/README.md
+++ b/source/server/README.md
@@ -1,0 +1,77 @@
+# Nighthawk test server
+
+A test-server filter which is capable of generating test responses.
+
+## Testing
+
+```bash
+bazel test -c dbg //test/server:http_test_server_filter_integration_test
+```
+
+## Building
+
+```bash
+bazel build -c opt :nighthawk_test_server
+```
+
+## Configuring the test server
+
+
+`test-server.yaml` sample content
+
+```yaml
+static_resources:
+  listeners:
+  # define an origin server on :10000 that always returns "lorem ipsum..."
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config: 
+          generate_request_id: false
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: envoy.fault
+            config:
+              max_active_faults: 100
+              delay:
+                header_delay: {}
+                percentage:
+                  numerator: 100
+          - name: test-server   # before envoy.router because order matters!
+            config:
+              response_size: 10
+              response_headers:
+              - { header: { key: "foo", value: "bar"} }
+              - { header: { key: "foo", value: "bar2"}, append: true }
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.router
+            config:
+              dynamic_stats: false
+admin:
+  access_log_path: /tmp/envoy.log
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8081
+```
+
+## Running the test server
+
+
+```
+# If you already have Envoy running, you might need to set --base-id to allow the test-server to start.
+➜ /bazel-bin/nighthawk/source/server/server --config-path /path/to/test-server-server.yaml
+
+# Verify the test server with a curl command similar to:
+➜ curl -H "x-envoy-fault-delay-request: 1000" -H "x-nighthawk-test-server-config: {response_size:20}"  -vv 127.0.0.1:10000 

--- a/source/server/http_test_server_filter.cc
+++ b/source/server/http_test_server_filter.cc
@@ -22,35 +22,46 @@ HttpTestServerDecoderFilter::HttpTestServerDecoderFilter(
 
 void HttpTestServerDecoderFilter::onDestroy() {}
 
+bool HttpTestServerDecoderFilter::mergeJsonConfig(std::string json,
+                                                  nighthawk::server::ResponseOptions& config,
+                                                  std::string& error_message) {
+  error_message = "";
+  try {
+    nighthawk::server::ResponseOptions json_config;
+    Envoy::MessageUtil::loadFromJson(json, json_config);
+    config.MergeFrom(json_config);
+    Envoy::MessageUtil::validate(config);
+  } catch (Envoy::EnvoyException exception) {
+    error_message = fmt::format("Error merging json config: {}", exception.what());
+  }
+  return error_message.empty();
+}
+
+void HttpTestServerDecoderFilter::applyConfigToResponseHeaders(
+    Envoy::Http::HeaderMap& response_headers,
+    nighthawk::server::ResponseOptions& response_options) {
+  for (const auto& header_value_option : response_options.response_headers()) {
+    const auto& header = header_value_option.header();
+    auto lower_case_key = Envoy::Http::LowerCaseString(header.key());
+    if (!header_value_option.append().value()) {
+      response_headers.remove(lower_case_key);
+    }
+    response_headers.addCopy(lower_case_key, header.value());
+  }
+}
+
 Envoy::Http::FilterHeadersStatus
 HttpTestServerDecoderFilter::decodeHeaders(Envoy::Http::HeaderMap& headers, bool) {
   const auto* request_config_header = headers.get(TestServer::HeaderNames::get().TestServerConfig);
   nighthawk::server::ResponseOptions base_config = config_->server_config();
-
   std::string error_message;
-  if (request_config_header != nullptr) {
-    try {
-      nighthawk::server::ResponseOptions json_config;
-      Envoy::MessageUtil::loadFromJson(request_config_header->value().c_str(), json_config);
-      base_config.MergeFrom(json_config);
-      Envoy::MessageUtil::validate(base_config);
-    } catch (Envoy::EnvoyException exception) {
-      error_message = exception.what();
-    }
-  }
 
-  if (error_message.empty()) {
+  if (!request_config_header ||
+      mergeJsonConfig(request_config_header->value().c_str(), base_config, error_message)) {
     decoder_callbacks_->sendLocalReply(
         static_cast<Envoy::Http::Code>(200), std::string(base_config.response_size(), 'a'),
         [&base_config](Envoy::Http::HeaderMap& direct_response_headers) {
-          for (const auto& header_value_option : base_config.response_headers()) {
-            const auto& header = header_value_option.header();
-            auto lower_case_key = Envoy::Http::LowerCaseString(header.key());
-            if (!header_value_option.append().value()) {
-              direct_response_headers.remove(lower_case_key);
-            }
-            direct_response_headers.addCopy(lower_case_key, header.value());
-          }
+          applyConfigToResponseHeaders(direct_response_headers, base_config);
         },
         absl::nullopt);
   } else {

--- a/source/server/http_test_server_filter.cc
+++ b/source/server/http_test_server_filter.cc
@@ -56,6 +56,7 @@ HttpTestServerDecoderFilter::decodeHeaders(Envoy::Http::HeaderMap& headers, bool
   nighthawk::server::ResponseOptions base_config = config_->server_config();
   absl::optional<std::string> error_message;
 
+  // TODO(oschaaf): Add functionality to clear fields
   if (!request_config_header ||
       mergeJsonConfig(request_config_header->value().c_str(), base_config, error_message)) {
     decoder_callbacks_->sendLocalReply(

--- a/source/server/http_test_server_filter.cc
+++ b/source/server/http_test_server_filter.cc
@@ -1,0 +1,83 @@
+#include <string>
+
+#include "server/http_test_server_filter.h"
+
+#include "absl/strings/numbers.h"
+
+#include "common/protobuf/utility.h"
+#include "envoy/server/filter_config.h"
+
+#include "api/server/response_options.pb.validate.h"
+
+namespace Nighthawk {
+namespace Server {
+
+HttpTestServerDecoderFilterConfig::HttpTestServerDecoderFilterConfig(
+    const nighthawk::server::ResponseOptions& proto_config)
+    : server_config_(proto_config) {}
+
+HttpTestServerDecoderFilter::HttpTestServerDecoderFilter(
+    HttpTestServerDecoderFilterConfigSharedPtr config)
+    : config_(config) {}
+
+HttpTestServerDecoderFilter::~HttpTestServerDecoderFilter() {}
+
+void HttpTestServerDecoderFilter::onDestroy() {}
+
+Envoy::Http::FilterHeadersStatus
+HttpTestServerDecoderFilter::decodeHeaders(Envoy::Http::HeaderMap& headers, bool) {
+  const auto* request_config_header = headers.get(TestServer::HeaderNames::get().TestServerConfig);
+  nighthawk::server::ResponseOptions base_config = config_->server_config();
+
+  std::string error_message = "";
+  if (request_config_header != nullptr) {
+    try {
+      nighthawk::server::ResponseOptions json_config;
+      Envoy::MessageUtil::loadFromJson(request_config_header->value().c_str(), json_config);
+      base_config.MergeFrom(json_config);
+      Envoy::MessageUtil::validate(base_config);
+    } catch (Envoy::EnvoyException exception) {
+      error_message = exception.what();
+    }
+  }
+
+  if (error_message.empty()) {
+    decoder_callbacks_->sendLocalReply(
+        static_cast<Envoy::Http::Code>(200), std::string(base_config.response_size(), 'a'),
+        [&base_config](Envoy::Http::HeaderMap& direct_response_headers) {
+          for (auto header_value_option : base_config.response_headers()) {
+            auto header = header_value_option.header();
+            auto lower_case_key = Envoy::Http::LowerCaseString(header.key());
+            if (!header_value_option.append().value()) {
+              direct_response_headers.remove(lower_case_key);
+            }
+            direct_response_headers.addCopy(lower_case_key, header.value());
+          }
+        },
+        absl::nullopt);
+  } else {
+    decoder_callbacks_->sendLocalReply(
+        static_cast<Envoy::Http::Code>(500),
+        fmt::format("test-server didn't understand the request: {}", error_message), nullptr,
+        absl::nullopt);
+  }
+  return Envoy::Http::FilterHeadersStatus::StopIteration;
+}
+
+Envoy::Http::FilterDataStatus HttpTestServerDecoderFilter::decodeData(Envoy::Buffer::Instance&,
+                                                                      bool) {
+  return Envoy::Http::FilterDataStatus::Continue;
+}
+
+Envoy::Http::FilterTrailersStatus
+HttpTestServerDecoderFilter::decodeTrailers(Envoy::Http::HeaderMap&) {
+  return Envoy::Http::FilterTrailersStatus::Continue;
+}
+
+void HttpTestServerDecoderFilter::setDecoderFilterCallbacks(
+    Envoy::Http::StreamDecoderFilterCallbacks& callbacks) {
+  decoder_callbacks_ = &callbacks;
+}
+
+} // namespace Server
+} // namespace Nighthawk

--- a/source/server/http_test_server_filter.cc
+++ b/source/server/http_test_server_filter.cc
@@ -22,13 +22,13 @@ HttpTestServerDecoderFilter::HttpTestServerDecoderFilter(
 
 void HttpTestServerDecoderFilter::onDestroy() {}
 
-bool HttpTestServerDecoderFilter::mergeJsonConfig(std::string json,
+bool HttpTestServerDecoderFilter::mergeJsonConfig(absl::string_view json,
                                                   nighthawk::server::ResponseOptions& config,
                                                   std::string& error_message) {
   error_message = "";
   try {
     nighthawk::server::ResponseOptions json_config;
-    Envoy::MessageUtil::loadFromJson(json, json_config);
+    Envoy::MessageUtil::loadFromJson(std::string(json), json_config);
     config.MergeFrom(json_config);
     Envoy::MessageUtil::validate(config);
   } catch (Envoy::EnvoyException exception) {

--- a/source/server/http_test_server_filter.cc
+++ b/source/server/http_test_server_filter.cc
@@ -60,7 +60,7 @@ HttpTestServerDecoderFilter::decodeHeaders(Envoy::Http::HeaderMap& headers, bool
       mergeJsonConfig(request_config_header->value().c_str(), base_config, error_message)) {
     decoder_callbacks_->sendLocalReply(
         static_cast<Envoy::Http::Code>(200), std::string(base_config.response_size(), 'a'),
-        [&base_config](Envoy::Http::HeaderMap& direct_response_headers) {
+        [this, &base_config](Envoy::Http::HeaderMap& direct_response_headers) {
           applyConfigToResponseHeaders(direct_response_headers, base_config);
         },
         absl::nullopt);

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -46,6 +46,11 @@ public:
   Envoy::Http::FilterTrailersStatus decodeTrailers(Envoy::Http::HeaderMap&) override;
   void setDecoderFilterCallbacks(Envoy::Http::StreamDecoderFilterCallbacks&) override;
 
+  bool mergeJsonConfig(std::string json, nighthawk::server::ResponseOptions& config,
+                       std::string& error_message);
+  void : applyConfigToResponseHeaders(Envoy::Http::HeaderMap& response_headers,
+                                      nighthawk::server::ResponseOptions& response_options);
+
 private:
   const HttpTestServerDecoderFilterConfigSharedPtr config_;
   Envoy::Http::StreamDecoderFilterCallbacks* decoder_callbacks_;

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -48,8 +48,8 @@ public:
 
   bool mergeJsonConfig(std::string json, nighthawk::server::ResponseOptions& config,
                        std::string& error_message);
-  void : applyConfigToResponseHeaders(Envoy::Http::HeaderMap& response_headers,
-                                      nighthawk::server::ResponseOptions& response_options);
+  void applyConfigToResponseHeaders(Envoy::Http::HeaderMap& response_headers,
+                                    nighthawk::server::ResponseOptions& response_options);
 
 private:
   const HttpTestServerDecoderFilterConfigSharedPtr config_;

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/server/filter_config.h"
+
+#include "api/server/response_options.pb.h"
+
+namespace Nighthawk {
+namespace Server {
+
+namespace TestServer {
+
+class HeaderNameValues {
+public:
+  const Envoy::Http::LowerCaseString TestServerConfig{"x-nighthawk-test-server-config"};
+};
+
+typedef Envoy::ConstSingleton<HeaderNameValues> HeaderNames;
+
+} // namespace TestServer
+
+// Basically this is left in as a placeholder for further configuration.
+class HttpTestServerDecoderFilterConfig {
+public:
+  HttpTestServerDecoderFilterConfig(const nighthawk::server::ResponseOptions& proto_config);
+  const nighthawk::server::ResponseOptions& server_config() { return server_config_; }
+
+private:
+  const nighthawk::server::ResponseOptions server_config_;
+};
+
+typedef std::shared_ptr<HttpTestServerDecoderFilterConfig>
+    HttpTestServerDecoderFilterConfigSharedPtr;
+
+class HttpTestServerDecoderFilter : public Envoy::Http::StreamDecoderFilter {
+public:
+  HttpTestServerDecoderFilter(HttpTestServerDecoderFilterConfigSharedPtr);
+  ~HttpTestServerDecoderFilter();
+
+  // Http::StreamFilterBase
+  void onDestroy() override;
+
+  // Http::StreamDecoderFilter
+  Envoy::Http::FilterHeadersStatus decodeHeaders(Envoy::Http::HeaderMap&, bool) override;
+  Envoy::Http::FilterDataStatus decodeData(Envoy::Buffer::Instance&, bool) override;
+  Envoy::Http::FilterTrailersStatus decodeTrailers(Envoy::Http::HeaderMap&) override;
+  void setDecoderFilterCallbacks(Envoy::Http::StreamDecoderFilterCallbacks&) override;
+
+private:
+  const HttpTestServerDecoderFilterConfigSharedPtr config_;
+  Envoy::Http::StreamDecoderFilterCallbacks* decoder_callbacks_;
+};
+
+} // namespace Server
+} // namespace Nighthawk

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -55,7 +55,7 @@ public:
    * @return bool false iff an error occurred.
    */
   bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions& config,
-                       std::string& error_message);
+                       absl::optional<std::string>& error_message);
 
   /**
    * Applies ResponseOptions onto a HeaderMap containing response headers.

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -46,8 +46,24 @@ public:
   Envoy::Http::FilterTrailersStatus decodeTrailers(Envoy::Http::HeaderMap&) override;
   void setDecoderFilterCallbacks(Envoy::Http::StreamDecoderFilterCallbacks&) override;
 
-  bool mergeJsonConfig(std::string json, nighthawk::server::ResponseOptions& config,
+  /**
+   * Merges a json string containing configuration into a ResponseOptions instance.
+   *
+   * @param json Json-formatted seralization of ResponseOptions to merge into the configuration.
+   * @param config The target that the json string should be merged into.
+   * @param error_message Will contain an error message iff an error occurred.
+   * @return bool false iff an error occurred.
+   */
+  bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions& config,
                        std::string& error_message);
+
+  /**
+   * Applies ResponseOptions onto a HeaderMap containing response headers.
+   *
+   * @param response_headers Response headers to transform to reflect the passed in response
+   * options.
+   * @param response_options Configuration specifying how to transform the header map.
+   */
   void applyConfigToResponseHeaders(Envoy::Http::HeaderMap& response_headers,
                                     nighthawk::server::ResponseOptions& response_options);
 

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -16,27 +16,26 @@ public:
   const Envoy::Http::LowerCaseString TestServerConfig{"x-nighthawk-test-server-config"};
 };
 
-typedef Envoy::ConstSingleton<HeaderNameValues> HeaderNames;
+using HeaderNames = Envoy::ConstSingleton<HeaderNameValues>;
 
 } // namespace TestServer
 
 // Basically this is left in as a placeholder for further configuration.
 class HttpTestServerDecoderFilterConfig {
 public:
-  HttpTestServerDecoderFilterConfig(const nighthawk::server::ResponseOptions& proto_config);
+  HttpTestServerDecoderFilterConfig(nighthawk::server::ResponseOptions proto_config);
   const nighthawk::server::ResponseOptions& server_config() { return server_config_; }
 
 private:
   const nighthawk::server::ResponseOptions server_config_;
 };
 
-typedef std::shared_ptr<HttpTestServerDecoderFilterConfig>
-    HttpTestServerDecoderFilterConfigSharedPtr;
+using HttpTestServerDecoderFilterConfigSharedPtr =
+    std::shared_ptr<HttpTestServerDecoderFilterConfig>;
 
 class HttpTestServerDecoderFilter : public Envoy::Http::StreamDecoderFilter {
 public:
   HttpTestServerDecoderFilter(HttpTestServerDecoderFilterConfigSharedPtr);
-  ~HttpTestServerDecoderFilter();
 
   // Http::StreamFilterBase
   void onDestroy() override;

--- a/source/server/http_test_server_filter_config.cc
+++ b/source/server/http_test_server_filter_config.cc
@@ -1,0 +1,59 @@
+#include <string>
+
+#include "server/http_test_server_filter.h"
+
+#include "common/config/json_utility.h"
+#include "envoy/registry/registry.h"
+
+#include "api/server/response_options.pb.h"
+#include "api/server/response_options.pb.validate.h"
+
+namespace Nighthawk {
+namespace Server {
+namespace Configuration {
+
+class HttpTestServerDecoderFilterConfig
+    : public Envoy::Server::Configuration::NamedHttpFilterConfigFactory {
+public:
+  Envoy::Http::FilterFactoryCb
+  createFilterFactory(const Envoy::Json::Object&, const std::string&,
+                      Envoy::Server::Configuration::FactoryContext&) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+
+  Envoy::Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Envoy::Protobuf::Message& proto_config, const std::string&,
+                               Envoy::Server::Configuration::FactoryContext& context) override {
+
+    return createFilter(
+        Envoy::MessageUtil::downcastAndValidate<const nighthawk::server::ResponseOptions&>(
+            proto_config),
+        context);
+  }
+
+  Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return Envoy::ProtobufTypes::MessagePtr{new nighthawk::server::ResponseOptions()};
+  }
+
+  std::string name() override { return "test-server"; }
+
+private:
+  Envoy::Http::FilterFactoryCb createFilter(const nighthawk::server::ResponseOptions& proto_config,
+                                            Envoy::Server::Configuration::FactoryContext&) {
+    Nighthawk::Server::HttpTestServerDecoderFilterConfigSharedPtr config =
+        std::make_shared<Nighthawk::Server::HttpTestServerDecoderFilterConfig>(
+            Nighthawk::Server::HttpTestServerDecoderFilterConfig(proto_config));
+
+    return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      auto* filter = new Nighthawk::Server::HttpTestServerDecoderFilter(config);
+      callbacks.addStreamDecoderFilter(Envoy::Http::StreamDecoderFilterSharedPtr{filter});
+    };
+  }
+};
+
+static Envoy::Registry::RegisterFactory<HttpTestServerDecoderFilterConfig,
+                                        Envoy::Server::Configuration::NamedHttpFilterConfigFactory>
+    register_;
+} // namespace Configuration
+} // namespace Server
+} // namespace Nighthawk

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -1,0 +1,18 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+envoy_cc_test(
+    name = "http_test_server_filter_integration_test",
+    srcs = ["http_test_server_filter_integration_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/server:http_test_server_filter_config",
+        "@envoy//include/envoy/upstream:cluster_manager_interface",
+        "@envoy//source/common/api:api_lib",
+        "@envoy//test/integration:http_integration_lib",
+    ],
+)

--- a/test/server/http_test_server_filter_integration_test.cc
+++ b/test/server/http_test_server_filter_integration_test.cc
@@ -269,7 +269,7 @@ TEST_F(HttpTestServerDecoderFilterTest, HeaderMerge) {
   Server::HttpTestServerDecoderFilterConfigSharedPtr config =
       std::make_shared<Server::HttpTestServerDecoderFilterConfig>(initial_options);
   Server::HttpTestServerDecoderFilter f(config);
-  std::string error_message;
+  absl::optional<std::string> error_message;
   nighthawk::server::ResponseOptions options = config->server_config();
 
   EXPECT_EQ(1, options.response_headers_size());
@@ -286,7 +286,7 @@ TEST_F(HttpTestServerDecoderFilterTest, HeaderMerge) {
   EXPECT_TRUE(f.mergeJsonConfig(
       R"({response_headers: [ { header: { key: "foo", value: "bar2"}, append: false } ]})", options,
       error_message));
-  EXPECT_EQ("", error_message);
+  EXPECT_EQ(absl::nullopt, error_message);
   EXPECT_EQ(2, options.response_headers_size());
 
   EXPECT_EQ("foo", options.response_headers(1).header().key());
@@ -300,7 +300,7 @@ TEST_F(HttpTestServerDecoderFilterTest, HeaderMerge) {
   EXPECT_TRUE(f.mergeJsonConfig(
       R"({response_headers: [ { header: { key: "foo2", value: "bar3"}, append: true } ]})", options,
       error_message));
-  EXPECT_EQ("", error_message);
+  EXPECT_EQ(absl::nullopt, error_message);
   EXPECT_EQ(3, options.response_headers_size());
 
   EXPECT_EQ("foo2", options.response_headers(2).header().key());

--- a/test/server/http_test_server_filter_integration_test.cc
+++ b/test/server/http_test_server_filter_integration_test.cc
@@ -1,0 +1,261 @@
+#include "gtest/gtest.h"
+
+#include "common/api/api_impl.h"
+#include "envoy/upstream/cluster_manager.h"
+#include "envoy/upstream/upstream.h"
+#include "test/common/upstream/utility.h"
+#include "test/integration/http_integration.h"
+
+#include "server/http_test_server_filter.h"
+
+namespace Nighthawk {
+
+class HttpTestServerIntegrationTestBase
+    : public Envoy::HttpIntegrationTest,
+      public testing::TestWithParam<Envoy::Network::Address::IpVersion> {
+public:
+  HttpTestServerIntegrationTestBase()
+      : HttpIntegrationTest(Envoy::Http::CodecClient::Type::HTTP1, GetParam(), realTime()) {}
+
+  // TODO(oschaaf): Modify Envoy's Envoy::IntegrationUtil::makeSingleRequest() to allow for a way to
+  // manipulate the request headers before they get send. Then we can eliminate these copies.
+  Envoy::BufferingStreamDecoderPtr
+  makeSingleRequest(uint32_t port, const std::string& method, const std::string& url,
+                    const std::string& body, Envoy::Http::CodecClient::Type type,
+                    Envoy::Network::Address::IpVersion ip_version, const std::string& host,
+                    const std::string& content_type,
+                    std::function<void(Envoy::Http::HeaderMapImpl&)> request_header_delegate) {
+    auto addr = Envoy::Network::Utility::resolveUrl(fmt::format(
+        "tcp://{}:{}", Envoy::Network::Test::getLoopbackAddressUrlString(ip_version), port));
+    return makeSingleRequest(addr, method, url, body, type, host, content_type,
+                             request_header_delegate);
+  }
+
+  Envoy::BufferingStreamDecoderPtr
+  makeSingleRequest(const Envoy::Network::Address::InstanceConstSharedPtr& addr,
+                    const std::string& method, const std::string& url, const std::string& body,
+                    Envoy::Http::CodecClient::Type type, const std::string& host,
+                    const std::string& content_type,
+                    std::function<void(Envoy::Http::HeaderMapImpl&)> request_header_delegate) {
+
+    testing::NiceMock<Envoy::Stats::MockIsolatedStatsStore> mock_stats_store;
+    Envoy::Event::GlobalTimeSystem time_system;
+    Envoy::Api::Impl api(Envoy::Thread::threadFactoryForTest(), mock_stats_store, time_system,
+                         Envoy::Filesystem::fileSystemForTest());
+    Envoy::Event::DispatcherPtr dispatcher(api.allocateDispatcher());
+    std::shared_ptr<Envoy::Upstream::MockClusterInfo> cluster{
+        new testing::NiceMock<Envoy::Upstream::MockClusterInfo>()};
+    Envoy::Upstream::HostDescriptionConstSharedPtr host_description{
+        Envoy::Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80")};
+    Envoy::Http::CodecClientProd client(
+        type,
+        dispatcher->createClientConnection(addr, Envoy::Network::Address::InstanceConstSharedPtr(),
+                                           Envoy::Network::Test::createRawBufferSocket(), nullptr),
+        host_description, *dispatcher);
+    Envoy::BufferingStreamDecoderPtr response(new Envoy::BufferingStreamDecoder([&]() -> void {
+      client.close();
+      dispatcher->exit();
+    }));
+    Envoy::Http::StreamEncoder& encoder = client.newStream(*response);
+    encoder.getStream().addCallbacks(*response);
+
+    Envoy::Http::HeaderMapImpl headers;
+    headers.insertMethod().value(method);
+    headers.insertPath().value(url);
+    headers.insertHost().value(host);
+    headers.insertScheme().value(Envoy::Http::Headers::get().SchemeValues.Http);
+    if (!content_type.empty()) {
+      headers.insertContentType().value(content_type);
+    }
+    request_header_delegate(headers);
+    encoder.encodeHeaders(headers, body.empty());
+    if (!body.empty()) {
+      Envoy::Buffer::OwnedImpl body_buffer(body);
+      encoder.encodeData(body_buffer, true);
+    }
+
+    dispatcher->run(Envoy::Event::Dispatcher::RunType::Block);
+    return response;
+  }
+
+  void testWithResponseSize(int response_size, bool expect_header = true) {
+    Envoy::BufferingStreamDecoderPtr response = makeSingleRequest(
+        lookupPort("http"), "GET", "/", "", downstream_protocol_, version_, "foo.com", "",
+        [response_size](Envoy::Http::HeaderMapImpl& request_headers) {
+          const std::string header_config = fmt::format("{{response_size:{}}}", response_size);
+          request_headers.addCopy(
+              Nighthawk::Server::TestServer::HeaderNames::get().TestServerConfig, header_config);
+        });
+    ASSERT_TRUE(response->complete());
+    EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+    if (expect_header) {
+      auto inserted_header = response->headers().get(Envoy::Http::LowerCaseString("x-supplied-by"));
+      ASSERT_NE(nullptr, inserted_header);
+      EXPECT_STREQ("nighthawk-test-server", inserted_header->value().c_str());
+    }
+    if (response_size == 0) {
+      EXPECT_EQ(nullptr, response->headers().ContentType());
+    } else {
+      EXPECT_STREQ("text/plain", response->headers().ContentType()->value().c_str());
+    }
+    EXPECT_EQ(std::string(response_size, 'a'), response->body());
+  }
+
+  void testBadResponseSize(int response_size) {
+    Envoy::BufferingStreamDecoderPtr response = makeSingleRequest(
+        lookupPort("http"), "GET", "/", "", downstream_protocol_, version_, "foo.com", "",
+        [response_size](Envoy::Http::HeaderMapImpl& request_headers) {
+          const std::string header_config = fmt::format("{{response_size:{}}}", response_size);
+          request_headers.addCopy(
+              Nighthawk::Server::TestServer::HeaderNames::get().TestServerConfig, header_config);
+        });
+    ASSERT_TRUE(response->complete());
+    EXPECT_STREQ("500", response->headers().Status()->value().c_str());
+  }
+};
+
+class HttpTestServerIntegrationTest : public HttpTestServerIntegrationTestBase {
+public:
+  void SetUp() override { initialize(); }
+
+  void initialize() override {
+    config_helper_.addFilter(R"EOF(
+name: test-server
+config:
+  response_size: 10
+  response_headers:
+  - { header: { key: "x-supplied-by", value: "nighthawk-test-server"} }
+)EOF");
+    HttpTestServerIntegrationTestBase::initialize();
+  }
+
+  void TearDown() override {
+    cleanupUpstreamAndDownstream();
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(IpVersions, HttpTestServerIntegrationTest,
+                        testing::ValuesIn(Envoy::TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(HttpTestServerIntegrationTest, TestNoHeaderConfig) {
+  Envoy::BufferingStreamDecoderPtr response =
+      makeSingleRequest(lookupPort("http"), "GET", "/", "", downstream_protocol_, version_,
+                        "foo.com", "", [](Envoy::Http::HeaderMapImpl&) {});
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_EQ(std::string(10, 'a'), response->body());
+}
+
+TEST_P(HttpTestServerIntegrationTest, TestBasics) {
+  testWithResponseSize(1);
+  testWithResponseSize(10);
+  testWithResponseSize(100);
+  testWithResponseSize(1000);
+  testWithResponseSize(10000);
+}
+
+TEST_P(HttpTestServerIntegrationTest, TestNegative) { testBadResponseSize(-1); }
+
+TEST_P(HttpTestServerIntegrationTest, TestZeroLengthRequest) { testWithResponseSize(0); }
+
+TEST_P(HttpTestServerIntegrationTest, TestMaxBoundaryLengthRequest) {
+  const int max = 1024 * 1024 * 4;
+  testWithResponseSize(max);
+}
+
+TEST_P(HttpTestServerIntegrationTest, TestTooLarge) {
+  const int max = 1024 * 1024 * 4;
+  testBadResponseSize(max + 1);
+}
+
+TEST_P(HttpTestServerIntegrationTest, TestHeaderConfig) {
+  Envoy::BufferingStreamDecoderPtr response = makeSingleRequest(
+      lookupPort("http"), "GET", "/", "", downstream_protocol_, version_, "foo.com", "",
+      [](Envoy::Http::HeaderMapImpl& request_headers) {
+        const std::string header_config =
+            "{response_headers: [ { header: { key: \"foo\", value: \"bar2\"}, append: true } ]}";
+        request_headers.addCopy(Nighthawk::Server::TestServer::HeaderNames::get().TestServerConfig,
+                                header_config);
+      });
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("bar2",
+               response->headers().get(Envoy::Http::LowerCaseString("foo"))->value().c_str());
+  EXPECT_EQ(std::string(10, 'a'), response->body());
+}
+
+class HttpTestServerIntegrationNoConfigTest : public HttpTestServerIntegrationTestBase {
+public:
+  void SetUp() override { initialize(); }
+
+  void TearDown() override {
+    cleanupUpstreamAndDownstream();
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+
+  void initialize() override {
+    config_helper_.addFilter(R"EOF(
+name: test-server
+)EOF");
+    HttpTestServerIntegrationTestBase::initialize();
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(IpVersions, HttpTestServerIntegrationNoConfigTest,
+                        testing::ValuesIn(Envoy::TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(HttpTestServerIntegrationNoConfigTest, TestNoHeaderConfig) {
+  Envoy::BufferingStreamDecoderPtr response =
+      makeSingleRequest(lookupPort("http"), "GET", "/", "", downstream_protocol_, version_,
+                        "foo.com", "", [](Envoy::Http::HeaderMapImpl&) {});
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_EQ(std::string(0, 'a'), response->body());
+}
+
+TEST_P(HttpTestServerIntegrationNoConfigTest, TestBasics) {
+  testWithResponseSize(1, false);
+  testWithResponseSize(10, false);
+  testWithResponseSize(100, false);
+  testWithResponseSize(1000, false);
+  testWithResponseSize(10000, false);
+}
+
+TEST_P(HttpTestServerIntegrationNoConfigTest, TestNegative) { testBadResponseSize(-1); }
+
+TEST_P(HttpTestServerIntegrationNoConfigTest, TestZeroLengthRequest) {
+  testWithResponseSize(0, false);
+}
+
+TEST_P(HttpTestServerIntegrationNoConfigTest, TestMaxBoundaryLengthRequest) {
+  const int max = 1024 * 1024 * 4;
+  testWithResponseSize(max, false);
+}
+
+TEST_P(HttpTestServerIntegrationNoConfigTest, TestTooLarge) {
+  const int max = 1024 * 1024 * 4;
+  testBadResponseSize(max + 1);
+}
+
+TEST_P(HttpTestServerIntegrationNoConfigTest, TestHeaderConfig) {
+  Envoy::BufferingStreamDecoderPtr response = makeSingleRequest(
+      lookupPort("http"), "GET", "/", "", downstream_protocol_, version_, "foo.com", "",
+      [](Envoy::Http::HeaderMapImpl& request_headers) {
+        const std::string header_config =
+            "{response_headers: [ { header: { key: \"foo\", value: \"bar2\"}, append: true } ]}";
+        request_headers.addCopy(Nighthawk::Server::TestServer::HeaderNames::get().TestServerConfig,
+                                header_config);
+      });
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("bar2",
+               response->headers().get(Envoy::Http::LowerCaseString("foo"))->value().c_str());
+  EXPECT_EQ(std::string(0, 'a'), response->body());
+}
+
+// TODO(oschaaf): maybe add a couple more tests for appending headers.
+
+} // namespace Nighthawk


### PR DESCRIPTION
Introduces a test origin for Nighthawk, based on Envoy.

Current functionality is simple: the request headers can be used to indicate how many bytes the response body should have, and response headers can be added/appended. The response consist of repeating the character `a`.

Deprecates envoyproxy/envoy-perf#70 
