### PR TITLE
Get us a fully clean clang-tidy run

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements'
 
-WarningsAsErrors: 'bugprone-assert-side-effect,modernize-make-shared,modernize-make-unique,readability-redundant-smartptr-get,readability-braces-around-statements,readability-redundant-string-cstr,bugprone-use-after-move'
+WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements'
 
 CheckOptions:
   - key:             bugprone-assert-side-effect.AssertMacros

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -33,11 +33,11 @@ public:
 
     EXPECT_CALL(benchmark_client_factory_, create(_, _, _, _))
         .Times(1)
-        .WillOnce(Return(ByMove(std::unique_ptr<MockBenchmarkClient>(benchmark_client_))));
+        .WillOnce(Return(ByMove(std::unique_ptr<BenchmarkClient>(benchmark_client_))));
 
     EXPECT_CALL(sequencer_factory_, create(_, _, _, _))
         .Times(1)
-        .WillOnce(Return(ByMove(std::unique_ptr<MockSequencer>(sequencer_))));
+        .WillOnce(Return(ByMove(std::unique_ptr<Sequencer>(sequencer_))));
   }
 
   StatisticPtrMap createStatisticPtrMap() const {

--- a/test/mocks.cc
+++ b/test/mocks.cc
@@ -1,45 +1,29 @@
-#include <chrono>
 #include <memory>
 
 #include "gmock/gmock.h"
 
 #include "test/mocks.h"
 
-using namespace std::chrono_literals;
-
 namespace Nighthawk {
 
 MockPlatformUtil::MockPlatformUtil() = default;
-MockPlatformUtil::~MockPlatformUtil() = default;
 
 MockRateLimiter::MockRateLimiter() = default;
-MockRateLimiter::~MockRateLimiter() = default;
-
-FakeSequencerTarget::FakeSequencerTarget() = default;
-FakeSequencerTarget::~FakeSequencerTarget() = default;
 
 MockSequencerTarget::MockSequencerTarget() = default;
-MockSequencerTarget::~MockSequencerTarget() = default;
 
 MockSequencer::MockSequencer() = default;
-MockSequencer::~MockSequencer() = default;
 
 MockOptions::MockOptions() = default;
-MockOptions::~MockOptions() = default;
 
 MockBenchmarkClientFactory::MockBenchmarkClientFactory() = default;
-MockBenchmarkClientFactory::~MockBenchmarkClientFactory() = default;
 
 MockSequencerFactory::MockSequencerFactory() = default;
-MockSequencerFactory::~MockSequencerFactory() = default;
 
 MockStoreFactory::MockStoreFactory() = default;
-MockStoreFactory::~MockStoreFactory() = default;
 
 MockStatisticFactory::MockStatisticFactory() = default;
-MockStatisticFactory::~MockStatisticFactory() = default;
 
 MockBenchmarkClient::MockBenchmarkClient() = default;
-MockBenchmarkClient::~MockBenchmarkClient() = default;
 
 } // namespace Nighthawk

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -34,7 +34,6 @@ namespace Nighthawk {
 class MockPlatformUtil : public PlatformUtil {
 public:
   MockPlatformUtil();
-  ~MockPlatformUtil() override;
 
   MOCK_CONST_METHOD0(yieldCurrentThread, void());
 };
@@ -42,7 +41,6 @@ public:
 class MockRateLimiter : public RateLimiter {
 public:
   MockRateLimiter();
-  ~MockRateLimiter() override;
 
   MOCK_METHOD0(tryAcquireOne, bool());
   MOCK_METHOD0(releaseOne, void());
@@ -51,7 +49,6 @@ public:
 class MockSequencer : public Sequencer {
 public:
   MockSequencer();
-  ~MockSequencer() override;
 
   MOCK_METHOD0(start, void());
   MOCK_METHOD0(waitForCompletion, void());
@@ -62,7 +59,6 @@ public:
 class MockOptions : public Client::Options {
 public:
   MockOptions();
-  ~MockOptions() override;
 
   MOCK_CONST_METHOD0(requestsPerSecond, uint64_t());
   MOCK_CONST_METHOD0(connections, uint64_t());
@@ -81,7 +77,6 @@ public:
 class MockBenchmarkClientFactory : public Client::BenchmarkClientFactory {
 public:
   MockBenchmarkClientFactory();
-  ~MockBenchmarkClientFactory() override;
   MOCK_CONST_METHOD4(create, Client::BenchmarkClientPtr(Envoy::Api::Api& api,
                                                         Envoy::Event::Dispatcher& dispatcher,
                                                         Envoy::Stats::Store& store, UriPtr&& uri));
@@ -90,7 +85,6 @@ public:
 class MockSequencerFactory : public Client::SequencerFactory {
 public:
   MockSequencerFactory();
-  ~MockSequencerFactory() override;
   MOCK_CONST_METHOD4(create, SequencerPtr(Envoy::TimeSource& time_source,
                                           Envoy::Event::Dispatcher& dispatcher,
                                           Envoy::MonotonicTime start_time,
@@ -100,21 +94,18 @@ public:
 class MockStoreFactory : public Client::StoreFactory {
 public:
   MockStoreFactory();
-  ~MockStoreFactory() override;
   MOCK_CONST_METHOD0(create, Envoy::Stats::StorePtr());
 };
 
 class MockStatisticFactory : public Client::StatisticFactory {
 public:
   MockStatisticFactory();
-  ~MockStatisticFactory() override;
   MOCK_CONST_METHOD0(create, StatisticPtr());
 };
 
 class FakeSequencerTarget {
 public:
-  FakeSequencerTarget();
-  virtual ~FakeSequencerTarget();
+  virtual ~FakeSequencerTarget() = default;
   // A fake method that matches the sequencer target signature.
   virtual bool callback(std::function<void()>) PURE;
 };
@@ -122,15 +113,12 @@ public:
 class MockSequencerTarget : public FakeSequencerTarget {
 public:
   MockSequencerTarget();
-  ~MockSequencerTarget() override;
-
   MOCK_METHOD1(callback, bool(std::function<void()>));
 };
 
 class MockBenchmarkClient : public Client::BenchmarkClient {
 public:
   MockBenchmarkClient();
-  ~MockBenchmarkClient() override;
 
   MOCK_METHOD1(initialize, void(Envoy::Runtime::Loader&));
   MOCK_METHOD0(terminate, void());


### PR DESCRIPTION
Fixes several issues. Also, now that `clang-tidy` runs fully clean, let's turn warnings to errors.
My hopes are up that this deflakes `clang-tidy` in CI.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>