### PR TITLE
Static request parameterization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,31 +15,61 @@ HTTPS certificates are not yet validated.
 First, follow steps 1 and 2 over at [Quick start Bazel build for developers](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers).
 
 ## Building and testing Nighthawk
+
 ```bash
 # test it
 bazel test -c fastbuild //test:nighthawk_test
 ```
-# build it. for best accuracy it is important to specify -c opt.
+
+### Build it
+
+```bash
+# for best accuracy it is important to specify -c opt.
 bazel build -c opt //:nighthawk_client
-
-## Using the Nighthawk client
-
 ```
+
+### Using the Nighthawk client
+
+```bash
 ➜ bazel-bin/nighthawk_client --help
 
 USAGE: 
 
-   bazel-bin/nighthawk_client [--prefetch-connections] [--output-format <human|yaml
-                                        |json>] [-v <trace|debug|info|warn
-                                        |error|critical>] [--concurrency
-                                        <string>] [--h2] [--timeout
-                                        <uint64_t>] [--duration <uint64_t>]
-                                        [--connections <uint64_t>] [--rps
-                                        <uint64_t>] [--] [--version] [-h]
-                                        <uri format>
+   bazel-bin/nighthawk_client  [--request-body-size <uint32_t>]
+                               [--request-header <string>] ... 
+                               [--request-method <GET|HEAD|POST|PUT|DELETE
+                               |CONNECT|OPTIONS|TRACE>] [--address-family
+                               <auto|v4|v6>] [--burst-size <uint64_t>]
+                               [--prefetch-connections] [--output-format
+                               <human|yaml|json>] [-v <trace|debug|info
+                               |warn|error|critical>] [--concurrency
+                               <string>] [--h2] [--timeout <uint64_t>]
+                               [--duration <uint64_t>] [--connections
+                               <uint64_t>] [--rps <uint64_t>] [--]
+                               [--version] [-h] <uri format>
 
 
 Where: 
+
+   --request-body-size <uint32_t>
+     Size of the request body to send. NH will send a number of consecutive
+     'a' characters equal to the number specified here. (default: 0, no
+     data).
+
+   --request-header <string>  (accepted multiple times)
+     Raw request headers in the format of 'name: value' pairs. This
+     argument may specified multiple times.
+
+   --request-method <GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE>
+     Request method used when sending requests. The default is 'GET'.
+
+   --address-family <auto|v4|v6>
+     Network addres family preference. Possible values: [auto, v4, v6]. The
+     default output format is 'v4'.
+
+   --burst-size <uint64_t>
+     Release requests in bursts of the specified size (default: 0, no
+     bursting).
 
    --prefetch-connections
      Prefetch connections before benchmarking (HTTP/1 only).
@@ -93,6 +123,8 @@ Where:
 
 
    Nighthawk, a L7 HTTP protocol family benchmarking tool based on Envoy.
+
+
 ```
 
 ## Sample benchmark run
@@ -103,75 +135,66 @@ $ taskset -c 3 /path/to/envoy --config-path nighthawk/tools/envoy.yaml
 
 # run a quick benchmark using cpu cores 4 and 5.
 $ taskset -c 4-5 bazel-bin/nighthawk_client --rps 1000 --concurrency auto http://127.0.0.1:10000/
+
 Nighthawk - A layer 7 protocol benchmarking tool.
 
-benchmark_http_client.queue_to_connect: 9997 samples, mean: 0.000010513s, pstdev: 0.000007883s
+benchmark_http_client.queue_to_connect: 9993 samples, mean: 0.000010053s, pstdev: 0.000011278s
 Percentile  Count       Latency        
-0           1           0.000006549s   
-0.5         4999        0.000007325s   
-0.75        7498        0.000010387s   
-0.8         7998        0.000012010s   
-0.9         8998        0.000017883s   
-0.95        9498        0.000025680s   
-0.990625    9905        0.000047415s   
-0.999023    9988        0.000076479s   
-1           9997        0.000113999s   
+0           1           0.000006713s   
+0.5         4997        0.000007821s   
+0.75        7495        0.000008677s   
+0.8         7995        0.000009084s   
+0.9         8994        0.000011583s   
+0.95        9494        0.000015702s   
+0.990625    9900        0.000077299s   
+0.999023    9984        0.000145863s   
+1           9993        0.000232383s   
 
-benchmark_http_client.request_to_response: 9997 samples, mean: 0.000156183s, pstdev: 0.000147691s
+benchmark_http_client.request_to_response: 9993 samples, mean: 0.000115456s, pstdev: 0.000052326s
 Percentile  Count       Latency        
-0           1           0.000055659s   
-0.5         5003        0.000146655s   
-0.75        7500        0.000152631s   
-0.8         7998        0.000161455s   
-0.9         8998        0.000205247s   
-0.95        9498        0.000269951s   
-0.990625    9904        0.000495695s   
-0.999023    9988        0.000971967s   
-1           9997        0.008059903s   
+0           1           0.000080279s   
+0.5         4998        0.000104799s   
+0.75        7496        0.000113787s   
+0.8         7996        0.000121359s   
+0.9         8994        0.000153487s   
+0.95        9494        0.000180647s   
+0.990625    9900        0.000382591s   
+0.999023    9984        0.000608159s   
+1           9993        0.000985951s   
 
-sequencer.blocking: 42 samples, mean: 0.000755961s, pstdev: 0.001613017s
+sequencer.blocking: 14 samples, mean: 0.000531127s, pstdev: 0.000070919s
 Percentile  Count       Latency        
-0           1           0.000067199s   
-0.5         21          0.000117843s   
-0.75        32          0.000540191s   
-0.8         34          0.000544223s   
-0.9         38          0.000653183s   
-0.95        40          0.003944319s   
-1           42          0.006995967s   
-1           42          0.006995967s   
-1           42          0.006995967s   
+0           1           0.000484127s   
+0.5         7           0.000495615s   
+0.75        11          0.000521007s   
+0.8         12          0.000545887s   
+0.9         13          0.000655839s   
+1           14          0.000736223s   
 
-sequencer.callback: 9997 samples, mean: 0.000173003s, pstdev: 0.000153462s
+sequencer.callback: 9993 samples, mean: 0.000131079s, pstdev: 0.000060199s
 Percentile  Count       Latency        
-0           1           0.000066339s   
-0.5         4999        0.000157879s   
-0.75        7498        0.000164863s   
-0.8         7998        0.000179951s   
-0.9         8998        0.000234383s   
-0.95        9498        0.000314831s   
-0.990625    9904        0.000558047s   
-0.999023    9988        0.001160063s   
-1           9997        0.008074751s   
+0           1           0.000091547s   
+0.5         4998        0.000116935s   
+0.75        7495        0.000127351s   
+0.8         7995        0.000137807s   
+0.9         8994        0.000174335s   
+0.95        9495        0.000210063s   
+0.990625    9900        0.000444063s   
+0.999023    9984        0.000664383s   
+1           9993        0.001103615s   
 
 Counter                                 Value       Per second
-client.benchmark.http_2xx               9999        1999.80
-client.upstream_cx_http1_total          2           0.40
-client.upstream_cx_rx_bytes_total       36026397    7205279.40
-client.upstream_cx_total                2           0.40
-client.upstream_cx_tx_bytes_total       599940      119988.00
-client.upstream_rq_pending_total        2           0.40
-client.upstream_rq_total                9999        1999.80
+client.benchmark.http_2xx               9995        1999.00
+client.upstream_cx_close_notify         98          19.60
+client.upstream_cx_http1_total          100         20.00
+client.upstream_cx_rx_bytes_total       8585215     1717043.00
+client.upstream_cx_total                100         20.00
+client.upstream_cx_tx_bytes_total       569715      113943.00
+client.upstream_rq_pending_total        100         20.00
+client.upstream_rq_total                9995        1999.00
 ```
 
-Nighthawk will create a directory called `measurements/` and log results in json format there.
-The name of the file will be `<epoch.json>`, which contains:
-
-- The start time of the test, and a serialization of the Nighthawk options involved.
-- The mean latency and the observed standard deviation.
-- Latency percentiles produced by HdrHistogram.
-- Counters as tracked by Envoy's connection-pool and ssl libraries.
-
-## Accuracy and repeatability considerations when using the Nighthawk client.
+## Accuracy and repeatability considerations when using the Nighthawk client
 
 - Processes not related to the benchmarking task at hand may add significant noise. Consider stopping any
   processes that are not needed. 
@@ -187,9 +210,10 @@ The name of the file will be `<epoch.json>`, which contains:
 | As this may change boot flags, take precautions, and familiarize yourself with the tool on systems that you don't mind breaking. For example, running this has been observed to mess up dual-boot systems! |
 | --- |
 
-```
+```bash
 sudo tuned-adm profile network-latency
 ```
+
 - When using Nighthawk with concurrency > 1 or multiple connections, workers may produce significantly different results. That can happen because of various reasons:
   - Server fairness. For example, connections may end up being serviced by the same server thread, or not.
   - One of the clients may be unlucky and structurally spend time waiting on requests from the other(s)

--- a/api/client/BUILD
+++ b/api/client/BUILD
@@ -1,0 +1,13 @@
+load("@envoy//api/bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "benchmark_options",
+    srcs = [
+        "options.proto",
+        "output.proto",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@envoy_api//envoy/api/v2/core:base_export"],
+)

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -6,12 +6,11 @@ import "google/protobuf/duration.proto";
 import "validate/validate.proto";
 import "envoy/api/v2/core/base.proto";
 
-
 message RequestOptions {
-  string request_method = 1;
+  envoy.api.v2.core.RequestMethod request_method = 1;
   repeated envoy.api.v2.core.HeaderValueOption request_headers = 2;
-  oneof oneof_request_size { 
-    uint32 request_size = 3 [(validate.rules).uint32 = {gte: 0, lte: 4194304}];
+  oneof oneof_request_body_size { 
+    uint32 request_body_size = 3 [(validate.rules).uint32 = {gte: 0, lte: 4194304}];
   }
 }
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -9,10 +9,9 @@ import "envoy/api/v2/core/base.proto";
 message RequestOptions {
   envoy.api.v2.core.RequestMethod request_method = 1;
   repeated envoy.api.v2.core.HeaderValueOption request_headers = 2;
-  oneof oneof_request_body_size { 
-    uint32 request_body_size = 3 [(validate.rules).uint32 = {gte: 0, lte: 4194304}];
-  }
+  uint32 request_body_size = 3 [(validate.rules).uint32 = {gte: 0, lte: 4194304}];
 }
+
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
 message CommandLineOptions {

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -38,8 +38,10 @@ message CommandLineOptions {
   uint64 burst_size = 10;
   // See :option:`--address-family` for details.
   string address_family = 11;
-  // See :option:`--request_options` for details.
-  RequestOptions request_options = 12;
+  oneof oneof_request_options {
+    // See :option:`--request_options` for details.
+    RequestOptions request_options = 12;
+  }
   // See :option:`--uri` for details.
   string uri = 13;
 }

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -3,7 +3,17 @@ syntax = "proto3";
 package nighthawk.client;
 
 import "google/protobuf/duration.proto";
+import "validate/validate.proto";
+import "envoy/api/v2/core/base.proto";
 
+
+message RequestOptions {
+  string request_method = 1;
+  repeated envoy.api.v2.core.HeaderValueOption request_headers = 2;
+  oneof oneof_request_size { 
+    uint32 request_size = 3 [(validate.rules).uint32 = {gte: 0, lte: 4194304}];
+  }
+}
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
 message CommandLineOptions {
@@ -29,6 +39,8 @@ message CommandLineOptions {
   uint64 burst_size = 10;
   // See :option:`--address-family` for details.
   string address_family = 11;
+  // See :option:`--request_options` for details.
+  RequestOptions request_options = 12;
   // See :option:`--uri` for details.
-  string uri = 12;
+  string uri = 13;
 }

--- a/api/client/output.proto
+++ b/api/client/output.proto
@@ -5,7 +5,7 @@ package nighthawk.client;
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-import "source/client/options.proto";
+import "api/client/options.proto";
 
 message Counter {
   string name = 1;

--- a/api/server/response_options.proto
+++ b/api/server/response_options.proto
@@ -8,7 +8,7 @@ import "envoy/api/v2/core/base.proto";
 
 message ResponseOptions {
     repeated envoy.api.v2.core.HeaderValueOption response_headers = 1;
-    oneof oneof_response_size { 
+    oneof oneof_response_size {
       uint32 response_size = 2 [(validate.rules).uint32 = {gte: 0, lte: 4194304}];
     }
 }

--- a/include/nighthawk/client/benchmark_client.h
+++ b/include/nighthawk/client/benchmark_client.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 
+#include "envoy/http/header_map.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/store.h"
 
@@ -78,7 +79,18 @@ public:
    * @param value Value to set the request header to.
    */
   virtual void setRequestHeader(absl::string_view key, absl::string_view value) PURE;
+
+  /**
+   * @brief Set the Request Body Size
+   *
+   * @param request_body_size number of bytes to send
+   */
   virtual void setRequestBodySize(uint32_t request_body_size) PURE;
+
+  /**
+   * @return const HeaderMap& the request headers.
+   */
+  virtual const Envoy::Http::HeaderMap& requestHeaders() const PURE;
 };
 
 using BenchmarkClientPtr = std::unique_ptr<BenchmarkClient>;

--- a/include/nighthawk/client/benchmark_client.h
+++ b/include/nighthawk/client/benchmark_client.h
@@ -64,6 +64,21 @@ public:
    * @return bool indicating if latency measurement is enabled.
    */
   virtual bool measureLatencies() const PURE;
+
+  /**
+   * Sets the request method to use when sending request.
+   * @param request_method to set.
+   */
+  virtual void setRequestMethod(absl::string_view request_method) PURE;
+
+  /**
+   * Sets request header named 'key' to the specified value.
+   *
+   * @param key Name of the request header to set.
+   * @param value Value to set the request header to.
+   */
+  virtual void setRequestHeader(absl::string_view key, absl::string_view value) PURE;
+  virtual void setRequestBodySize(uint32_t request_body_size) PURE;
 };
 
 using BenchmarkClientPtr = std::unique_ptr<BenchmarkClient>;

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -34,7 +34,7 @@ public:
   virtual std::string addressFamily() const PURE;
   virtual std::string requestMethod() const PURE;
   virtual std::vector<std::string> requestHeaders() const PURE;
-  virtual uint32_t requestSize() const PURE;
+  virtual uint32_t requestBodySize() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -6,7 +6,7 @@
 
 #include "envoy/common/pure.h"
 
-#include "source/client/options.pb.h"
+#include "api/client/options.pb.h"
 
 namespace Nighthawk {
 namespace Client {
@@ -32,6 +32,9 @@ public:
   virtual bool prefetchConnections() const PURE;
   virtual uint64_t burstSize() const PURE;
   virtual std::string addressFamily() const PURE;
+  virtual std::string requestMethod() const PURE;
+  virtual std::vector<std::string> requestHeaders() const PURE;
+  virtual uint32_t requestSize() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/include/nighthawk/common/statistic.h
+++ b/include/nighthawk/common/statistic.h
@@ -10,7 +10,7 @@
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
 
-#include "source/client/output.pb.h"
+#include "api/client/output.pb.h"
 
 namespace Nighthawk {
 

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -1,19 +1,9 @@
-load("@envoy//api/bazel:api_build_system.bzl", "api_proto_library_internal")
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
 )
 
 licenses(["notice"])  # Apache 2
-
-api_proto_library_internal(
-    name = "benchmark_options",
-    srcs = [
-        "options.proto",
-        "output.proto",
-    ],
-    visibility = ["//visibility:public"],
-)
 
 envoy_cc_library(
     name = "nighthawk_client_lib",
@@ -38,7 +28,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
-        ":benchmark_options_cc",
+        "//api/client:benchmark_options_cc",
         "//include/nighthawk/client:client_includes",
         "//include/nighthawk/common:base_includes",
         "//source/common:nighthawk_common_lib",

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -196,9 +196,10 @@ bool BenchmarkClientHttpImpl::tryStartOne(std::function<void()> caller_completio
     return false;
   }
 
-  auto stream_decoder = new StreamDecoder(
-      dispatcher_, api_.timeSource(), *this, std::move(caller_completion_callback),
-      *connect_statistic_, *response_statistic_, request_headers_, measureLatencies());
+  auto stream_decoder = new StreamDecoder(dispatcher_, api_.timeSource(), *this,
+                                          std::move(caller_completion_callback),
+                                          *connect_statistic_, *response_statistic_,
+                                          request_headers_, measureLatencies(), request_body_size_);
   requests_initiated_++;
   pool_->pool().newStream(*stream_decoder, *stream_decoder);
   return true;

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -177,6 +177,13 @@ StatisticPtrMap BenchmarkClientHttpImpl::statistics() const {
   return statistics;
 };
 
+void BenchmarkClientHttpImpl::setRequestHeader(absl::string_view key, absl::string_view value) {
+  auto lower_case_key = Envoy::Http::LowerCaseString(std::string(key));
+  request_headers_.remove(lower_case_key);
+  // TODO(oschaaf): we've performed zero validation on the header key/value.
+  request_headers_.addCopy(lower_case_key, std::string(value));
+}
+
 bool BenchmarkClientHttpImpl::tryStartOne(std::function<void()> caller_completion_callback) {
   if (!cluster_->resourceManager(Envoy::Upstream::ResourcePriority::Default)
            .pendingRequests()

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -71,13 +71,13 @@ public:
   Envoy::Stats::Store& store() const override { return store_; }
 
   void setRequestMethod(absl::string_view request_method) override {
-    // TODO(oschaaf): normalize method? test invalid methods.
     request_headers_.insertMethod().value(request_method);
   };
   void setRequestHeader(absl::string_view key, absl::string_view value) override;
   void setRequestBodySize(uint32_t request_body_size) override {
     request_body_size_ = request_body_size;
   };
+  const Envoy::Http::HeaderMap& requestHeaders() const override { return request_headers_; }
 
   // StreamDecoderCompletionCallback
   void onComplete(bool success, const Envoy::Http::HeaderMap& headers) override;

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -69,19 +69,28 @@ public:
   }
   bool tryStartOne(std::function<void()> caller_completion_callback) override;
   Envoy::Stats::Store& store() const override { return store_; }
+
+  void setRequestMethod(absl::string_view request_method) override {
+    // TODO(oschaaf): normalize method? test invalid methods.
+    request_headers_.insertMethod().value(request_method);
+  };
+  void setRequestHeader(absl::string_view key, absl::string_view value) override;
+  void setRequestBodySize(uint32_t request_body_size) override {
+    request_body_size_ = request_body_size;
+  };
+
   // StreamDecoderCompletionCallback
   void onComplete(bool success, const Envoy::Http::HeaderMap& headers) override;
   void onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason reason) override;
 
 private:
   void prefetchPoolConnections() override;
-
   Envoy::Api::Api& api_;
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::Stats::Store& store_;
   Envoy::Stats::ScopePtr scope_;
   Envoy::Http::HeaderMapImpl request_headers_;
-  // These are declared order dependent. Changing orderering may trigger on assert upon
+  // These are declared order dependent. Changing ordering may trigger on assert upon
   // destruction when tls has been involved during usage.
   std::unique_ptr<Envoy::Server::Configuration::TransportSocketFactoryContext>
       transport_socket_factory_context_;
@@ -103,6 +112,7 @@ private:
   uint64_t requests_initiated_{};
   bool measure_latencies_{};
   BenchmarkClientStats benchmark_client_stats_;
+  uint32_t request_body_size_{0};
 };
 
 } // namespace Client

--- a/source/client/client.cc
+++ b/source/client/client.cc
@@ -159,7 +159,7 @@ public:
   const std::vector<ClientWorkerPtr>& createWorkers(const UriImpl& uri,
                                                     const uint32_t concurrency) {
     // TODO(oschaaf): Expose kMinimalDelay in configuration.
-    const std::chrono::seconds kMinimalWorkerDelay = 2s;
+    const std::chrono::milliseconds kMinimalWorkerDelay = 500ms;
     ASSERT(workers_.size() == 0);
 
     // We try to offset the start of each thread so that workers will execute tasks evenly spaced in

--- a/source/client/client.cc
+++ b/source/client/client.cc
@@ -20,6 +20,7 @@
 #include "common/runtime/runtime_impl.h"
 #include "common/thread_local/thread_local_impl.h"
 
+#include "api/client/output.pb.h"
 #include "client/client_worker_impl.h"
 #include "client/factories_impl.h"
 #include "client/options_impl.h"
@@ -27,7 +28,6 @@
 #include "common/uri_impl.h"
 #include "common/utility.h"
 #include "nighthawk/client/output_formatter.h"
-#include "source/client/output.pb.h"
 
 using namespace std::chrono_literals;
 

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -29,7 +29,6 @@ BenchmarkClientPtr BenchmarkClientFactoryImpl::create(Envoy::Api::Api& api,
 
   benchmark_client->setRequestMethod(options_.requestMethod());
 
-  // TODO(oschaaf): Summon default request headers here, and merge?
   auto request_options = options_.toCommandLineOptions()->request_options();
   if (request_options.request_headers_size() > 0) {
     for (const auto& header : request_options.request_headers()) {

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -26,6 +26,18 @@ BenchmarkClientPtr BenchmarkClientFactoryImpl::create(Envoy::Api::Api& api,
   auto benchmark_client = std::make_unique<BenchmarkClientHttpImpl>(
       api, dispatcher, store, statistic_factory.create(), statistic_factory.create(),
       std::move(uri), options_.h2(), options_.prefetchConnections());
+
+  benchmark_client->setRequestMethod(options_.requestMethod());
+
+  // TODO(oschaaf): Summon default request headers here, and merge?
+  auto request_options = options_.toCommandLineOptions()->request_options();
+  if (request_options.request_headers_size() > 0) {
+    for (const auto header : request_options.request_headers()) {
+      benchmark_client->setRequestHeader(header.header().key(), header.header().value());
+    }
+  }
+
+  benchmark_client->setRequestBodySize(options_.requestBodySize());
   benchmark_client->setConnectionTimeout(options_.timeout());
   benchmark_client->setConnectionLimit(options_.connections());
   return benchmark_client;

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -32,7 +32,7 @@ BenchmarkClientPtr BenchmarkClientFactoryImpl::create(Envoy::Api::Api& api,
   // TODO(oschaaf): Summon default request headers here, and merge?
   auto request_options = options_.toCommandLineOptions()->request_options();
   if (request_options.request_headers_size() > 0) {
-    for (const auto header : request_options.request_headers()) {
+    for (const auto& header : request_options.request_headers()) {
       benchmark_client->setRequestHeader(header.header().key(), header.header().value());
     }
   }

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -193,8 +193,11 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   command_line_options->set_burst_size(burstSize());
   command_line_options->set_address_family(addressFamily());
   auto request_options = command_line_options->mutable_request_options();
-  request_options->set_request_method(requestMethod());
-  for (const auto header : requestHeaders()) {
+  envoy::api::v2::core::RequestMethod method =
+      envoy::api::v2::core::RequestMethod::METHOD_UNSPECIFIED;
+  envoy::api::v2::core::RequestMethod_Parse(requestMethod(), &method);
+  request_options->set_request_method(method);
+  for (const auto& header : requestHeaders()) {
     auto header_value_option = request_options->add_request_headers();
     // TODO(oschaaf): expose append option in CLI? For now we just set.
     header_value_option->mutable_append()->set_value(false);
@@ -207,7 +210,7 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
       request_header->set_value(split_header[1]);
     }
   }
-  request_options->set_request_size(requestBodySize());
+  request_options->set_request_body_size(requestBodySize());
 
   return command_line_options;
 }

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -91,7 +91,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::MultiArg<std::string> request_headers("", "request-header",
                                                "Raw request headers in the format of 'name: value' "
                                                "pairs. This argument may specified multiple times.",
-                                               false, "string");
+                                               false, "string", cmd);
   TCLAP::ValueArg<uint32_t> request_body_size(
       "", "request-body-size",
       "Size of the request body to send. NH will send a number of consecutive 'a' characters equal "

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+#include "absl/strings/str_split.h"
+
 #include "tclap/CmdLine.h"
 
 #include "common/uri_impl.h"
@@ -78,6 +80,24 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "default output format is 'v4'.",
       false, "v4", &address_families_allowed, cmd);
 
+  std::vector<std::string> request_methods = {"GET",    "HEAD",    "POST",    "PUT",
+                                              "DELETE", "CONNECT", "OPTIONS", "TRACE"};
+  TCLAP::ValuesConstraint<std::string> request_methods_allowed(request_methods);
+  TCLAP::ValueArg<std::string> request_method("", "request-method",
+                                              "Request method used when sending requests. The "
+                                              "default is 'GET'.",
+                                              false, "GET", &request_methods_allowed, cmd);
+
+  TCLAP::MultiArg<std::string> request_headers("", "request-header",
+                                               "Raw request headers in the format of 'name: value' "
+                                               "pairs. This argument may specified multiple times.",
+                                               false, "string");
+  TCLAP::ValueArg<uint32_t> request_size(
+      "", "request-size",
+      "Size of the request body to send. NH will send a number of consecutive 'a' characters equal "
+      "to the number specified here. (default: 0, no data).",
+      false, 0, "uint32_t", cmd);
+
   TCLAP::UnlabeledValueArg<std::string> uri("uri",
                                             "uri to benchmark. http:// and https:// are supported, "
                                             "but in case of https no certificates are validated.",
@@ -112,6 +132,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   prefetch_connections_ = prefetch_connections.getValue();
   burst_size_ = burst_size.getValue();
   address_family_ = address_family.getValue();
+  request_method_ = request_method.getValue();
+  request_headers_ = request_headers.getValue();
+  request_size_ = request_size.getValue();
 
   // We cap on negative values. TCLAP accepts negative values which we will get here as very
   // large values. We just cap values to 2^63.
@@ -169,6 +192,21 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   command_line_options->set_prefetch_connections(prefetchConnections());
   command_line_options->set_burst_size(burstSize());
   command_line_options->set_address_family(addressFamily());
+  auto request_options = command_line_options->mutable_request_options();
+  request_options->set_request_method(requestMethod());
+  for (auto header : requestHeaders()) {
+    auto header_value_option = request_options->add_request_headers();
+    // TODO(oschaaf): expose append option in CLI? For now we just set.
+    header_value_option->mutable_append()->set_value(false);
+    auto request_header = header_value_option->mutable_header();
+    std::vector<std::string> split_header =
+        absl::StrSplit(header, ':'); // TODO(oschaaf): maybe throw when we find > 2 elements.
+    request_header->set_key(split_header[0]);
+    if (split_header.size() == 2) {
+      request_header->set_value(split_header[1]);
+    }
+  }
+  request_options->set_request_size(requestSize());
 
   return command_line_options;
 }

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -30,7 +30,7 @@ public:
   std::string addressFamily() const override { return address_family_; };
   std::string requestMethod() const override { return request_method_; };
   std::vector<std::string> requestHeaders() const override { return request_headers_; };
-  uint32_t requestSize() const override { return request_size_; };
+  uint32_t requestBodySize() const override { return request_body_size_; };
 
 private:
   uint64_t requests_per_second_;
@@ -47,7 +47,7 @@ private:
   std::string address_family_;
   std::string request_method_;
   std::vector<std::string> request_headers_;
-  uint32_t request_size_;
+  uint32_t request_body_size_;
 };
 
 } // namespace Client

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -7,8 +7,6 @@
 #include "nighthawk/client/options.h"
 #include "nighthawk/common/exception.h"
 
-#include "source/client/options.pb.h"
-
 namespace Nighthawk {
 namespace Client {
 
@@ -30,6 +28,9 @@ public:
   bool prefetchConnections() const override { return prefetch_connections_; }
   uint64_t burstSize() const override { return burst_size_; }
   std::string addressFamily() const override { return address_family_; };
+  std::string requestMethod() const override { return request_method_; };
+  std::vector<std::string> requestHeaders() const override { return request_headers_; };
+  uint32_t requestSize() const override { return request_size_; };
 
 private:
   uint64_t requests_per_second_;
@@ -44,6 +45,9 @@ private:
   bool prefetch_connections_;
   uint64_t burst_size_;
   std::string address_family_;
+  std::string request_method_;
+  std::vector<std::string> request_headers_;
+  uint32_t request_size_;
 };
 
 } // namespace Client

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -57,6 +57,8 @@ void StreamDecoder::onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason
 
 void StreamDecoder::onPoolReady(Envoy::Http::StreamEncoder& encoder,
                                 Envoy::Upstream::HostDescriptionConstSharedPtr) {
+  // TODO(oschaaf): Here's where we want to call encoder.encodeData() if the configuration suggests
+  // we should do so.
   encoder.encodeHeaders(request_headers_, true);
   request_start_ = time_source_.monotonicTime();
   if (measure_latencies_) {

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -57,9 +57,15 @@ void StreamDecoder::onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason
 
 void StreamDecoder::onPoolReady(Envoy::Http::StreamEncoder& encoder,
                                 Envoy::Upstream::HostDescriptionConstSharedPtr) {
-  // TODO(oschaaf): Here's where we want to call encoder.encodeData() if the configuration suggests
-  // we should do so.
-  encoder.encodeHeaders(request_headers_, true);
+  encoder.encodeHeaders(request_headers_, request_body_size_ == 0);
+  if (request_body_size_ > 0) {
+    // TODO(oschaaf): We can probably get away without allocating/copying here if we pregenerate
+    // potential request-body candidates up front. Revisit this when we have non-uniform request
+    // distributions and on-the-fly reconfiguration in place.
+    std::string body(request_body_size_, 'a');
+    Envoy::Buffer::OwnedImpl body_buffer(body);
+    encoder.encodeData(body_buffer, true);
+  }
   request_start_ = time_source_.monotonicTime();
   if (measure_latencies_) {
     connect_statistic_.addValue((request_start_ - connect_start_).count());

--- a/source/client/stream_decoder.h
+++ b/source/client/stream_decoder.h
@@ -33,13 +33,14 @@ public:
                 StreamDecoderCompletionCallback& decoder_completion_callback,
                 std::function<void()> caller_completion_callback, Statistic& connect_statistic,
                 Statistic& latency_statistic, const Envoy::Http::HeaderMap& request_headers,
-                bool measure_latencies)
+                bool measure_latencies, uint32_t request_body_size)
       : dispatcher_(dispatcher), time_source_(time_source),
         decoder_completion_callback_(decoder_completion_callback),
         caller_completion_callback_(std::move(caller_completion_callback)),
         connect_statistic_(connect_statistic), latency_statistic_(latency_statistic),
         request_headers_(request_headers), connect_start_(time_source_.monotonicTime()),
-        complete_(false), measure_latencies_(measure_latencies) {}
+        complete_(false), measure_latencies_(measure_latencies),
+        request_body_size_(request_body_size) {}
 
   // Http::StreamDecoder
   void decode100ContinueHeaders(Envoy::Http::HeaderMapPtr&&) override {
@@ -78,6 +79,7 @@ private:
   Envoy::MonotonicTime request_start_;
   bool complete_;
   bool measure_latencies_;
+  const uint32_t request_body_size_;
 };
 
 } // namespace Client

--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -29,9 +29,9 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        "//api/client:benchmark_options_cc",
         "//include/nighthawk/client:client_includes",
         "//include/nighthawk/common:base_includes",
-        "//source/client:benchmark_options_cc",
         "@dep_hdrhistogram_c//:hdrhistogram_c",
         "@envoy//source/common/common:compiler_requirements_lib",
         "@envoy//source/common/common:minimal_logger_lib",

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -392,6 +392,27 @@ TEST_P(BenchmarkClientHttpTest, ConnectionPrefetching) {
   EXPECT_EQ(50, getCounter("upstream_cx_total"));
 }
 
+TEST_P(BenchmarkClientHttpTest, RequestMethodPost) {
+  setupBenchmarkClient("/", false, true);
+  client_->setRequestMethod("GET");
+  client_->setRequestBodySize(1313);
+  client_->initialize(runtime_);
+
+  EXPECT_EQ(true, client_->tryStartOne([&]() { dispatcher_->exit(); }));
+  dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
+
+  EXPECT_EQ(1, getCounter("benchmark.http_4xx"));
+  EXPECT_LE(1390, getCounter("upstream_cx_tx_bytes_total"));
+  EXPECT_EQ(1, getCounter("upstream_cx_total"));
+  EXPECT_EQ(1, getCounter("upstream_rq_total"));
+  EXPECT_EQ(1, getCounter("upstream_cx_overflow"));
+  EXPECT_EQ(116, getCounter("upstream_cx_rx_bytes_total"));
+  EXPECT_EQ(1, getCounter("upstream_rq_pending_total"));
+  EXPECT_EQ(1, getCounter("upstream_cx_close_notify"));
+  EXPECT_EQ(1, getCounter("upstream_cx_http1_total"));
+  EXPECT_EQ(9, nonZeroValuedCounterCount());
+}
+
 // TODO(oschaaf): test protocol violations, stream resets, etc.
 
 } // namespace Nighthawk

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -394,15 +394,28 @@ TEST_P(BenchmarkClientHttpTest, ConnectionPrefetching) {
 
 TEST_P(BenchmarkClientHttpTest, RequestMethodPost) {
   setupBenchmarkClient("/", false, true);
-  client_->setRequestMethod("GET");
+  EXPECT_EQ("GET", client_->requestHeaders().Method()->value().getStringView());
+  client_->setRequestMethod("POST");
+  client_->setRequestHeader("a", "b");
+  client_->setRequestHeader("c", "d");
   client_->setRequestBodySize(1313);
+
+  EXPECT_EQ("POST", client_->requestHeaders().Method()->value().getStringView());
+  EXPECT_EQ(
+      "b",
+      client_->requestHeaders().get(Envoy::Http::LowerCaseString("a"))->value().getStringView());
+  EXPECT_EQ(
+      "d",
+      client_->requestHeaders().get(Envoy::Http::LowerCaseString("c"))->value().getStringView());
+
   client_->initialize(runtime_);
 
   EXPECT_EQ(true, client_->tryStartOne([&]() { dispatcher_->exit(); }));
   dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
 
   EXPECT_EQ(1, getCounter("benchmark.http_4xx"));
-  EXPECT_LE(1390, getCounter("upstream_cx_tx_bytes_total"));
+  EXPECT_EQ(GetParam() == Envoy::Network::Address::IpVersion::v4 ? 1407 : 1403,
+            getCounter("upstream_cx_tx_bytes_total"));
   EXPECT_EQ(1, getCounter("upstream_cx_total"));
   EXPECT_EQ(1, getCounter("upstream_rq_total"));
   EXPECT_EQ(1, getCounter("upstream_cx_overflow"));

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -32,11 +32,15 @@ public:
 
 TEST_F(FactoriesTest, CreateBenchmarkClient) {
   BenchmarkClientFactoryImpl factory(options_);
-
   EXPECT_CALL(options_, timeout()).Times(1);
   EXPECT_CALL(options_, connections()).Times(1);
   EXPECT_CALL(options_, h2()).Times(1);
   EXPECT_CALL(options_, prefetchConnections()).Times(1);
+  EXPECT_CALL(options_, requestMethod()).Times(1);
+  EXPECT_CALL(options_, requestBodySize()).Times(1);
+  EXPECT_CALL(options_, toCommandLineOptions())
+      .Times(1)
+      .WillOnce(Return(ByMove(std::make_unique<nighthawk::client::CommandLineOptions>())));
 
   auto benchmark_client =
       factory.create(*api_, dispatcher_, stats_store_, std::make_unique<UriImpl>("http://foo/"));

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -72,6 +72,10 @@ public:
   MOCK_CONST_METHOD0(prefetchConnections, bool());
   MOCK_CONST_METHOD0(burstSize, uint64_t());
   MOCK_CONST_METHOD0(addressFamily, std::string());
+  MOCK_CONST_METHOD0(requestMethod, std::string());
+  MOCK_CONST_METHOD0(requestHeaders, std::vector<std::string>());
+  MOCK_CONST_METHOD0(requestSize, uint32_t());
+
   MOCK_CONST_METHOD0(toCommandLineOptions, Client::CommandLineOptionsPtr());
 };
 

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -135,6 +135,7 @@ public:
   MOCK_METHOD1(setRequestMethod, void(absl::string_view));
   MOCK_METHOD2(setRequestHeader, void(absl::string_view, absl::string_view));
   MOCK_METHOD1(setRequestBodySize, void(uint32_t));
+  MOCK_CONST_METHOD0(requestHeaders, const Envoy::Http::HeaderMap&());
 
 protected:
   MOCK_CONST_METHOD0(measureLatencies, bool());

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -74,8 +74,7 @@ public:
   MOCK_CONST_METHOD0(addressFamily, std::string());
   MOCK_CONST_METHOD0(requestMethod, std::string());
   MOCK_CONST_METHOD0(requestHeaders, std::vector<std::string>());
-  MOCK_CONST_METHOD0(requestSize, uint32_t());
-
+  MOCK_CONST_METHOD0(requestBodySize, uint32_t());
   MOCK_CONST_METHOD0(toCommandLineOptions, Client::CommandLineOptionsPtr());
 };
 
@@ -132,6 +131,10 @@ public:
   MOCK_METHOD1(tryStartOne, bool(std::function<void()>));
   MOCK_CONST_METHOD0(store, Envoy::Stats::Store&());
   MOCK_METHOD0(prefetchPoolConnections, void());
+
+  MOCK_METHOD1(setRequestMethod, void(absl::string_view));
+  MOCK_METHOD2(setRequestHeader, void(absl::string_view, absl::string_view));
+  MOCK_METHOD1(setRequestBodySize, void(uint32_t));
 
 protected:
   MOCK_CONST_METHOD0(measureLatencies, bool());

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -8,8 +8,8 @@
 
 #include "common/filesystem/filesystem_impl.h"
 
+#include "api/client/options.pb.h"
 #include "common/statistic_impl.h"
-#include "source/client/options.pb.h"
 #include "test/mocks.h"
 #include "test/test_common/environment.h"
 

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -52,7 +52,7 @@ TEST_F(StreamDecoderTest, HeaderOnlyTest) {
   bool is_complete = false;
   auto decoder =
       new StreamDecoder(*dispatcher_, time_system_, *this, [&is_complete]() { is_complete = true; },
-                        connect_statistic_, latency_statistic_, request_headers_, false);
+                        connect_statistic_, latency_statistic_, request_headers_, false, 0);
   auto headers = std::make_unique<Envoy::Http::HeaderMapImpl>();
   decoder->decodeHeaders(std::move(headers), true);
   EXPECT_TRUE(is_complete);
@@ -63,7 +63,7 @@ TEST_F(StreamDecoderTest, HeaderWithBodyTest) {
   bool is_complete = false;
   auto decoder =
       new StreamDecoder(*dispatcher_, time_system_, *this, [&is_complete]() { is_complete = true; },
-                        connect_statistic_, latency_statistic_, request_headers_, false);
+                        connect_statistic_, latency_statistic_, request_headers_, false, 0);
   auto headers = std::make_unique<Envoy::Http::HeaderMapImpl>();
   decoder->decodeHeaders(std::move(headers), false);
   EXPECT_FALSE(is_complete);
@@ -79,7 +79,7 @@ TEST_F(StreamDecoderTest, TrailerTest) {
   bool is_complete = false;
   auto decoder =
       new StreamDecoder(*dispatcher_, time_system_, *this, [&is_complete]() { is_complete = true; },
-                        connect_statistic_, latency_statistic_, request_headers_, false);
+                        connect_statistic_, latency_statistic_, request_headers_, false, 0);
   auto headers = std::make_unique<Envoy::Http::HeaderMapImpl>();
   decoder->decodeHeaders(std::move(headers), false);
   auto trailers = std::make_unique<Envoy::Http::HeaderMapImpl>();
@@ -90,7 +90,7 @@ TEST_F(StreamDecoderTest, TrailerTest) {
 
 TEST_F(StreamDecoderTest, LatencyIsNotMeasured) {
   auto decoder = new StreamDecoder(*dispatcher_, time_system_, *this, []() {}, connect_statistic_,
-                                   latency_statistic_, request_headers_, false);
+                                   latency_statistic_, request_headers_, false, 0);
   Envoy::Http::MockStreamEncoder stream_encoder;
   Envoy::Upstream::HostDescriptionConstSharedPtr ptr;
   EXPECT_CALL(stream_encoder, encodeHeaders(HeaderMapEqualRef(&request_headers_), true));
@@ -103,7 +103,7 @@ TEST_F(StreamDecoderTest, LatencyIsNotMeasured) {
 
 TEST_F(StreamDecoderTest, LatencyIsMeasured) {
   auto decoder = new StreamDecoder(*dispatcher_, time_system_, *this, []() {}, connect_statistic_,
-                                   latency_statistic_, request_headers_, true);
+                                   latency_statistic_, request_headers_, true, 0);
   Envoy::Http::MockStreamEncoder stream_encoder;
   Envoy::Upstream::HostDescriptionConstSharedPtr ptr;
   EXPECT_CALL(stream_encoder, encodeHeaders(HeaderMapEqualRef(&request_headers_), true));
@@ -119,7 +119,7 @@ TEST_F(StreamDecoderTest, StreamResetTest) {
   bool is_complete = false;
   auto decoder =
       new StreamDecoder(*dispatcher_, time_system_, *this, [&is_complete]() { is_complete = true; },
-                        connect_statistic_, latency_statistic_, request_headers_, false);
+                        connect_statistic_, latency_statistic_, request_headers_, false, 0);
   auto headers = std::make_unique<Envoy::Http::HeaderMapImpl>();
   decoder->decodeHeaders(std::move(headers), false);
   auto trailers = std::make_unique<Envoy::Http::HeaderMapImpl>();
@@ -132,7 +132,7 @@ TEST_F(StreamDecoderTest, PoolFailureTest) {
   bool is_complete = false;
   auto decoder =
       new StreamDecoder(*dispatcher_, time_system_, *this, [&is_complete]() { is_complete = true; },
-                        connect_statistic_, latency_statistic_, request_headers_, false);
+                        connect_statistic_, latency_statistic_, request_headers_, false, 0);
   Envoy::Upstream::HostDescriptionConstSharedPtr ptr;
   decoder->onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason::Overflow, "fooreason",
                          ptr);


### PR DESCRIPTION
Adds static request parameterization options to NH:
- Request method (`--request-method FOO`)
- Request headers (`--request-header foo:bar`)
- Request entity body size is adjustable (`--request-body-size 123`)

This fixes https://github.com/envoyproxy/nighthawk/issues/20

Moves some proto's into to where they belong: `/api/client` (tech-debt).
Fixes https://github.com/envoyproxy/nighthawk/issues/56

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>