### PR TITLE
Experiment: Mixer integration server for testing

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -51,6 +51,7 @@ envoy_cc_test(
         "//source/client:nighthawk_client_lib",
         "//test:nighthawk_mocks",
         "//test/client:utility_lib",
+        "//test/server:int_server_lib",
         "//test/test_common:environment_lib",
         "@envoy//source/common/filesystem:filesystem_lib",
         "@envoy//source/common/network:dns_lib",

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -34,7 +34,7 @@ class ClientServerTest : public TestWithParam<Envoy::Network::Address::IpVersion
                          Envoy::Logger::Loggable<Envoy::Logger::Id::testing> {
 public:
   ClientServerTest()
-      : transport_socket_factory_(), ip_version_(GetParam()),
+      : ip_version_(GetParam()),
         listening_socket_(
             Envoy::Network::Utility::parseInternetAddressAndPort(fmt::format(
                 "{}:{}", Envoy::Network::Test::getLoopbackAddressUrlString(ip_version_), 0)),

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -22,75 +22,30 @@
 #include "client/factories_impl.h"
 #include "client/options_impl.h"
 
+#include "test/server/int_server.h"
+
 using namespace std::chrono_literals;
 using namespace testing;
 
 namespace Nighthawk {
 namespace Client {
 
-class ClientTest : public Envoy::BaseIntegrationTest,
-                   public TestWithParam<Envoy::Network::Address::IpVersion> {
+class ClientServerTest : public TestWithParam<Envoy::Network::Address::IpVersion>,
+                         Envoy::Logger::Loggable<Envoy::Logger::Id::testing> {
 public:
-  ClientTest() : Envoy::BaseIntegrationTest(GetParam(), realTime(), readEnvoyConfiguration()) {}
-
-  std::string readEnvoyConfiguration() {
-    Envoy::Filesystem::InstanceImplPosix file_system;
-    std::string envoy_config = file_system.fileReadToEnd(Envoy::TestEnvironment::runfilesPath(
-        "test/test_data/benchmark_http_client_test_envoy.yaml"));
-    return Envoy::TestEnvironment::substitute(envoy_config);
-  }
-
-  void SetUp() override {
-    // We fork the integration test fixture into a child process, to avoid conflicting
-    // runtimeloaders as both NH and the integration server want to own that and we can have only
-    // one. The plan is to move to python for this type of testing, so hopefully we can deprecate
-    // this test and it's peculiar setup with fork/pipe soon.
-    RELEASE_ASSERT(pipe(fd_port_) == 0, "Failed to open pipe");
-    RELEASE_ASSERT(pipe(fd_confirm_) == 0, "Failed to open pipe");
-    pid_ = fork();
-    RELEASE_ASSERT(pid_ >= 0, "Fork failed");
-
-    if (pid_ == 0) {
-      // child process running the integration test server.
-      ares_library_init(ARES_LIB_INIT_ALL);
-      Envoy::Event::Libevent::Global::initialize();
-      initialize();
-      int port = lookupPort("listener_0");
-      int parent_message;
-      RELEASE_ASSERT(write(fd_port_[1], &port, sizeof(port)) == sizeof(port), "write failed");
-      // The parent process writes to fd_confirm_ when it has read the port. This call to read
-      // blocks until that happens.
-      RELEASE_ASSERT(read(fd_confirm_[0], &parent_message, sizeof(parent_message)) ==
-                         sizeof(parent_message),
-                     "Invalid read size");
-      RELEASE_ASSERT(parent_message == port, "Failed to confirm port");
-      // The parent process closes fd_port_ when the test tears down. The read call blocks until it
-      // does that.
-      RELEASE_ASSERT(read(fd_port_[0], &port_, sizeof(port_)) == -1, "read failed");
-      GTEST_SKIP();
-    } else if (pid_ > 0) {
-      RELEASE_ASSERT(read(fd_port_[0], &port_, sizeof(port_)) > 0, "read failed");
-      RELEASE_ASSERT(port_ > 0, "read unexpected port_ value");
-      RELEASE_ASSERT(write(fd_confirm_[1], &port_, sizeof(port_)) == sizeof(port_), "write failed");
-    }
-  }
-
-  void TearDown() override {
-    if (pid_ == 0) {
-      test_server_.reset();
-      fake_upstreams_.clear();
-      ares_library_cleanup();
-    }
-    RELEASE_ASSERT(!close(fd_confirm_[0]), "close failed");
-    RELEASE_ASSERT(!close(fd_confirm_[1]), "close failed");
-    RELEASE_ASSERT(!close(fd_port_[0]), "close failed");
-    RELEASE_ASSERT(!close(fd_port_[1]), "close failed");
-  }
+  ClientServerTest()
+      : transport_socket_factory_(), ip_version_(GetParam()),
+        listening_socket_(
+            Envoy::Network::Utility::parseInternetAddressAndPort(fmt::format(
+                "{}:{}", Envoy::Network::Test::getLoopbackAddressUrlString(ip_version_), 0)),
+            nullptr, true),
+        server_("server", listening_socket_, transport_socket_factory_,
+                Envoy::Http::CodecClient::Type::HTTP1) {}
 
   std::string testUrl() {
-    RELEASE_ASSERT(pid_ > 0, "Unexpected call to testUrl");
     const std::string address = Envoy::Network::Test::getLoopbackAddressUrlString(GetParam());
-    return fmt::format("http://{}:{}/", address, port_);
+    uint16_t port = static_cast<uint16_t>(listening_socket_.localAddress()->ip()->port());
+    return fmt::format("http://{}:{}/", address, port);
   }
 
   const char* getAddressFamilyOptionString() {
@@ -101,24 +56,48 @@ public:
     return ip_version == Envoy::Network::Address::IpVersion::v6 ? "v6" : "v4";
   }
 
-  int port_;
-  pid_t pid_;
-  int fd_port_[2];
-  int fd_confirm_[2];
+protected:
+  Envoy::Network::RawBufferSocketFactory transport_socket_factory_;
+  Envoy::Network::Address::IpVersion ip_version_;
+  Envoy::Network::TcpListenSocket listening_socket_;
+  Mixer::Integration::Server server_;
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, ClientTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, ClientServerTest,
                          ValuesIn(Envoy::TestEnvironment::getIpVersionsForTest()),
                          Envoy::TestUtility::ipTestParamsToString);
 
-TEST_P(ClientTest, NormalRun) {
+TEST_P(ClientServerTest, NormalRun) {
+  Mixer::Integration::ServerCallbackHelper server_callbacks; // sends a 200 OK to everything
   Main program(Nighthawk::Client::TestUtility::createOptionsImpl(
       fmt::format("foo --address-family {} --duration 2 --rps 10 {}",
                   getAddressFamilyOptionString(), testUrl())));
+  server_.start(server_callbacks);
   EXPECT_TRUE(program.run());
+  EXPECT_EQ(server_callbacks.connectionsAccepted(), 1);
+  EXPECT_GE(server_callbacks.requestsReceived(), 10);
+  // Server does not close its own sockets but instead relies on the client to initate the close
+  EXPECT_EQ(0, server_callbacks.localCloses());
+  // Server sees a client-initiated close for every socket it accepts
+  EXPECT_EQ(server_callbacks.remoteCloses(), server_callbacks.connectionsAccepted());
 }
 
-TEST_P(ClientTest, AutoConcurrencyRun) {
+TEST_P(ClientServerTest, Prefetching) {
+  Mixer::Integration::ServerCallbackHelper server_callbacks; // sends a 200 OK to everything
+  Main program(Nighthawk::Client::TestUtility::createOptionsImpl(fmt::format(
+      "foo --address-family {} --duration 2 --prefetch-connections --connections 25 --rps 10 {}",
+      getAddressFamilyOptionString(), testUrl())));
+  server_.start(server_callbacks);
+  EXPECT_TRUE(program.run());
+  EXPECT_EQ(server_callbacks.connectionsAccepted(), 25);
+  EXPECT_GE(server_callbacks.requestsReceived(), 10);
+  // Server does not close its own sockets but instead relies on the client to initate the close
+  EXPECT_EQ(0, server_callbacks.localCloses());
+  // Server sees a client-initiated close for every socket it accepts
+  EXPECT_EQ(server_callbacks.remoteCloses(), server_callbacks.connectionsAccepted());
+}
+
+TEST_P(ClientServerTest, AutoConcurrencyRun) {
   std::vector<const char*> argv;
   argv.push_back("foo");
   argv.push_back("--concurrency");
@@ -126,19 +105,28 @@ TEST_P(ClientTest, AutoConcurrencyRun) {
   argv.push_back("--address-family");
   argv.push_back(getAddressFamilyOptionString());
   argv.push_back("--duration");
-  argv.push_back("1");
+  argv.push_back("2");
   argv.push_back("--rps");
-  argv.push_back("1");
+  argv.push_back("5");
   argv.push_back("--verbosity");
   argv.push_back("error");
   std::string url = testUrl();
   argv.push_back(url.c_str());
-
+  Mixer::Integration::ServerCallbackHelper server_callbacks; // sends a 200 OK to everything
   Main program(argv.size(), argv.data());
+
+  server_.start(server_callbacks);
   EXPECT_TRUE(program.run());
+  // each worker ought to have created a single connection.
+  EXPECT_EQ(server_callbacks.connectionsAccepted(), PlatformUtils::determineCpuCoresWithAffinity());
+  EXPECT_GE(server_callbacks.requestsReceived(), 1);
+  // Server does not close its own sockets but instead relies on the client to initate the close
+  EXPECT_EQ(0, server_callbacks.localCloses());
+  // Server sees a client-initiated close for every socket it accepts
+  EXPECT_EQ(server_callbacks.remoteCloses(), server_callbacks.connectionsAccepted());
 }
 
-TEST_P(ClientTest, BadRun) {
+TEST_P(ClientServerTest, BadRun) {
   Main program(Nighthawk::Client::TestUtility::createOptionsImpl(
       fmt::format("foo --address-family {} --duration 1 --rps 1 https://unresolveable.host/",
                   getAddressFamilyOptionString())));

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -1,9 +1,25 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
+    "envoy_cc_test_library",
 )
 
 package(default_visibility = ["//visibility:public"])
+
+envoy_cc_test_library(
+    name = "int_server_lib",
+    srcs = [
+        "int_server.cc",
+    ],
+    hdrs = [
+        "int_server.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        "@envoy//source/server:server_lib",
+        "@envoy//test/integration:http_protocol_integration_lib",
+    ],
+)
 
 envoy_cc_test(
     name = "http_test_server_filter_integration_test",

--- a/test/server/int_server.cc
+++ b/test/server/int_server.cc
@@ -1,0 +1,733 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "int_server.h"
+#include "common/common/lock_guard.h"
+#include "common/common/logger.h"
+#include "common/grpc/codec.h"
+#include "common/http/conn_manager_config.h"
+#include "common/http/conn_manager_impl.h"
+#include "common/http/exception.h"
+#include "common/http/http1/codec_impl.h"
+#include "common/http/http2/codec_impl.h"
+#include "common/network/listen_socket_impl.h"
+#include "common/network/raw_buffer_socket.h"
+#include "envoy/http/codec.h"
+#include "envoy/network/transport_socket.h"
+#include "fmt/printf.h"
+#include "server/connection_handler_impl.h"
+#include "test/test_common/network_utility.h"
+#include "test/test_common/thread_factory_for_test.h"
+#include "test/test_common/utility.h"
+#include <future>
+
+namespace Mixer {
+namespace Integration {
+
+static Envoy::Http::LowerCaseString RequestId(std::string("x-request-id"));
+
+ServerStream::ServerStream() {}
+
+ServerStream::~ServerStream() {}
+
+class ServerStreamImpl : public ServerStream,
+                         public Envoy::Http::StreamDecoder,
+                         public Envoy::Http::StreamCallbacks,
+                         Envoy::Logger::Loggable<Envoy::Logger::Id::testing> {
+public:
+  ServerStreamImpl(uint32_t id, ServerConnection& connection,
+                   ServerRequestCallback request_callback,
+                   Envoy::Http::StreamEncoder& stream_encoder)
+      : id_(id), connection_(connection), request_callback_(request_callback),
+        stream_encoder_(stream_encoder) {
+    // TODO do i have to do this? stream_encoder_.addCallbacks(*this);
+  }
+
+  virtual ~ServerStreamImpl() {
+    ENVOY_LOG(trace, "ServerStream({}:{}:{}) destroyed", connection_.name(), connection_.id(), id_);
+  }
+
+  ServerStreamImpl(ServerStreamImpl&&) = default;
+  ServerStreamImpl& operator=(ServerStreamImpl&&) = default;
+
+  //
+  // ServerStream
+  //
+
+  virtual void sendResponseHeaders(const Envoy::Http::HeaderMap& response_headers,
+                                   const std::chrono::milliseconds delay) override {
+    if (connection_.networkConnection().state() != Envoy::Network::Connection::State::Open) {
+      ENVOY_LOG(warn, "ServerStream({}:{}:{})'s underlying connection is not open!",
+                connection_.name(), connection_.id(), id_);
+      // TODO return error to caller
+      return;
+    }
+
+    if (delay <= std::chrono::milliseconds(0)) {
+      ENVOY_LOG(debug, "ServerStream({}:{}:{}) sending response headers", connection_.name(),
+                connection_.id(), id_);
+      stream_encoder_.encodeHeaders(response_headers, true);
+      return;
+    }
+
+    // Limitation: at most one response can be sent on a stream at a time.
+    assert(nullptr == delay_timer.get());
+    if (delay_timer.get()) {
+      return;
+    }
+
+    response_headers_ = std::make_unique<Envoy::Http::HeaderMapImpl>(response_headers);
+    delay_timer = connection_.dispatcher().createTimer([this, delay]() {
+      ENVOY_LOG(debug, "ServerStream({}:{}:{}) sending response headers after {} msec delay",
+                connection_.name(), connection_.id(), id_, static_cast<long int>(delay.count()));
+      stream_encoder_.encodeHeaders(*response_headers_, true);
+      delay_timer->disableTimer();
+      delay_timer = nullptr;
+      response_headers_ = nullptr;
+    });
+    delay_timer->enableTimer(delay);
+  }
+
+  virtual void sendGrpcResponse(Envoy::Grpc::Status::GrpcStatus status,
+                                const Envoy::Protobuf::Message& message,
+                                const std::chrono::milliseconds delay) override {
+    if (delay <= std::chrono::milliseconds(0)) {
+      ENVOY_LOG(debug, "ServerStream({}:{}:{}) sending gRPC response", connection_.name(),
+                connection_.id(), id_);
+      stream_encoder_.encodeHeaders(Envoy::Http::TestHeaderMapImpl{{":status", "200"}}, false);
+      Envoy::Buffer::InstancePtr serialized_response = Envoy::Grpc::Common::serializeBody(message);
+      stream_encoder_.encodeData(*serialized_response, false);
+      stream_encoder_.encodeTrailers(Envoy::Http::TestHeaderMapImpl{
+          {"grpc-status", std::to_string(static_cast<uint32_t>(status))}});
+      delete_after_callback_ = true;
+      return;
+    }
+
+    // Limitation: at most one response can be sent on a stream at a time.
+    assert(nullptr == delay_timer.get());
+    if (delay_timer.get()) {
+      return;
+    }
+
+    delete_after_callback_ = false;
+    response_status_ = status;
+    response_body_ = Envoy::Grpc::Common::serializeBody(message);
+    delay_timer = connection_.dispatcher().createTimer([this, delay]() {
+      ENVOY_LOG(debug, "ServerStream({}:{}:{}) sending gRPC response after {} msec delay",
+                connection_.name(), connection_.id(), id_, static_cast<long int>(delay.count()));
+      stream_encoder_.encodeHeaders(Envoy::Http::TestHeaderMapImpl{{":status", "200"}}, false);
+      stream_encoder_.encodeData(*response_body_, false);
+      stream_encoder_.encodeTrailers(Envoy::Http::TestHeaderMapImpl{
+          {"grpc-status", std::to_string(static_cast<uint32_t>(response_status_))}});
+      delay_timer->disableTimer();
+      connection_.removeStream(id_);
+      // stream is destroyed
+    });
+    delay_timer->enableTimer(delay);
+  }
+
+  //
+  // Envoy::Http::StreamDecoder
+  //
+
+  virtual void decode100ContinueHeaders(Envoy::Http::HeaderMapPtr&&) override {
+    ENVOY_LOG(error, "ServerStream({}:{}:{}) got continue headers?!?!", connection_.name(),
+              connection_.id(), id_);
+  }
+
+  /**
+   * Called with decoded headers, optionally indicating end of stream.
+   * @param headers supplies the decoded headers map that is moved into the
+   * callee.
+   * @param end_stream supplies whether this is a header only request/response.
+   */
+  virtual void decodeHeaders(Envoy::Http::HeaderMapPtr&& headers, bool end_stream) override {
+    ENVOY_LOG(debug, "ServerStream({}:{}:{}) got request headers", connection_.name(),
+              connection_.id(), id_);
+
+    request_headers_ = std::move(headers);
+
+    /*  TODO use x-request-id for e2e logging
+     *
+        const Envoy::Http::HeaderEntry *header =
+     request_headers_->get(RequestId);
+
+        if (header) {
+          request_id_ = header->value().c_str();
+        }
+    */
+
+    if (end_stream) {
+      onEndStream();
+      // stream is now destroyed
+    }
+  }
+
+  virtual void decodeData(Envoy::Buffer::Instance&, bool end_stream) override {
+    ENVOY_LOG(debug, "ServerStream({}:{}:{}) got request body data", connection_.name(),
+              connection_.id(), id_);
+
+    if (end_stream) {
+      onEndStream();
+      // stream is now destroyed
+    }
+  }
+
+  virtual void decodeTrailers(Envoy::Http::HeaderMapPtr&&) override {
+    ENVOY_LOG(trace, "ServerStream({}:{}:{}) got request trailers", connection_.name(),
+              connection_.id(), id_);
+    onEndStream();
+    // stream is now destroyed
+  }
+
+  virtual void decodeMetadata(Envoy::Http::MetadataMapPtr&&) override {
+    ENVOY_LOG(trace, "ServerStream({}:{}):{} got metadata", connection_.name(), connection_.id(),
+              id_);
+  }
+
+  //
+  // Envoy::Http::StreamCallbacks
+  //
+
+  virtual void onResetStream(Envoy::Http::StreamResetReason reason,
+                             absl::string_view /*transport_failure_reason*/) override {
+    // TODO test with h2 to see if we get these and whether the connection error
+    // handling is enough to handle it.
+    switch (reason) {
+    case Envoy::Http::StreamResetReason::LocalReset:
+      ENVOY_LOG(trace, "ServerStream({}:{}:{}) was locally reset", connection_.name(),
+                connection_.id(), id_);
+      break;
+    case Envoy::Http::StreamResetReason::LocalRefusedStreamReset:
+      ENVOY_LOG(trace, "ServerStream({}:{}:{}) refused local stream reset", connection_.name(),
+                connection_.id(), id_);
+      break;
+    case Envoy::Http::StreamResetReason::RemoteReset:
+      ENVOY_LOG(trace, "ServerStream({}:{}:{}) was remotely reset", connection_.name(),
+                connection_.id(), id_);
+      break;
+    case Envoy::Http::StreamResetReason::RemoteRefusedStreamReset:
+      ENVOY_LOG(trace, "ServerStream({}:{}:{}) refused remote stream reset", connection_.name(),
+                connection_.id(), id_);
+      break;
+    case Envoy::Http::StreamResetReason::ConnectionFailure:
+      ENVOY_LOG(trace, "ServerStream({}:{}:{}) reseet due to initial connection failure",
+                connection_.name(), connection_.id(), id_);
+      break;
+    case Envoy::Http::StreamResetReason::ConnectionTermination:
+      ENVOY_LOG(trace, "ServerStream({}:{}:{}) reset due to underlying connection reset",
+                connection_.name(), connection_.id(), id_);
+      break;
+    case Envoy::Http::StreamResetReason::Overflow:
+      ENVOY_LOG(trace, "ServerStream({}:{}:{}) reset due to resource overflow", connection_.name(),
+                connection_.id(), id_);
+      break;
+    default:
+      ENVOY_LOG(trace, "ServerStream({}:{}:{}) reset due to unknown reason", connection_.name(),
+                connection_.id(), id_);
+      break;
+    }
+  }
+
+  virtual void onAboveWriteBufferHighWatermark() override {
+    // TODO is their anything to be done here?
+    ENVOY_LOG(trace, "ServerStream({}:{}:{}) above write buffer high watermark", connection_.name(),
+              connection_.id(), id_);
+  }
+
+  virtual void onBelowWriteBufferLowWatermark() override {
+    // TODO is their anything to be done here?
+    ENVOY_LOG(trace, "ServerStream({}:{}:{}) below write buffer low watermark", connection_.name(),
+              connection_.id(), id_);
+  }
+
+private:
+  virtual void onEndStream() {
+    ENVOY_LOG(debug, "ServerStream({}:{}:{}) complete", connection_.name(), connection_.id(), id_);
+    request_callback_(connection_, *this, std::move(request_headers_));
+
+    if (delete_after_callback_) {
+      connection_.removeStream(id_);
+      // This stream is now destroyed
+    }
+  }
+
+  ServerStreamImpl(const ServerStreamImpl&) = delete;
+
+  ServerStreamImpl& operator=(const ServerStreamImpl&) = delete;
+
+  uint32_t id_;
+  ServerConnection& connection_;
+  Envoy::Http::HeaderMapPtr request_headers_{nullptr};
+  Envoy::Http::HeaderMapPtr response_headers_{nullptr};
+  Envoy::Buffer::InstancePtr response_body_{nullptr};
+  Envoy::Grpc::Status::GrpcStatus response_status_{Envoy::Grpc::Status::Ok};
+  ServerRequestCallback request_callback_;
+  Envoy::Http::StreamEncoder& stream_encoder_;
+  Envoy::Event::TimerPtr delay_timer{nullptr};
+  bool delete_after_callback_{true};
+};
+
+ServerConnection::ServerConnection(const std::string& name, uint32_t id,
+                                   ServerRequestCallback request_callback,
+                                   ServerCloseCallback close_callback,
+                                   Envoy::Network::Connection& network_connection,
+                                   Envoy::Event::Dispatcher& dispatcher,
+                                   Envoy::Http::CodecClient::Type http_type,
+                                   Envoy::Stats::Scope& scope)
+    : name_(name), id_(id), network_connection_(network_connection), dispatcher_(dispatcher),
+      request_callback_(request_callback), close_callback_(close_callback) {
+  // TODO make use of network_connection_->socketOptions() and possibly http settings;
+
+  const uint64_t max_request_headers_kb = 16;
+
+  switch (http_type) {
+  case Envoy::Http::CodecClient::Type::HTTP1:
+    http_connection_ = std::make_unique<Envoy::Http::Http1::ServerConnectionImpl>(
+        network_connection, *this, Envoy::Http::Http1Settings(), max_request_headers_kb);
+    break;
+  case Envoy::Http::CodecClient::Type::HTTP2: {
+    Envoy::Http::Http2Settings settings;
+    settings.allow_connect_ = true;
+    settings.allow_metadata_ = true;
+    http_connection_ = std::make_unique<Envoy::Http::Http2::ServerConnectionImpl>(
+        network_connection, *this, scope, settings, max_request_headers_kb);
+  } break;
+  default:
+    ENVOY_LOG(error, "ServerConnection({}:{}) doesn't support http type %d, defaulting to HTTP1",
+              name_, id_, static_cast<int>(http_type) + 1);
+    http_connection_ = std::make_unique<Envoy::Http::Http1::ServerConnectionImpl>(
+        network_connection, *this, Envoy::Http::Http1Settings(), max_request_headers_kb);
+  }
+}
+
+ServerConnection::~ServerConnection() {
+  ENVOY_LOG(trace, "ServerConnection({}:{}) destroyed", name_, id_);
+}
+
+const std::string& ServerConnection::name() const { return name_; }
+
+uint32_t ServerConnection::id() const { return id_; }
+
+Envoy::Network::Connection& ServerConnection::networkConnection() { return network_connection_; }
+
+const Envoy::Network::Connection& ServerConnection::networkConnection() const {
+  return network_connection_;
+}
+
+Envoy::Http::ServerConnection& ServerConnection::httpConnection() { return *http_connection_; }
+
+const Envoy::Http::ServerConnection& ServerConnection::httpConnection() const {
+  return *http_connection_;
+}
+
+Envoy::Event::Dispatcher& ServerConnection::dispatcher() { return dispatcher_; }
+
+Envoy::Network::FilterStatus ServerConnection::onData(Envoy::Buffer::Instance& data,
+                                                      bool end_stream) {
+  ENVOY_LOG(trace, "ServerConnection({}:{}) got data", name_, id_);
+
+  try {
+    http_connection_->dispatch(data);
+  } catch (const Envoy::Http::CodecProtocolException& e) {
+    ENVOY_LOG(error, "ServerConnection({}:{}) received the wrong protocol: {}", name_, id_,
+              e.what());
+    network_connection_.close(Envoy::Network::ConnectionCloseType::NoFlush);
+    return Envoy::Network::FilterStatus::StopIteration;
+  }
+
+  if (end_stream) {
+    ENVOY_LOG(error, "ServerConnection({}:{}) got end stream - TODO relay to all active streams?!?",
+              name_, id_);
+  }
+
+  return Envoy::Network::FilterStatus::StopIteration;
+}
+
+Envoy::Network::FilterStatus ServerConnection::onNewConnection() {
+  ENVOY_LOG(trace, "ServerConnection({}:{}) onNewConnection", name_, id_);
+  return Envoy::Network::FilterStatus::Continue;
+}
+
+void ServerConnection::initializeReadFilterCallbacks(Envoy::Network::ReadFilterCallbacks&) {}
+
+Envoy::Http::StreamDecoder& ServerConnection::newStream(Envoy::Http::StreamEncoder& stream_encoder,
+                                                        bool) {
+  ServerStreamImpl* raw = nullptr;
+  uint32_t id = 0U;
+
+  {
+    std::lock_guard<std::mutex> guard(streams_lock_);
+
+    id = stream_counter_++;
+    auto stream = std::make_unique<ServerStreamImpl>(id, *this, request_callback_, stream_encoder);
+    raw = stream.get();
+    streams_[id] = std::move(stream);
+  }
+
+  ENVOY_LOG(debug, "ServerConnection({}:{}) received new Stream({}:{}:{})", name_, id_, name_, id_,
+            id);
+
+  return *raw;
+}
+
+void ServerConnection::removeStream(uint32_t stream_id) {
+  unsigned long size = 0UL;
+
+  {
+    std::lock_guard<std::mutex> guard(streams_lock_);
+    streams_.erase(stream_id);
+    size = streams_.size();
+  }
+
+  if (0 == size) {
+    // TODO do anything special here?
+    ENVOY_LOG(debug, "ServerConnection({}:{}) is idle", name_, id_);
+  }
+}
+
+void ServerConnection::onEvent(Envoy::Network::ConnectionEvent event) {
+  switch (event) {
+  case Envoy::Network::ConnectionEvent::RemoteClose:
+    ENVOY_LOG(debug, "ServerConnection({}:{}) closed by peer or reset", name_, id_);
+    close_callback_(*this, ServerCloseReason::REMOTE_CLOSE);
+    return;
+  case Envoy::Network::ConnectionEvent::LocalClose:
+    ENVOY_LOG(debug, "ServerConnection({}:{}) closed locally", name_, id_);
+    close_callback_(*this, ServerCloseReason::LOCAL_CLOSE);
+    return;
+  default:
+    ENVOY_LOG(error, "ServerConnection({}:{}) got unknown event", name_, id_);
+  }
+}
+
+void ServerConnection::onAboveWriteBufferHighWatermark() {
+  ENVOY_LOG(debug, "ServerConnection({}:{}) above write buffer high watermark", name_, id_);
+  // TODO - is this the right way to handle?
+  http_connection_->onUnderlyingConnectionAboveWriteBufferHighWatermark();
+}
+
+void ServerConnection::onBelowWriteBufferLowWatermark() {
+  ENVOY_LOG(debug, "ServerConnection({}:{}) below write buffer low watermark", name_, id_);
+  // TODO - is this the right way to handle?
+  http_connection_->onUnderlyingConnectionBelowWriteBufferLowWatermark();
+}
+
+void ServerConnection::onGoAway() {
+  ENVOY_LOG(warn, "ServerConnection({}) got go away", name_);
+  // TODO how should this be handled? I've never seen it fire.
+}
+
+ServerFilterChain::ServerFilterChain(
+    Envoy::Network::TransportSocketFactory& transport_socket_factory)
+    : transport_socket_factory_(transport_socket_factory) {}
+
+ServerFilterChain::~ServerFilterChain() {}
+
+const Envoy::Network::TransportSocketFactory& ServerFilterChain::transportSocketFactory() const {
+  return transport_socket_factory_;
+}
+
+const std::vector<Envoy::Network::FilterFactoryCb>&
+ServerFilterChain::networkFilterFactories() const {
+  return network_filter_factories_;
+}
+
+LocalListenSocket::LocalListenSocket(Envoy::Network::Address::IpVersion ip_version, uint16_t port,
+                                     const Envoy::Network::Socket::OptionsSharedPtr& options,
+                                     bool bind_to_port)
+    : NetworkListenSocket(Envoy::Network::Utility::parseInternetAddress(
+                              Envoy::Network::Test::getAnyAddressUrlString(ip_version), port),
+                          options, bind_to_port) {}
+
+LocalListenSocket::~LocalListenSocket() {}
+
+ServerCallbackHelper::ServerCallbackHelper(ServerRequestCallback request_callback,
+                                           ServerAcceptCallback accept_callback,
+                                           ServerCloseCallback close_callback)
+    : accept_callback_(accept_callback), request_callback_(request_callback),
+      close_callback_(close_callback) {
+  if (request_callback) {
+    request_callback_ = [this, &request_callback](ServerConnection& connection,
+                                                  ServerStream& stream,
+                                                  Envoy::Http::HeaderMapPtr request_headers) {
+      ++requests_received_;
+      request_callback(connection, stream, std::move(request_headers));
+    };
+  } else {
+    request_callback_ = [this](ServerConnection&, ServerStream& stream,
+                               Envoy::Http::HeaderMapPtr&&) {
+      ++requests_received_;
+      Envoy::Http::TestHeaderMapImpl response{{":status", "200"}};
+      stream.sendResponseHeaders(response);
+    };
+  }
+
+  if (accept_callback) {
+    accept_callback_ = [this,
+                        &accept_callback](ServerConnection& connection) -> ServerCallbackResult {
+      ++accepts_;
+      return accept_callback(connection);
+    };
+  } else {
+    accept_callback_ = [this](ServerConnection&) -> ServerCallbackResult {
+      ++accepts_;
+      return ServerCallbackResult::CONTINUE;
+    };
+  }
+
+  if (close_callback) {
+    close_callback_ = [this, &close_callback](ServerConnection& connection,
+                                              ServerCloseReason reason) {
+      switch (reason) {
+      case ServerCloseReason::REMOTE_CLOSE:
+        ++remote_closes_;
+        break;
+      case ServerCloseReason::LOCAL_CLOSE:
+        ++local_closes_;
+        break;
+      }
+
+      close_callback(connection, reason);
+      condvar_.notify_one();
+    };
+  } else {
+    close_callback_ = [this](ServerConnection&, ServerCloseReason reason) {
+      switch (reason) {
+      case ServerCloseReason::REMOTE_CLOSE:
+        ++remote_closes_;
+        break;
+      case ServerCloseReason::LOCAL_CLOSE:
+        ++local_closes_;
+        break;
+      }
+      condvar_.notify_one();
+    };
+  }
+}
+
+ServerCallbackHelper::~ServerCallbackHelper() {}
+
+uint32_t ServerCallbackHelper::connectionsAccepted() const { return accepts_; }
+
+uint32_t ServerCallbackHelper::requestsReceived() const { return requests_received_; }
+
+uint32_t ServerCallbackHelper::localCloses() const { return local_closes_; }
+
+uint32_t ServerCallbackHelper::remoteCloses() const { return remote_closes_; }
+
+ServerAcceptCallback ServerCallbackHelper::acceptCallback() const { return accept_callback_; }
+
+ServerRequestCallback ServerCallbackHelper::requestCallback() const { return request_callback_; }
+
+ServerCloseCallback ServerCallbackHelper::closeCallback() const { return close_callback_; }
+
+void ServerCallbackHelper::wait(uint32_t connections_closed) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (connections_closed > local_closes_ + remote_closes_) {
+    condvar_.wait(lock);
+  }
+}
+
+void ServerCallbackHelper::wait() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (accepts_ > local_closes_ + remote_closes_) {
+    condvar_.wait(lock);
+  }
+}
+
+Server::Server(const std::string& name, Envoy::Network::Socket& listening_socket,
+               Envoy::Network::TransportSocketFactory& transport_socket_factory,
+               Envoy::Http::CodecClient::Type http_type)
+    : name_(name), stats_(), time_system_(),
+      api_(Envoy::Thread::threadFactoryForTest(), stats_, time_system_, file_system_),
+      dispatcher_(api_.allocateDispatcher()),
+      connection_handler_(new Envoy::Server::ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),
+      thread_(nullptr), listening_socket_(listening_socket),
+      server_filter_chain_(transport_socket_factory), http_type_(http_type) {}
+
+Server::~Server() { stop(); }
+
+void Server::start(ServerAcceptCallback accept_callback, ServerRequestCallback request_callback,
+                   ServerCloseCallback close_callback) {
+  accept_callback_ = accept_callback;
+  request_callback_ = request_callback;
+  close_callback_ = close_callback;
+  std::promise<bool> promise;
+
+  thread_ = api_.threadFactory().createThread([this, &promise]() {
+    is_running = true;
+    ENVOY_LOG(debug, "Server({}) started", name_.c_str());
+    connection_handler_->addListener(*this);
+
+    promise.set_value(true); // do not use promise again after this
+    while (is_running) {
+      dispatcher_->run(Envoy::Event::Dispatcher::RunType::NonBlock);
+    }
+
+    ENVOY_LOG(debug, "Server({}) stopped", name_.c_str());
+
+    connection_handler_.reset();
+  });
+
+  promise.get_future().get();
+}
+
+void Server::start(ServerCallbackHelper& helper) {
+  start(helper.acceptCallback(), helper.requestCallback(), helper.closeCallback());
+}
+
+void Server::stop() {
+  is_running = false;
+
+  if (thread_) {
+    thread_->join();
+    thread_ = nullptr;
+  }
+}
+
+void Server::stopAcceptingConnections() {
+  ENVOY_LOG(debug, "Server({}) stopped accepting connections", name_);
+  connection_handler_->disableListeners();
+}
+
+void Server::startAcceptingConnections() {
+  ENVOY_LOG(debug, "Server({}) started accepting connections", name_);
+  connection_handler_->enableListeners();
+}
+
+const Envoy::Stats::Store& Server::statsStore() const { return stats_; }
+
+void Server::setPerConnectionBufferLimitBytes(uint32_t limit) {
+  connection_buffer_limit_bytes_ = limit;
+}
+
+//
+// Envoy::Network::ListenerConfig
+//
+
+Envoy::Network::FilterChainManager& Server::filterChainManager() { return *this; }
+
+Envoy::Network::FilterChainFactory& Server::filterChainFactory() { return *this; }
+
+Envoy::Network::Socket& Server::socket() { return listening_socket_; }
+
+const Envoy::Network::Socket& Server::socket() const { return listening_socket_; }
+
+bool Server::bindToPort() { return true; }
+
+bool Server::handOffRestoredDestinationConnections() const { return false; }
+
+uint32_t Server::perConnectionBufferLimitBytes() const { return connection_buffer_limit_bytes_; }
+
+std::chrono::milliseconds Server::listenerFiltersTimeout() const {
+  return std::chrono::milliseconds(0);
+}
+
+Envoy::Stats::Scope& Server::listenerScope() { return stats_; }
+
+uint64_t Server::listenerTag() const { return 0; }
+
+const std::string& Server::name() const { return name_; }
+
+const Envoy::Network::FilterChain*
+Server::findFilterChain(const Envoy::Network::ConnectionSocket&) const {
+  return &server_filter_chain_;
+}
+
+bool Server::createNetworkFilterChain(Envoy::Network::Connection& network_connection,
+                                      const std::vector<Envoy::Network::FilterFactoryCb>&) {
+  uint32_t id = connection_counter_++;
+  ENVOY_LOG(debug, "Server({}) accepted new Connection({}:{})", name_, name_, id);
+
+  ServerConnectionSharedPtr connection =
+      std::make_shared<ServerConnection>(name_, id, request_callback_, close_callback_,
+                                         network_connection, *dispatcher_, http_type_, stats_);
+  network_connection.addReadFilter(connection);
+  network_connection.addConnectionCallbacks(*connection);
+
+  if (ServerCallbackResult::CLOSE == accept_callback_(*connection)) {
+    // Envoy will close the connection immediately, which will in turn
+    // trigger the user supplied close callback.
+    return false;
+  }
+
+  return true;
+}
+
+bool Server::createListenerFilterChain(Envoy::Network::ListenerFilterManager&) { return true; }
+
+ClusterHelper::ClusterHelper(std::initializer_list<ServerCallbackHelper*> server_callbacks) {
+  for (auto it = server_callbacks.begin(); it != server_callbacks.end(); ++it) {
+    server_callback_helpers_.emplace_back(*it);
+  }
+}
+
+ClusterHelper::~ClusterHelper() {}
+
+const std::vector<ServerCallbackHelperPtr>& ClusterHelper::servers() const {
+  return server_callback_helpers_;
+}
+
+std::vector<ServerCallbackHelperPtr>& ClusterHelper::servers() { return server_callback_helpers_; }
+
+uint32_t ClusterHelper::connectionsAccepted() const {
+  uint32_t total = 0U;
+
+  for (size_t i = 0; i < server_callback_helpers_.size(); ++i) {
+    total += server_callback_helpers_[i]->connectionsAccepted();
+  }
+
+  return total;
+}
+
+uint32_t ClusterHelper::requestsReceived() const {
+  uint32_t total = 0U;
+
+  for (size_t i = 0; i < server_callback_helpers_.size(); ++i) {
+    total += server_callback_helpers_[i]->requestsReceived();
+  }
+
+  return total;
+}
+
+uint32_t ClusterHelper::localCloses() const {
+  uint32_t total = 0U;
+
+  for (size_t i = 0; i < server_callback_helpers_.size(); ++i) {
+    total += server_callback_helpers_[i]->localCloses();
+  }
+
+  return total;
+}
+
+uint32_t ClusterHelper::remoteCloses() const {
+  uint32_t total = 0U;
+
+  for (size_t i = 0; i < server_callback_helpers_.size(); ++i) {
+    total += server_callback_helpers_[i]->remoteCloses();
+  }
+
+  return total;
+}
+
+void ClusterHelper::wait() {
+  for (size_t i = 0; i < server_callback_helpers_.size(); ++i) {
+    server_callback_helpers_[i]->wait();
+  }
+}
+
+} // namespace Integration
+} // namespace Mixer

--- a/test/server/int_server.h
+++ b/test/server/int_server.h
@@ -1,0 +1,432 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "common/api/api_impl.h"
+#include "common/grpc/common.h"
+#include "common/http/codec_client.h"
+#include "common/network/listen_socket_impl.h"
+#include "common/stats/isolated_store_impl.h"
+#include "test/test_common/test_time.h"
+#include "test/test_common/utility.h"
+
+#include "common/filesystem/filesystem_impl.h"
+
+namespace Mixer {
+namespace Integration {
+
+enum class ServerCloseReason {
+  REMOTE_CLOSE, // Peer closed or connection was reset after it was established.
+  LOCAL_CLOSE   // This process decided to close the connection.
+};
+
+enum class ServerCallbackResult {
+  CONTINUE, // Leave the connection open
+  CLOSE     // Close the connection.
+};
+
+class ServerStream {
+public:
+  ServerStream();
+
+  virtual ~ServerStream();
+
+  ServerStream(ServerStream&&) = default;
+  ServerStream& operator=(ServerStream&&) = default;
+
+  /**
+   * Send a HTTP header-only response and close the stream.
+   *
+   * @param response_headers the response headers
+   * @param delay delay in msec before sending the response.  if 0 send immediately
+   */
+  virtual void
+  sendResponseHeaders(const Envoy::Http::HeaderMap& response_headers,
+                      const std::chrono::milliseconds delay = std::chrono::milliseconds(0)) PURE;
+
+  /**
+   * Send a gRPC response and close the stream
+   *
+   * @param status The gRPC status (carried in the HTTP response trailer)
+   * @param response The gRPC response (carried in the HTTP response body)
+   * @param delay delay in msec before sending the response.  if 0 send immediately
+   */
+  virtual void
+  sendGrpcResponse(Envoy::Grpc::Status::GrpcStatus status, const Envoy::Protobuf::Message& response,
+                   const std::chrono::milliseconds delay = std::chrono::milliseconds(0)) PURE;
+
+private:
+  ServerStream(const ServerStream&) = delete;
+  void operator=(const ServerStream&) = delete;
+};
+
+typedef std::unique_ptr<ServerStream> ServerStreamPtr;
+typedef std::shared_ptr<ServerStream> ServerStreamSharedPtr;
+
+class ServerConnection;
+
+// NB: references passed to any of these callbacks are owned by the caller and must not be used
+// after the callback returns -- except for the request headers which may be moved into the caller.
+typedef std::function<ServerCallbackResult(ServerConnection& server_connection)>
+    ServerAcceptCallback;
+typedef std::function<void(ServerConnection& connection, ServerCloseReason reason)>
+    ServerCloseCallback;
+// TODO support sending delayed responses
+typedef std::function<void(ServerConnection& connection, ServerStream& stream,
+                           Envoy::Http::HeaderMapPtr request_headers)>
+    ServerRequestCallback;
+
+class ServerConnection : public Envoy::Network::ReadFilter,
+                         public Envoy::Network::ConnectionCallbacks,
+                         public Envoy::Http::ServerConnectionCallbacks,
+                         Envoy::Logger::Loggable<Envoy::Logger::Id::testing> {
+public:
+  ServerConnection(const std::string& name, uint32_t id, ServerRequestCallback request_callback,
+                   ServerCloseCallback close_callback,
+                   Envoy::Network::Connection& network_connection,
+                   Envoy::Event::Dispatcher& dispatcher, Envoy::Http::CodecClient::Type http_type,
+                   Envoy::Stats::Scope& scope);
+
+  virtual ~ServerConnection();
+
+  ServerConnection(ServerConnection&&) = default;
+  ServerConnection& operator=(ServerConnection&&) = default;
+
+  const std::string& name() const;
+
+  uint32_t id() const;
+
+  Envoy::Network::Connection& networkConnection();
+  const Envoy::Network::Connection& networkConnection() const;
+
+  Envoy::Http::ServerConnection& httpConnection();
+  const Envoy::Http::ServerConnection& httpConnection() const;
+
+  Envoy::Event::Dispatcher& dispatcher();
+
+  /**
+   * For internal use
+   */
+  void removeStream(uint32_t stream_id);
+
+  //
+  // Envoy::Network::ReadFilter
+  //
+
+  virtual Envoy::Network::FilterStatus onData(Envoy::Buffer::Instance& data,
+                                              bool end_stream) override;
+
+  virtual Envoy::Network::FilterStatus onNewConnection() override;
+
+  virtual void initializeReadFilterCallbacks(Envoy::Network::ReadFilterCallbacks&) override;
+
+  //
+  // Envoy::Http::ConnectionCallbacks
+  //
+
+  virtual void onGoAway() override;
+
+  //
+  // Envoy::Http::ServerConnectionCallbacks
+  //
+
+  virtual Envoy::Http::StreamDecoder& newStream(Envoy::Http::StreamEncoder& stream_encoder,
+                                                bool is_internally_created = false) override;
+
+  //
+  // Envoy::Network::ConnectionCallbacks
+  //
+
+  virtual void onEvent(Envoy::Network::ConnectionEvent event) override;
+
+  virtual void onAboveWriteBufferHighWatermark() override;
+
+  virtual void onBelowWriteBufferLowWatermark() override;
+
+private:
+  ServerConnection(const ServerConnection&) = delete;
+  ServerConnection& operator=(const ServerConnection&) = delete;
+
+  std::string name_;
+  uint32_t id_;
+  Envoy::Network::Connection& network_connection_;
+  Envoy::Http::ServerConnectionPtr http_connection_;
+  Envoy::Event::Dispatcher& dispatcher_;
+  ServerRequestCallback request_callback_;
+  ServerCloseCallback close_callback_;
+
+  std::mutex streams_lock_;
+  std::unordered_map<uint32_t, ServerStreamPtr> streams_;
+  uint32_t stream_counter_{0U};
+};
+
+typedef std::unique_ptr<ServerConnection> ServerConnectionPtr;
+typedef std::shared_ptr<ServerConnection> ServerConnectionSharedPtr;
+
+class ServerFilterChain : public Envoy::Network::FilterChain {
+public:
+  ServerFilterChain(Envoy::Network::TransportSocketFactory& transport_socket_factory);
+
+  virtual ~ServerFilterChain();
+
+  ServerFilterChain(ServerFilterChain&&) = default;
+  ServerFilterChain& operator=(ServerFilterChain&&) = default;
+
+  //
+  // Envoy::Network::FilterChain
+  //
+
+  virtual const Envoy::Network::TransportSocketFactory& transportSocketFactory() const override;
+
+  virtual const std::vector<Envoy::Network::FilterFactoryCb>&
+  networkFilterFactories() const override;
+
+private:
+  ServerFilterChain(const ServerFilterChain&) = delete;
+  ServerFilterChain& operator=(const ServerFilterChain&) = delete;
+
+  Envoy::Network::TransportSocketFactory& transport_socket_factory_;
+  std::vector<Envoy::Network::FilterFactoryCb> network_filter_factories_;
+};
+
+/**
+ * A convenience class for creating a listening socket bound to localhost
+ */
+class LocalListenSocket : public Envoy::Network::TcpListenSocket {
+public:
+  /**
+   * Create a listening socket bound to localhost.
+   *
+   * @param ip_version v4 or v6.  v4 by default.
+   * @param port the port.  If 0, let the kernel allocate an avaiable ephemeral port.  0 by default.
+   * @param options socket options.  nullptr by default
+   * @param bind_to_port if true immediately bind to the port, allocating one if necessary.  true by
+   * default.
+   */
+  LocalListenSocket(
+      Envoy::Network::Address::IpVersion ip_version = Envoy::Network::Address::IpVersion::v4,
+      uint16_t port = 0, const Envoy::Network::Socket::OptionsSharedPtr& options = nullptr,
+      bool bind_to_port = true);
+
+  virtual ~LocalListenSocket();
+
+  LocalListenSocket(LocalListenSocket&&) = default;
+  LocalListenSocket& operator=(LocalListenSocket&&) = default;
+
+private:
+  LocalListenSocket(const LocalListenSocket&) = delete;
+  void operator=(const LocalListenSocket&) = delete;
+};
+
+/**
+ * A convenience class for passing callbacks to a Server.  If no callbacks are provided, default
+ * callbacks that track some simple metrics will be used.   If callbacks are provided, they will be
+ * wrapped with callbacks that maintain the same simple set of metrics.
+ */
+class ServerCallbackHelper {
+public:
+  ServerCallbackHelper(ServerRequestCallback request_callback = nullptr,
+                       ServerAcceptCallback accept_callback = nullptr,
+                       ServerCloseCallback close_callback = nullptr);
+
+  virtual ~ServerCallbackHelper();
+
+  ServerCallbackHelper(ServerCallbackHelper&&) = default;
+  ServerCallbackHelper& operator=(ServerCallbackHelper&&) = default;
+
+  uint32_t connectionsAccepted() const;
+  uint32_t requestsReceived() const;
+  uint32_t localCloses() const;
+  uint32_t remoteCloses() const;
+  ServerAcceptCallback acceptCallback() const;
+  ServerRequestCallback requestCallback() const;
+  ServerCloseCallback closeCallback() const;
+
+  /*
+   * Wait until the server has accepted n connections and seen them closed (due to error or client
+   * close)
+   */
+  void wait(uint32_t connections);
+
+  /*
+   * Wait until the server has seen a close for every connection it has accepted.
+   */
+  void wait();
+
+private:
+  ServerCallbackHelper(const ServerCallbackHelper&) = delete;
+  void operator=(const ServerCallbackHelper&) = delete;
+
+  ServerAcceptCallback accept_callback_;
+  ServerRequestCallback request_callback_;
+  ServerCloseCallback close_callback_;
+
+  std::atomic<uint32_t> accepts_{0};
+  std::atomic<uint32_t> requests_received_{0};
+  std::atomic<uint32_t> local_closes_{0};
+  std::atomic<uint32_t> remote_closes_{0};
+  std::mutex mutex_;
+  std::condition_variable condvar_;
+};
+
+typedef std::unique_ptr<ServerCallbackHelper> ServerCallbackHelperPtr;
+typedef std::shared_ptr<ServerCallbackHelper> ServerCallbackHelperSharedPtr;
+
+class Server : public Envoy::Network::FilterChainManager,
+               public Envoy::Network::FilterChainFactory,
+               public Envoy::Network::ListenerConfig,
+               Envoy::Logger::Loggable<Envoy::Logger::Id::testing> {
+public:
+  // TODO make use of Network::Socket::OptionsSharedPtr
+  Server(const std::string& name, Envoy::Network::Socket& listening_socket,
+         Envoy::Network::TransportSocketFactory& transport_socket_factory,
+         Envoy::Http::CodecClient::Type http_type);
+
+  virtual ~Server();
+
+  Server(Server&&) = default;
+  Server& operator=(Server&&) = default;
+
+  void start(ServerAcceptCallback accept_callback, ServerRequestCallback request_callback,
+             ServerCloseCallback close_callback);
+
+  void start(ServerCallbackHelper& helper);
+
+  void stop();
+
+  void stopAcceptingConnections();
+
+  void startAcceptingConnections();
+
+  const Envoy::Stats::Store& statsStore() const;
+
+  // TODO does this affect socket recv buffer size?  Only for new connections?
+  void setPerConnectionBufferLimitBytes(uint32_t limit);
+
+  //
+  // Envoy::Network::ListenerConfig
+  //
+
+  virtual Envoy::Network::FilterChainManager& filterChainManager() override;
+
+  virtual Envoy::Network::FilterChainFactory& filterChainFactory() override;
+
+  virtual Envoy::Network::Socket& socket() override;
+
+  virtual const Envoy::Network::Socket& socket() const override;
+
+  virtual bool bindToPort() override;
+
+  virtual bool handOffRestoredDestinationConnections() const override;
+
+  // TODO does this affect socket recv buffer size?  Only for new connections?
+  virtual uint32_t perConnectionBufferLimitBytes() const override;
+
+  virtual std::chrono::milliseconds listenerFiltersTimeout() const override;
+
+  virtual Envoy::Stats::Scope& listenerScope() override;
+
+  virtual uint64_t listenerTag() const override;
+
+  virtual const std::string& name() const override;
+
+  //
+  // Envoy::Network::FilterChainManager
+  //
+
+  virtual const Envoy::Network::FilterChain*
+  findFilterChain(const Envoy::Network::ConnectionSocket&) const override;
+
+  //
+  // Envoy::Network::FilterChainFactory
+  //
+
+  virtual bool
+  createNetworkFilterChain(Envoy::Network::Connection& network_connection,
+                           const std::vector<Envoy::Network::FilterFactoryCb>&) override;
+
+  virtual bool createListenerFilterChain(Envoy::Network::ListenerFilterManager&) override;
+
+private:
+  Server(const Server&) = delete;
+  void operator=(const Server&) = delete;
+
+  std::string name_;
+  Envoy::Stats::IsolatedStoreImpl stats_;
+  Envoy::Event::TestRealTimeSystem time_system_;
+  Envoy::Api::Impl api_;
+  Envoy::Event::DispatcherPtr dispatcher_;
+  Envoy::Network::ConnectionHandlerPtr connection_handler_;
+  Envoy::Thread::ThreadPtr thread_;
+  Envoy::Filesystem::InstanceImplPosix file_system_;
+  std::atomic<bool> is_running{false};
+
+  ServerAcceptCallback accept_callback_{nullptr};
+  ServerRequestCallback request_callback_{nullptr};
+  ServerCloseCallback close_callback_{nullptr};
+
+  //
+  // Envoy::Network::ListenerConfig
+  //
+
+  Envoy::Network::Socket& listening_socket_;
+  std::atomic<uint32_t> connection_buffer_limit_bytes_{0U};
+
+  //
+  // Envoy::Network::FilterChainManager
+  //
+
+  ServerFilterChain server_filter_chain_;
+
+  //
+  // Envoy::Network::FilterChainFactory
+  //
+
+  Envoy::Http::CodecClient::Type http_type_;
+  std::atomic<uint32_t> connection_counter_{0U};
+};
+
+typedef std::unique_ptr<Server> ServerPtr;
+typedef std::shared_ptr<Server> ServerSharedPtr;
+
+class ClusterHelper {
+public:
+  /*template <typename... Args>
+  ClusterHelper(Args &&... args) : servers_(std::forward<Args>(args)...){};*/
+
+  ClusterHelper(std::initializer_list<ServerCallbackHelper*> server_callbacks);
+
+  virtual ~ClusterHelper();
+
+  const std::vector<ServerCallbackHelperPtr>& servers() const;
+  std::vector<ServerCallbackHelperPtr>& servers();
+
+  uint32_t connectionsAccepted() const;
+  uint32_t requestsReceived() const;
+  uint32_t localCloses() const;
+  uint32_t remoteCloses() const;
+
+  void wait();
+
+private:
+  ClusterHelper(const ClusterHelper&) = delete;
+  void operator=(const ClusterHelper&) = delete;
+
+  std::vector<ServerCallbackHelperPtr> server_callback_helpers_;
+};
+
+} // namespace Integration
+} // namespace Mixer

--- a/test/server/int_server.h
+++ b/test/server/int_server.h
@@ -68,44 +68,41 @@ public:
   sendGrpcResponse(Envoy::Grpc::Status::GrpcStatus status, const Envoy::Protobuf::Message& response,
                    const std::chrono::milliseconds delay = std::chrono::milliseconds(0)) PURE;
 
-private:
-  ServerStream(const ServerStream&) = delete;
-  void operator=(const ServerStream&) = delete;
+  // private:
+  //  ServerStream(const ServerStream&) = delete;
+  //  void operator=(const ServerStream&) = delete;
 };
 
-typedef std::unique_ptr<ServerStream> ServerStreamPtr;
-typedef std::shared_ptr<ServerStream> ServerStreamSharedPtr;
+using ServerStreamPtr = std::unique_ptr<ServerStream>;
+using ServerStreamSharedPtr = std::shared_ptr<ServerStream>;
 
 class ServerConnection;
 
 // NB: references passed to any of these callbacks are owned by the caller and must not be used
 // after the callback returns -- except for the request headers which may be moved into the caller.
-typedef std::function<ServerCallbackResult(ServerConnection& server_connection)>
-    ServerAcceptCallback;
-typedef std::function<void(ServerConnection& connection, ServerCloseReason reason)>
-    ServerCloseCallback;
+using ServerAcceptCallback = std::function<ServerCallbackResult(ServerConnection&)>;
+using ServerCloseCallback = std::function<void(ServerConnection&, ServerCloseReason)>;
 // TODO support sending delayed responses
-typedef std::function<void(ServerConnection& connection, ServerStream& stream,
-                           Envoy::Http::HeaderMapPtr request_headers)>
-    ServerRequestCallback;
+using ServerRequestCallback =
+    std::function<void(ServerConnection&, ServerStream&, Envoy::Http::HeaderMapPtr)>;
 
 class ServerConnection : public Envoy::Network::ReadFilter,
                          public Envoy::Network::ConnectionCallbacks,
                          public Envoy::Http::ServerConnectionCallbacks,
                          Envoy::Logger::Loggable<Envoy::Logger::Id::testing> {
 public:
-  ServerConnection(const std::string& name, uint32_t id, ServerRequestCallback request_callback,
+  ServerConnection(absl::string_view name, uint32_t id, ServerRequestCallback request_callback,
                    ServerCloseCallback close_callback,
                    Envoy::Network::Connection& network_connection,
                    Envoy::Event::Dispatcher& dispatcher, Envoy::Http::CodecClient::Type http_type,
                    Envoy::Stats::Scope& scope);
 
-  virtual ~ServerConnection();
+  ~ServerConnection() override;
 
-  ServerConnection(ServerConnection&&) = default;
-  ServerConnection& operator=(ServerConnection&&) = default;
+  // ServerConnection(ServerConnection&&) = default;
+  // ServerConnection& operator=(ServerConnection&&) = default;
 
-  const std::string& name() const;
+  absl::string_view name() const;
 
   uint32_t id() const;
 
@@ -126,39 +123,38 @@ public:
   // Envoy::Network::ReadFilter
   //
 
-  virtual Envoy::Network::FilterStatus onData(Envoy::Buffer::Instance& data,
-                                              bool end_stream) override;
+  Envoy::Network::FilterStatus onData(Envoy::Buffer::Instance& data, bool end_stream) override;
 
-  virtual Envoy::Network::FilterStatus onNewConnection() override;
+  Envoy::Network::FilterStatus onNewConnection() override;
 
-  virtual void initializeReadFilterCallbacks(Envoy::Network::ReadFilterCallbacks&) override;
+  void initializeReadFilterCallbacks(Envoy::Network::ReadFilterCallbacks&) override;
 
   //
   // Envoy::Http::ConnectionCallbacks
   //
 
-  virtual void onGoAway() override;
+  void onGoAway() override;
 
   //
   // Envoy::Http::ServerConnectionCallbacks
   //
 
-  virtual Envoy::Http::StreamDecoder& newStream(Envoy::Http::StreamEncoder& stream_encoder,
-                                                bool is_internally_created = false) override;
+  Envoy::Http::StreamDecoder& newStream(Envoy::Http::StreamEncoder& stream_encoder,
+                                        bool is_internally_created = false) override;
 
   //
   // Envoy::Network::ConnectionCallbacks
   //
 
-  virtual void onEvent(Envoy::Network::ConnectionEvent event) override;
+  void onEvent(Envoy::Network::ConnectionEvent event) override;
 
-  virtual void onAboveWriteBufferHighWatermark() override;
+  void onAboveWriteBufferHighWatermark() override;
 
-  virtual void onBelowWriteBufferLowWatermark() override;
+  void onBelowWriteBufferLowWatermark() override;
 
 private:
-  ServerConnection(const ServerConnection&) = delete;
-  ServerConnection& operator=(const ServerConnection&) = delete;
+  // ServerConnection(const ServerConnection&) = delete;
+  // ServerConnection& operator=(const ServerConnection&) = delete;
 
   std::string name_;
   uint32_t id_;
@@ -173,30 +169,29 @@ private:
   uint32_t stream_counter_{0U};
 };
 
-typedef std::unique_ptr<ServerConnection> ServerConnectionPtr;
-typedef std::shared_ptr<ServerConnection> ServerConnectionSharedPtr;
+using ServerConnectionPtr = std::unique_ptr<ServerConnection>;
+using ServerConnectionSharedPtr = std::shared_ptr<ServerConnection>;
 
 class ServerFilterChain : public Envoy::Network::FilterChain {
 public:
   ServerFilterChain(Envoy::Network::TransportSocketFactory& transport_socket_factory);
 
-  virtual ~ServerFilterChain();
+  ~ServerFilterChain() override;
 
-  ServerFilterChain(ServerFilterChain&&) = default;
-  ServerFilterChain& operator=(ServerFilterChain&&) = default;
+  // ServerFilterChain(ServerFilterChain&&) = default;
+  // ServerFilterChain& operator=(ServerFilterChain&&) = default;
 
   //
   // Envoy::Network::FilterChain
   //
 
-  virtual const Envoy::Network::TransportSocketFactory& transportSocketFactory() const override;
+  const Envoy::Network::TransportSocketFactory& transportSocketFactory() const override;
 
-  virtual const std::vector<Envoy::Network::FilterFactoryCb>&
-  networkFilterFactories() const override;
+  const std::vector<Envoy::Network::FilterFactoryCb>& networkFilterFactories() const override;
 
 private:
-  ServerFilterChain(const ServerFilterChain&) = delete;
-  ServerFilterChain& operator=(const ServerFilterChain&) = delete;
+  // ServerFilterChain(const ServerFilterChain&) = delete;
+  // ServerFilterChain& operator=(const ServerFilterChain&) = delete;
 
   Envoy::Network::TransportSocketFactory& transport_socket_factory_;
   std::vector<Envoy::Network::FilterFactoryCb> network_filter_factories_;
@@ -220,15 +215,12 @@ public:
       Envoy::Network::Address::IpVersion ip_version = Envoy::Network::Address::IpVersion::v4,
       uint16_t port = 0, const Envoy::Network::Socket::OptionsSharedPtr& options = nullptr,
       bool bind_to_port = true);
+  // LocalListenSocket(LocalListenSocket&&) = default;
+  // LocalListenSocket& operator=(LocalListenSocket&&) = default;
 
-  virtual ~LocalListenSocket();
-
-  LocalListenSocket(LocalListenSocket&&) = default;
-  LocalListenSocket& operator=(LocalListenSocket&&) = default;
-
-private:
-  LocalListenSocket(const LocalListenSocket&) = delete;
-  void operator=(const LocalListenSocket&) = delete;
+  // private:
+  // LocalListenSocket(const LocalListenSocket&) = delete;
+  // void operator=(const LocalListenSocket&) = delete;
 };
 
 /**
@@ -243,9 +235,8 @@ public:
                        ServerCloseCallback close_callback = nullptr);
 
   virtual ~ServerCallbackHelper();
-
-  ServerCallbackHelper(ServerCallbackHelper&&) = default;
-  ServerCallbackHelper& operator=(ServerCallbackHelper&&) = default;
+  // ServerCallbackHelper(ServerCallbackHelper&&) = default;
+  // ServerCallbackHelper& operator=(ServerCallbackHelper&&) = default;
 
   uint32_t connectionsAccepted() const;
   uint32_t requestsReceived() const;
@@ -266,10 +257,10 @@ public:
    */
   void wait();
 
-private:
   ServerCallbackHelper(const ServerCallbackHelper&) = delete;
   void operator=(const ServerCallbackHelper&) = delete;
 
+private:
   ServerAcceptCallback accept_callback_;
   ServerRequestCallback request_callback_;
   ServerCloseCallback close_callback_;
@@ -282,8 +273,8 @@ private:
   std::condition_variable condvar_;
 };
 
-typedef std::unique_ptr<ServerCallbackHelper> ServerCallbackHelperPtr;
-typedef std::shared_ptr<ServerCallbackHelper> ServerCallbackHelperSharedPtr;
+using ServerCallbackHelperPtr = std::unique_ptr<ServerCallbackHelper>;
+using ServerCallbackHelperSharedPtr = std::shared_ptr<ServerCallbackHelper>;
 
 class Server : public Envoy::Network::FilterChainManager,
                public Envoy::Network::FilterChainFactory,
@@ -291,14 +282,13 @@ class Server : public Envoy::Network::FilterChainManager,
                Envoy::Logger::Loggable<Envoy::Logger::Id::testing> {
 public:
   // TODO make use of Network::Socket::OptionsSharedPtr
-  Server(const std::string& name, Envoy::Network::Socket& listening_socket,
+  Server(absl::string_view name, Envoy::Network::Socket& listening_socket,
          Envoy::Network::TransportSocketFactory& transport_socket_factory,
          Envoy::Http::CodecClient::Type http_type);
 
-  virtual ~Server();
-
-  Server(Server&&) = default;
-  Server& operator=(Server&&) = default;
+  ~Server() override;
+  // Server(Server&&) = default;
+  // Server& operator=(Server&&) = default;
 
   void start(ServerAcceptCallback accept_callback, ServerRequestCallback request_callback,
              ServerCloseCallback close_callback);
@@ -320,50 +310,49 @@ public:
   // Envoy::Network::ListenerConfig
   //
 
-  virtual Envoy::Network::FilterChainManager& filterChainManager() override;
+  Envoy::Network::FilterChainManager& filterChainManager() override;
 
-  virtual Envoy::Network::FilterChainFactory& filterChainFactory() override;
+  Envoy::Network::FilterChainFactory& filterChainFactory() override;
 
-  virtual Envoy::Network::Socket& socket() override;
+  Envoy::Network::Socket& socket() override;
 
-  virtual const Envoy::Network::Socket& socket() const override;
+  const Envoy::Network::Socket& socket() const override;
 
-  virtual bool bindToPort() override;
+  bool bindToPort() override;
 
-  virtual bool handOffRestoredDestinationConnections() const override;
+  bool handOffRestoredDestinationConnections() const override;
 
   // TODO does this affect socket recv buffer size?  Only for new connections?
-  virtual uint32_t perConnectionBufferLimitBytes() const override;
+  uint32_t perConnectionBufferLimitBytes() const override;
 
-  virtual std::chrono::milliseconds listenerFiltersTimeout() const override;
+  std::chrono::milliseconds listenerFiltersTimeout() const override;
 
-  virtual Envoy::Stats::Scope& listenerScope() override;
+  Envoy::Stats::Scope& listenerScope() override;
 
-  virtual uint64_t listenerTag() const override;
+  uint64_t listenerTag() const override;
 
-  virtual const std::string& name() const override;
+  const std::string& name() const override;
 
   //
   // Envoy::Network::FilterChainManager
   //
 
-  virtual const Envoy::Network::FilterChain*
+  const Envoy::Network::FilterChain*
   findFilterChain(const Envoy::Network::ConnectionSocket&) const override;
 
   //
   // Envoy::Network::FilterChainFactory
   //
 
-  virtual bool
-  createNetworkFilterChain(Envoy::Network::Connection& network_connection,
-                           const std::vector<Envoy::Network::FilterFactoryCb>&) override;
+  bool createNetworkFilterChain(Envoy::Network::Connection& network_connection,
+                                const std::vector<Envoy::Network::FilterFactoryCb>&) override;
 
-  virtual bool createListenerFilterChain(Envoy::Network::ListenerFilterManager&) override;
+  bool createListenerFilterChain(Envoy::Network::ListenerFilterManager&) override;
 
-private:
   Server(const Server&) = delete;
   void operator=(const Server&) = delete;
 
+private:
   std::string name_;
   Envoy::Stats::IsolatedStoreImpl stats_;
   Envoy::Event::TestRealTimeSystem time_system_;
@@ -399,8 +388,8 @@ private:
   std::atomic<uint32_t> connection_counter_{0U};
 };
 
-typedef std::unique_ptr<Server> ServerPtr;
-typedef std::shared_ptr<Server> ServerSharedPtr;
+using ServerPtr = std::unique_ptr<Server>;
+using ServerSharedPtr = std::shared_ptr<Server>;
 
 class ClusterHelper {
 public:
@@ -421,10 +410,10 @@ public:
 
   void wait();
 
-private:
   ClusterHelper(const ClusterHelper&) = delete;
   void operator=(const ClusterHelper&) = delete;
 
+private:
   std::vector<ServerCallbackHelperPtr> server_callback_helpers_;
 };
 


### PR DESCRIPTION
Putting this out here for discussion:
This PR absorbs int_server.cc/int_server.h from
https://github.com/duderino/proxy/blob/jblatt_mixer_fault_testing/test/integration/
(with a few tiny maintenance tweaks to get it to build with Envoy's latest version)

Then it goes on to update the end-to-end integration test for the NH client
to rely on this server for testing, swapping out Envoy's integration
server. This allows us to ditch the awkward fork() we have to do
to avoid runtime conflicts and deflake CI.

Also enhanced and added to the existing client tests while playing around with
the new server, to get a feel for ease of use (which seems to be pretty easy).