### PR TITLE
 Connection prefetching feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bazel build -c opt //:nighthawk_client
 
 USAGE: 
 
-   bazel-bin/nighthawk_client  [--output-format <human|yaml
+   bazel-bin/nighthawk_client [--prefetch-connections] [--output-format <human|yaml
                                         |json>] [-v <trace|debug|info|warn
                                         |error|critical>] [--concurrency
                                         <string>] [--h2] [--timeout
@@ -41,6 +41,9 @@ USAGE:
 
 Where: 
 
+   --prefetch-connections
+     Prefetch connections before benchmarking (HTTP/1 only).
+
    --output-format <human|yaml|json>
      Verbosity of the output. Possible values: [human, yaml, json]. The
      default output format is 'human'.
@@ -48,7 +51,7 @@ Where:
    -v <trace|debug|info|warn|error|critical>,  --verbosity <trace|debug
       |info|warn|error|critical>
      Verbosity of the output. Possible values: [trace, debug, info, warn,
-     error, critical]. The default output format is 'info'.
+     error, critical]. The default level is 'info'.
 
    --concurrency <string>
      The number of concurrent event loops that should be used. Specify
@@ -70,7 +73,7 @@ Where:
 
    --connections <uint64_t>
      The number of connections per event loop that the test should
-     maximally use. Default: 1.
+     maximally use. HTTP/1 only. Default: 1.
 
    --rps <uint64_t>
      The target requests-per-second rate. Default: 5.

--- a/include/nighthawk/client/BUILD
+++ b/include/nighthawk/client/BUILD
@@ -16,6 +16,7 @@ envoy_basic_cc_library(
         "factories.h",
         "options.h",
         "output_formatter.h",
+        "prefetchable_pool.h",
     ],
     include_prefix = "nighthawk/client",
     deps = [

--- a/include/nighthawk/client/BUILD
+++ b/include/nighthawk/client/BUILD
@@ -22,6 +22,7 @@ envoy_basic_cc_library(
     deps = [
         "//include/nighthawk/common:base_includes",
         "@envoy//include/envoy/common:base_includes",
+        "@envoy//include/envoy/http:conn_pool_interface",
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/common/common:non_copyable",
         "@envoy//source/common/network:dns_lib",

--- a/include/nighthawk/client/benchmark_client.h
+++ b/include/nighthawk/client/benchmark_client.h
@@ -56,6 +56,8 @@ public:
    */
   virtual Envoy::Stats::Store& store() const PURE;
 
+  virtual void prefetchPoolConnections() PURE;
+
   /**
    * Determines if latency measurement is on.
    *

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -29,6 +29,7 @@ public:
   virtual std::string concurrency() const PURE;
   virtual std::string verbosity() const PURE;
   virtual std::string outputFormat() const PURE;
+  virtual bool prefetchConnections() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/include/nighthawk/client/prefetchable_pool.h
+++ b/include/nighthawk/client/prefetchable_pool.h
@@ -16,7 +16,14 @@ public:
    * prefetchConnections will open up the maximum number of allowed connections.
    */
   virtual void prefetchConnections() PURE;
+  /**
+   * @return Envoy::Http::ConnectionPool::Instance& Accessor for getting to connection pool
+   * implementation.
+   */
+  virtual Envoy::Http::ConnectionPool::Instance& pool() PURE;
 };
+
+using PrefetchablePoolPtr = std::unique_ptr<PrefetchablePool>;
 
 } // namespace Client
 } // namespace Nighthawk

--- a/include/nighthawk/client/prefetchable_pool.h
+++ b/include/nighthawk/client/prefetchable_pool.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/common/pure.h"
+#include "envoy/http/conn_pool.h"
 
 namespace Nighthawk {
 namespace Client {

--- a/include/nighthawk/client/prefetchable_pool.h
+++ b/include/nighthawk/client/prefetchable_pool.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+
+namespace Nighthawk {
+namespace Client {
+
+/**
+ * Interface that adds connection prefetching capability to the pool.
+ */
+class PrefetchablePool {
+public:
+  virtual ~PrefetchablePool() = default;
+
+  /**
+   * prefetchConnections will open up the maximum number of allowed connections.
+   */
+  virtual void prefetchConnections() PURE;
+};
+
+} // namespace Client
+} // namespace Nighthawk

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -63,6 +63,7 @@ public:
       createNewConnection();
     }
   }
+  Envoy::Http::ConnectionPool::Instance& pool() override { return *this; }
 };
 
 class H2Pool : public PrefetchablePool, public Envoy::Http::Http2::ProdConnPoolImpl {
@@ -75,7 +76,10 @@ public:
   void prefetchConnections() override {
     // No-op, this is a "pool" with a single connection.
   }
+  Envoy::Http::ConnectionPool::Instance& pool() override { return *this; }
 };
+
+void BenchmarkClientHttpImpl::prefetchPoolConnections() { pool_->prefetchConnections(); }
 
 void BenchmarkClientHttpImpl::initialize(Envoy::Runtime::Loader& runtime) {
   ASSERT(uri_->address() != nullptr);
@@ -189,7 +193,7 @@ bool BenchmarkClientHttpImpl::tryStartOne(std::function<void()> caller_completio
       dispatcher_, api_.timeSource(), *this, std::move(caller_completion_callback),
       *connect_statistic_, *response_statistic_, request_headers_, measureLatencies());
   requests_initiated_++;
-  pool_->newStream(*stream_decoder, *stream_decoder);
+  pool_->pool().newStream(*stream_decoder, *stream_decoder);
   return true;
 }
 

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -56,9 +56,9 @@ public:
   H1Pool(Envoy::Event::Dispatcher& dispatcher, Envoy::Upstream::HostConstSharedPtr host,
          Envoy::Upstream::ResourcePriority priority,
          const Envoy::Network::ConnectionSocket::OptionsSharedPtr& options)
-      : Envoy::Http::Http1::ProdConnPoolImpl(dispatcher, host, priority, options) {}
+      : Envoy::Http::Http1::ProdConnPoolImpl(dispatcher, std::move(host), priority, options) {}
 
-  void prefetchConnections() {
+  void prefetchConnections() override {
     while (host_->cluster().resourceManager(priority_).connections().canCreate()) {
       createNewConnection();
     }
@@ -70,9 +70,9 @@ public:
   H2Pool(Envoy::Event::Dispatcher& dispatcher, Envoy::Upstream::HostConstSharedPtr host,
          Envoy::Upstream::ResourcePriority priority,
          const Envoy::Network::ConnectionSocket::OptionsSharedPtr& options)
-      : Envoy::Http::Http2::ProdConnPoolImpl(dispatcher, host, priority, options) {}
+      : Envoy::Http::Http2::ProdConnPoolImpl(dispatcher, std::move(host), priority, options) {}
 
-  void prefetchConnections() {
+  void prefetchConnections() override {
     // No-op, this is a "pool" with a single connection.
   }
 };

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -12,8 +12,10 @@
 #include "envoy/upstream/upstream.h"
 
 #include "nighthawk/client/benchmark_client.h"
+#include "nighthawk/client/prefetchable_pool.h"
 #include "nighthawk/common/sequencer.h"
 #include "nighthawk/common/statistic.h"
+#include "nighthawk/common/uri.h"
 
 #include "common/common/logger.h"
 #include "common/http/header_map_impl.h"
@@ -21,7 +23,6 @@
 
 #include "client/stream_decoder.h"
 #include "common/ssl.h"
-#include "nighthawk/common/uri.h"
 
 namespace Nighthawk {
 namespace Client {
@@ -41,12 +42,6 @@ using namespace Envoy; // We need this because of macro expectations.
 
 struct BenchmarkClientStats {
   ALL_BENCHMARK_CLIENT_STATS(GENERATE_COUNTER_STRUCT)
-};
-
-class PrefetchablePool {
-public:
-  virtual ~PrefetchablePool() = default;
-  virtual void prefetchConnections() PURE;
 };
 
 class BenchmarkClientHttpImpl : public BenchmarkClient,

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -74,9 +74,7 @@ public:
   void onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason reason) override;
 
 private:
-  void prefetchPoolConnections() override {
-    dynamic_cast<PrefetchablePool*>(pool_.get())->prefetchConnections();
-  }
+  void prefetchPoolConnections() override;
 
   Envoy::Api::Api& api_;
   Envoy::Event::Dispatcher& dispatcher_;
@@ -98,7 +96,7 @@ private:
   std::chrono::seconds timeout_{5s};
   uint64_t connection_limit_{1};
   uint64_t max_pending_requests_{1};
-  Envoy::Http::ConnectionPool::InstancePtr pool_;
+  PrefetchablePoolPtr pool_;
   Envoy::Event::TimerPtr timer_;
   Envoy::Runtime::RandomGeneratorImpl generator_;
   uint64_t requests_completed_{};

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -43,13 +43,20 @@ struct BenchmarkClientStats {
   ALL_BENCHMARK_CLIENT_STATS(GENERATE_COUNTER_STRUCT)
 };
 
+class PrefetchablePool {
+public:
+  virtual ~PrefetchablePool() = default;
+  virtual void prefetchConnections() PURE;
+};
+
 class BenchmarkClientHttpImpl : public BenchmarkClient,
                                 public StreamDecoderCompletionCallback,
                                 public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
   BenchmarkClientHttpImpl(Envoy::Api::Api& api, Envoy::Event::Dispatcher& dispatcher,
                           Envoy::Stats::Store& store, StatisticPtr&& connect_statistic,
-                          StatisticPtr&& response_statistic, UriPtr&& uri, bool use_h2);
+                          StatisticPtr&& response_statistic, UriPtr&& uri, bool use_h2,
+                          bool prefetch_connections);
 
   void setConnectionLimit(uint64_t connection_limit) { connection_limit_ = connection_limit; }
   void setConnectionTimeout(std::chrono::seconds timeout) { timeout_ = timeout; }
@@ -67,12 +74,15 @@ public:
   }
   bool tryStartOne(std::function<void()> caller_completion_callback) override;
   Envoy::Stats::Store& store() const override { return store_; }
-
   // StreamDecoderCompletionCallback
   void onComplete(bool success, const Envoy::Http::HeaderMap& headers) override;
   void onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason reason) override;
 
 private:
+  void prefetchPoolConnections() override {
+    dynamic_cast<PrefetchablePool*>(pool_.get())->prefetchConnections();
+  }
+
   Envoy::Api::Api& api_;
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::Stats::Store& store_;
@@ -88,6 +98,7 @@ private:
   StatisticPtr connect_statistic_;
   StatisticPtr response_statistic_;
   const bool use_h2_;
+  const bool prefetch_connections_;
   const UriPtr uri_;
   std::chrono::seconds timeout_{5s};
   uint64_t connection_limit_{1};

--- a/source/client/client_worker_impl.cc
+++ b/source/client/client_worker_impl.cc
@@ -15,15 +15,10 @@ ClientWorkerImpl::ClientWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Ins
                                           *benchmark_client_)) {}
 
 void ClientWorkerImpl::simpleWarmup() {
-  ENVOY_LOG(debug, "> worker {}: warming up.", worker_number_);
-  // TODO(oschaaf): Maybe add BenchmarkClient::warmup() and call that here.
-  // Ideally we prefetch the requested amount of connections.
-  // Currently it is possible to use less connections then specified if
-  // completions are fast enough. While this may be an asset, it may also be annoying
-  // when comparing results to some other tools, which do open up the specified amount
-  // of connections.
+  ENVOY_LOG(debug, "> worker {}: warmup start.", worker_number_);
   benchmark_client_->tryStartOne([this] { dispatcher_->exit(); });
   dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
+  ENVOY_LOG(debug, "> worker {}: warmup done.", worker_number_);
 }
 
 void ClientWorkerImpl::work() {

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -25,7 +25,7 @@ BenchmarkClientPtr BenchmarkClientFactoryImpl::create(Envoy::Api::Api& api,
   StatisticFactoryImpl statistic_factory(options_);
   auto benchmark_client = std::make_unique<BenchmarkClientHttpImpl>(
       api, dispatcher, store, statistic_factory.create(), statistic_factory.create(),
-      std::move(uri), options_.h2());
+      std::move(uri), options_.h2(), options_.prefetchConnections());
   benchmark_client->setConnectionTimeout(options_.timeout());
   benchmark_client->setConnectionLimit(options_.connections());
   return benchmark_client;

--- a/source/client/options.proto
+++ b/source/client/options.proto
@@ -23,6 +23,8 @@ message CommandLineOptions {
   string verbosity = 7;
   // See :option:`--output-format` for details.
   string output_format = 8;
+  // See :option:`--prefetch-connections` for details.
+  bool prefetch_connections = 9;
   // See :option:`--uri` for details.
-  string uri = 9;
+  string uri = 10;
 }

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -20,7 +20,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::ValueArg<uint64_t> connections(
       "", "connections",
       "The number of connections per event loop that the test should maximally "
-      "use. Default: 1.",
+      "use. HTTP/1 only. Default: 1.",
       false, 1, "uint64_t", cmd);
   TCLAP::ValueArg<uint64_t> duration("", "duration",
                                      "The number of seconds that the test should run. Default: 5.",
@@ -59,6 +59,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "default output format is 'human'.",
       false, "human", &output_formats_allowed, cmd);
 
+  TCLAP::SwitchArg prefetch_connections(
+      "", "prefetch-connections", "Prefetch connections before benchmarking (HTTP/1 only).", cmd);
+
   TCLAP::UnlabeledValueArg<std::string> uri("uri",
                                             "uri to benchmark. http:// and https:// are supported, "
                                             "but in case of https no certificates are validated.",
@@ -90,6 +93,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   concurrency_ = concurrency.getValue();
   verbosity_ = verbosity.getValue();
   output_format_ = output_format.getValue();
+  prefetch_connections_ = prefetch_connections.getValue();
 
   // We cap on negative values. TCLAP accepts negative values which we will get here as very
   // large values. We just cap values to 2^63.
@@ -144,6 +148,7 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   command_line_options->set_concurrency(concurrency());
   command_line_options->set_verbosity(verbosity());
   command_line_options->set_output_format(outputFormat());
+  command_line_options->set_prefetch_connections(prefetchConnections());
 
   return command_line_options;
 }

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -27,6 +27,7 @@ public:
   std::string concurrency() const override { return concurrency_; }
   std::string verbosity() const override { return verbosity_; };
   std::string outputFormat() const override { return output_format_; };
+  bool prefetchConnections() const override { return prefetch_connections_; }
 
 private:
   uint64_t requests_per_second_;
@@ -38,6 +39,7 @@ private:
   std::string concurrency_;
   std::string verbosity_;
   std::string output_format_;
+  bool prefetch_connections_;
 };
 
 } // namespace Client

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -74,7 +74,7 @@ public:
   void testBasicFunctionality(absl::string_view uriPath, const uint64_t max_pending,
                               const uint64_t connection_limit, const bool use_h2,
                               const uint64_t amount_of_request) {
-    setupBenchmarkClient(uriPath, use_h2);
+    setupBenchmarkClient(uriPath, use_h2, false);
 
     client_->setConnectionTimeout(10s);
     client_->setMaxPendingRequests(max_pending);
@@ -102,9 +102,11 @@ public:
     EXPECT_EQ(0, getCounter("benchmark.stream_resets"));
   }
 
-  virtual void setupBenchmarkClient(absl::string_view uriPath, bool use_h2) = 0;
+  virtual void setupBenchmarkClient(absl::string_view uriPath, bool use_h2,
+                                    bool prefetch_connections) = 0;
 
-  void doSetupBenchmarkClient(absl::string_view uriPath, bool use_https, bool use_h2) {
+  void doSetupBenchmarkClient(absl::string_view uriPath, bool use_https, bool use_h2,
+                              bool prefetch_connections) {
     const std::string address = Envoy::Network::Test::getLoopbackAddressUrlString(GetParam());
     auto uri = std::make_unique<UriImpl>(fmt::format("{}://{}:{}{}", use_https ? "https" : "http",
                                                      address, getTestServerHostAndPort(), uriPath));
@@ -113,7 +115,7 @@ public:
                                    : Envoy::Network::DnsLookupFamily::V6Only);
     client_ = std::make_unique<Client::BenchmarkClientHttpImpl>(
         api_, *dispatcher_, store_, std::make_unique<StreamingStatistic>(),
-        std::make_unique<StreamingStatistic>(), std::move(uri), use_h2);
+        std::make_unique<StreamingStatistic>(), std::move(uri), use_h2, prefetch_connections);
   }
 
   uint64_t nonZeroValuedCounterCount() {
@@ -143,8 +145,9 @@ class BenchmarkClientHttpTest : public BenchmarkClientTestBase {
 public:
   void SetUp() override { BenchmarkClientHttpTest::initialize(); }
 
-  void setupBenchmarkClient(absl::string_view uriPath, bool use_h2) override {
-    doSetupBenchmarkClient(uriPath, false, use_h2);
+  void setupBenchmarkClient(absl::string_view uriPath, bool use_h2,
+                            bool prefetch_connections) override {
+    doSetupBenchmarkClient(uriPath, false, use_h2, prefetch_connections);
   };
 };
 
@@ -152,8 +155,9 @@ class BenchmarkClientHttpsTest : public BenchmarkClientTestBase {
 public:
   void SetUp() override { BenchmarkClientHttpsTest::initialize(); }
 
-  void setupBenchmarkClient(absl::string_view uriPath, bool use_h2) override {
-    doSetupBenchmarkClient(uriPath, true, use_h2);
+  void setupBenchmarkClient(absl::string_view uriPath, bool use_h2,
+                            bool prefetch_connections) override {
+    doSetupBenchmarkClient(uriPath, true, use_h2, prefetch_connections);
   };
 
   void initialize() override {
@@ -315,7 +319,7 @@ TEST_P(BenchmarkClientHttpTest, H1MultiConnectionFailure) {
 }
 
 TEST_P(BenchmarkClientHttpTest, EnableLatencyMeasurement) {
-  setupBenchmarkClient("/", false);
+  setupBenchmarkClient("/", false, false);
   int callback_count = 0;
   client_->initialize(runtime_);
 
@@ -347,7 +351,7 @@ TEST_P(BenchmarkClientHttpTest, StatusTrackingInOnComplete) {
   auto store = std::make_unique<Envoy::Stats::IsolatedStoreImpl>();
   client_ = std::make_unique<Client::BenchmarkClientHttpImpl>(
       api_, *dispatcher_, *store, std::make_unique<StreamingStatistic>(),
-      std::make_unique<StreamingStatistic>(), std::move(uri), false);
+      std::make_unique<StreamingStatistic>(), std::move(uri), false, false);
   Envoy::Http::HeaderMapImpl header;
 
   auto& status = header.insertStatus();
@@ -376,6 +380,15 @@ TEST_P(BenchmarkClientHttpTest, StatusTrackingInOnComplete) {
   EXPECT_EQ(1, getCounter("benchmark.http_5xx"));
   EXPECT_EQ(2, getCounter("benchmark.http_xxx"));
   EXPECT_EQ(1, getCounter("benchmark.stream_resets"));
+}
+
+TEST_P(BenchmarkClientHttpTest, ConnectionPrefetching) {
+  setupBenchmarkClient("/", false, true);
+  client_->setConnectionLimit(50);
+  client_->initialize(runtime_);
+  EXPECT_EQ(true, client_->tryStartOne([&]() { dispatcher_->exit(); }));
+  dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
+  EXPECT_EQ(50, getCounter("upstream_cx_total"));
 }
 
 // TODO(oschaaf): test protocol violations, stream resets, etc.

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -35,6 +35,7 @@ TEST_F(FactoriesTest, CreateBenchmarkClient) {
   EXPECT_CALL(options_, timeout()).Times(1);
   EXPECT_CALL(options_, connections()).Times(1);
   EXPECT_CALL(options_, h2()).Times(1);
+  EXPECT_CALL(options_, prefetchConnections()).Times(1);
 
   auto benchmark_client =
       factory.create(*api_, dispatcher_, stats_store_, std::make_unique<UriImpl>("http://foo/"));

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -73,6 +73,7 @@ public:
   MOCK_CONST_METHOD0(concurrency, std::string());
   MOCK_CONST_METHOD0(verbosity, std::string());
   MOCK_CONST_METHOD0(outputFormat, std::string());
+  MOCK_CONST_METHOD0(prefetchConnections, bool());
   MOCK_CONST_METHOD0(toCommandLineOptions, Client::CommandLineOptionsPtr());
 };
 
@@ -136,6 +137,7 @@ public:
   MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
   MOCK_METHOD1(tryStartOne, bool(std::function<void()>));
   MOCK_CONST_METHOD0(store, Envoy::Stats::Store&());
+  MOCK_METHOD0(prefetchPoolConnections, void());
 
 protected:
   MOCK_CONST_METHOD0(measureLatencies, bool());

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -6,11 +6,12 @@
 #include "client/options_impl.h"
 
 using namespace std::chrono_literals;
+using namespace testing;
 
 namespace Nighthawk {
 namespace Client {
 
-class OptionsImplTest : public testing::Test {
+class OptionsImplTest : public Test {
 public:
   OptionsImplTest()
       : client_name_("nighthawk_client"), good_test_uri_("http://127.0.0.1/"),
@@ -21,8 +22,7 @@ public:
   std::string no_arg_match_;
 };
 
-class OptionsImplIntTest : public OptionsImplTest,
-                           public testing::WithParamInterface<const char*> {};
+class OptionsImplIntTest : public OptionsImplTest, public WithParamInterface<const char*> {};
 
 TEST_F(OptionsImplTest, BogusInput) {
   // When just passing the non-existing argument --foo it would be interpreted as a
@@ -32,6 +32,7 @@ TEST_F(OptionsImplTest, BogusInput) {
                           MalformedArgvException, "Invalid URI");
 }
 
+// This test should cover every option we offer.
 TEST_F(OptionsImplTest, All) {
   std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(fmt::format(
       "{} --rps 4 --connections 5 --duration 6 --timeout 7 --h2 "
@@ -63,22 +64,26 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(cmd->uri(), options->uri());
 }
 
+// Test that TCLAP's way of handling --help behaves as expected.
 TEST_F(OptionsImplTest, Help) {
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format("{}  --help", client_name_)),
                           NoServingException, "NoServingException");
 }
 
+// Test that TCLAP's way of handling --version behaves as expected.
 TEST_F(OptionsImplTest, Version) {
   EXPECT_THROW_WITH_REGEX(
       TestUtility::createOptionsImpl(fmt::format("{}  --version", client_name_)),
       NoServingException, "NoServingException");
 }
 
+// We should fail when no arguments are passed.
 TEST_F(OptionsImplTest, NoArguments) {
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format("{}", client_name_)),
                           MalformedArgvException, "Required argument missing: uri");
 }
 
+// Check standard expectations for any integer values options we offer.
 TEST_P(OptionsImplIntTest, IntOptionsBadValuesThrow) {
   const char* option_name = GetParam();
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format("{} {} --{} 0", client_name_,
@@ -98,17 +103,9 @@ TEST_P(OptionsImplIntTest, IntOptionsBadValuesThrow) {
 }
 
 INSTANTIATE_TEST_SUITE_P(IntOptionTests, OptionsImplIntTest,
-                         testing::Values("rps", "connections", "duration", "timeout"));
+                         Values("rps", "connections", "duration", "timeout"));
 
-TEST_F(OptionsImplTest, BadH2FlagThrows) {
-  EXPECT_THROW_WITH_REGEX(
-      TestUtility::createOptionsImpl(fmt::format("{} {} --h2 0", client_name_, good_test_uri_)),
-      MalformedArgvException, "Couldn't find match for argument");
-  EXPECT_THROW_WITH_REGEX(
-      TestUtility::createOptionsImpl(fmt::format("{} {} --h2 true", client_name_, good_test_uri_)),
-      MalformedArgvException, "Couldn't find match for argument");
-}
-
+// Test behaviour of the boolean valued --h2 flag.
 TEST_F(OptionsImplTest, H2Flag) {
   EXPECT_FALSE(
       TestUtility::createOptionsImpl(fmt::format("{} {}", client_name_, good_test_uri_))->h2());
@@ -137,6 +134,9 @@ TEST_F(OptionsImplTest, PrefetchConnectionsFlag) {
                           MalformedArgvException, "Couldn't find match for argument");
 }
 
+// Test --concurrency, which is a bit special. It's an int option, which also accepts 'auto' as
+// a value. We need to implement some stuff ourselves to get this to work, hence we don't run it
+// through the OptionsImplIntTest.
 TEST_F(OptionsImplTest, BadConcurrencyValuesThrow) {
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
                               fmt::format("{} {} --concurrency 0", client_name_, good_test_uri_)),
@@ -158,12 +158,25 @@ TEST_F(OptionsImplTest, BadConcurrencyValuesThrow) {
       MalformedArgvException, "Value out of range: --concurrency");
 }
 
+// Test we accept --concurrency auto
 TEST_F(OptionsImplTest, AutoConcurrencyValueParsedOK) {
   std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(
       fmt::format("{} --concurrency auto {} ", client_name_, good_test_uri_));
   EXPECT_EQ("auto", options->concurrency());
 }
 
+class OptionsImplVerbosityTest : public OptionsImplTest, public WithParamInterface<const char*> {};
+
+// Test we accept all possible --verbosity values.
+TEST_P(OptionsImplVerbosityTest, VerbosityValues) {
+  TestUtility::createOptionsImpl(
+      fmt::format("{} --verbosity {} {}", client_name_, GetParam(), good_test_uri_));
+}
+
+INSTANTIATE_TEST_SUITE_P(VerbosityOptionTests, OptionsImplVerbosityTest,
+                         Values("trace", "debug", "info", "warn", "error", "critical"));
+
+// Test we don't accept any bad --verbosity values.
 TEST_F(OptionsImplTest, VerbosityValuesAreConstrained) {
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
                               fmt::format("{} {} --verbosity foo", client_name_, good_test_uri_)),

--- a/test/test_data/output_formatter.json.gold
+++ b/test/test_data/output_formatter.json.gold
@@ -6,6 +6,7 @@
   "concurrency": "",
   "verbosity": "",
   "output_format": "",
+  "prefetch_connections": false,
   "uri": "",
   "duration": "1s"
  },

--- a/test/test_data/output_formatter.yaml.gold
+++ b/test/test_data/output_formatter.yaml.gold
@@ -5,6 +5,7 @@ options:
   concurrency: ""
   verbosity: ""
   output_format: ""
+  prefetch_connections: false
   uri: ""
   duration: 1s
 results:


### PR DESCRIPTION
Enabling connection prefetching will cause the client to open the requested amount of connections to the benchmark target, before performing the actual benchmark. The prefetching is only performed intially.