### PR TITLE
Update CI image & Envoy, move to clang-tidy-8

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,1 @@
 import %workspace%/envoy/.bazelrc
-build:asan --action_env="CC=clang"
-build:asan --action_env="CXX=clang++"
-
-build:tsan --action_env="CC=clang"
-build:tsan --action_env="CXX=clang++"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
   envoy-build-image: &envoy-build-image
-    envoyproxy/envoy-build:b3995b7c5e3846f80f6f09436043ec4c8c8f762a
+    envoyproxy/envoy-build:cfc514546bc0284536893cca5fa43d7128edcd35
 
 version: 2
 jobs:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies'
 
 WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements'
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,8 +61,6 @@ cc_library(
     url = "https://github.com/HdrHistogram/HdrHistogram_c/archive/0.9.8.tar.gz",
 )
 
-cc_configure()
-
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -10,15 +10,4 @@ echo "build ${BAZEL_BUILD_OPTIONS}" >> .bazelrc
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
 tools/gen_compilation_database.py --run_bazel_build --include_headers
-
-if [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
-    echo "Running full clang-tidy..."
-    run-clang-tidy-7 -extra-arg-before=-xc++
-    elif [[ -z "${CIRCLE_PR_NUMBER}" && "$CIRCLE_BRANCH" == "master" ]]; then
-    echo "On master branch, running clang-tidy-diff against previous commit..."
-    git diff HEAD^ | clang-tidy-diff-7.py -p 1
-else
-    echo "Running clang-tidy-diff against master branch..."
-    git fetch https://github.com/envoyproxy/envoy-perf.git master
-    git diff $(git merge-base HEAD FETCH_HEAD)..HEAD | clang-tidy-diff-7.py -p 1
-fi
+run-clang-tidy-8 -extra-arg-before=-xc++ -quiet

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -46,7 +46,7 @@ SequencerPtr SequencerFactoryImpl::create(Envoy::TimeSource& time_source,
     rate_limiter = std::make_unique<BurstingRateLimiter>(std::move(rate_limiter), burst_size);
   }
   SequencerTarget sequencer_target = [&benchmark_client](std::function<void()> f) -> bool {
-    return benchmark_client.tryStartOne(f);
+    return benchmark_client.tryStartOne(std::move(f));
   };
   return std::make_unique<SequencerImpl>(platform_util_, dispatcher, time_source, start_time,
                                          std::move(rate_limiter), sequencer_target,

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -40,7 +40,7 @@ SimpleStatistic::SimpleStatistic() : count_(0), sum_x_(0), sum_x2_(0) {}
 void SimpleStatistic::addValue(uint64_t value) {
   count_++;
   sum_x_ += value;
-  sum_x2_ += value * value; // NOLINT
+  sum_x2_ += 1.0 * value * value;
 }
 
 uint64_t SimpleStatistic::count() const { return count_; }
@@ -72,7 +72,7 @@ void StreamingStatistic::addValue(uint64_t value) {
   delta = value - mean_;
   delta_n = delta / count_;
   mean_ += delta_n;
-  accumulated_variance_ += delta * delta_n * (count_ - 1); // NOLINT
+  accumulated_variance_ += delta * delta_n * (count_ - 1.0);
 }
 
 uint64_t StreamingStatistic::count() const { return count_; }

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -40,7 +40,7 @@ SimpleStatistic::SimpleStatistic() : count_(0), sum_x_(0), sum_x2_(0) {}
 void SimpleStatistic::addValue(uint64_t value) {
   count_++;
   sum_x_ += value;
-  sum_x2_ += value * value;
+  sum_x2_ += value * value; // NOLINT
 }
 
 uint64_t SimpleStatistic::count() const { return count_; }
@@ -72,7 +72,7 @@ void StreamingStatistic::addValue(uint64_t value) {
   delta = value - mean_;
   delta_n = delta / count_;
   mean_ += delta_n;
-  accumulated_variance_ += delta * delta_n * (count_ - 1);
+  accumulated_variance_ += delta * delta_n * (count_ - 1); // NOLINT
 }
 
 uint64_t StreamingStatistic::count() const { return count_; }

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -381,6 +381,8 @@ TEST_P(BenchmarkClientHttpTest, StatusTrackingInOnComplete) {
   EXPECT_EQ(1, getCounter("benchmark.http_5xx"));
   EXPECT_EQ(2, getCounter("benchmark.http_xxx"));
   EXPECT_EQ(1, getCounter("benchmark.stream_resets"));
+
+  client_.reset();
 }
 
 TEST_P(BenchmarkClientHttpTest, ConnectionPrefetching) {

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -31,7 +31,9 @@ namespace Client {
 class ClientTest : public Envoy::BaseIntegrationTest,
                    public TestWithParam<Envoy::Network::Address::IpVersion> {
 public:
-  ClientTest() : Envoy::BaseIntegrationTest(GetParam(), realTime(), readEnvoyConfiguration()) {}
+  ClientTest()
+      : Envoy::BaseIntegrationTest(GetParam(), realTime(), readEnvoyConfiguration()),
+        fd_port_(2, 0), fd_confirm_(2, 0) {}
 
   std::string readEnvoyConfiguration() {
     Envoy::Filesystem::InstanceImplPosix file_system;
@@ -103,8 +105,8 @@ public:
 
   int port_;
   pid_t pid_;
-  std::vector<int> fd_port_ = {0, 0};
-  std::vector<int> fd_confirm_ = {0, 0};
+  std::vector<int> fd_port_;
+  std::vector<int> fd_confirm_;
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ClientTest,

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -45,8 +45,8 @@ public:
     // runtimeloaders as both NH and the integration server want to own that and we can have only
     // one. The plan is to move to python for this type of testing, so hopefully we can deprecate
     // this test and it's peculiar setup with fork/pipe soon.
-    RELEASE_ASSERT(pipe(fd_port_) == 0, "Failed to open pipe");
-    RELEASE_ASSERT(pipe(fd_confirm_) == 0, "Failed to open pipe");
+    RELEASE_ASSERT(pipe(&fd_port_[0]) == 0, "Failed to open pipe");
+    RELEASE_ASSERT(pipe(&fd_confirm_[0]) == 0, "Failed to open pipe");
     pid_ = fork();
     RELEASE_ASSERT(pid_ >= 0, "Fork failed");
 
@@ -103,8 +103,8 @@ public:
 
   int port_;
   pid_t pid_;
-  int fd_port_[2];    // NOLINT
-  int fd_confirm_[2]; // NOLINT
+  std::vector<int> fd_port_ = {0, 0};
+  std::vector<int> fd_confirm_ = {0, 0};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ClientTest,

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -45,8 +45,8 @@ public:
     // runtimeloaders as both NH and the integration server want to own that and we can have only
     // one. The plan is to move to python for this type of testing, so hopefully we can deprecate
     // this test and it's peculiar setup with fork/pipe soon.
-    RELEASE_ASSERT(pipe(&fd_port_[0]) == 0, "Failed to open pipe");
-    RELEASE_ASSERT(pipe(&fd_confirm_[0]) == 0, "Failed to open pipe");
+    RELEASE_ASSERT(pipe(fd_port_.data()) == 0, "Failed to open pipe");
+    RELEASE_ASSERT(pipe(fd_confirm_.data()) == 0, "Failed to open pipe");
     pid_ = fork();
     RELEASE_ASSERT(pid_ >= 0, "Fork failed");
 

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -103,8 +103,8 @@ public:
 
   int port_;
   pid_t pid_;
-  int fd_port_[2];
-  int fd_confirm_[2];
+  int fd_port_[2];    // NOLINT
+  int fd_confirm_[2]; // NOLINT
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ClientTest,

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -79,11 +79,11 @@ public:
     timer2_ = new NiceMock<Envoy::Event::MockTimer>();
     EXPECT_CALL(*dispatcher_, createTimer_(_))
         .WillOnce(Invoke([&](Envoy::Event::TimerCb cb) {
-          timer_cb_1_ = cb;
+          timer_cb_1_ = std::move(cb);
           return timer1_;
         }))
         .WillOnce(Invoke([&](Envoy::Event::TimerCb cb) {
-          timer_cb_2_ = cb;
+          timer_cb_2_ = std::move(cb);
           return timer2_;
         }));
     EXPECT_CALL(*timer1_, disableTimer()).WillOnce(Invoke([&]() { timer1_set_ = false; }));

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -210,6 +210,7 @@ TEST(StatisticTest, SimpleStatisticProtoOutputLargeValues) {
   const nighthawk::client::Statistic proto = a.toProto();
 
   EXPECT_EQ(proto.count(), 2);
+  // NOLINTNEXTLINE
   Helper::expectNear(((1ul * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
                      value, a.significantDigits() - 1);
   // 0 because std::nan() gets translated to that.
@@ -227,6 +228,7 @@ TEST(StatisticTest, HdrStatisticProtoOutputLargeValues) {
   // TODO(oschaaf): hdr doesn't seem to the promised precision in this scenario.
   // We substract one from the indicated significant digits to make this test pass.
   // TODO(oschaaf): revisit this to make sure there's not a different underlying problem.
+  // NOLINTNEXTLINE
   Helper::expectNear(((1ul * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
                      value, a.significantDigits() - 1);
   EXPECT_EQ(proto.pstdev().nanos(), 0);
@@ -240,6 +242,8 @@ TEST(StatisticTest, StreamingStatProtoOutputLargeValues) {
   const nighthawk::client::Statistic proto = a.toProto();
 
   EXPECT_EQ(proto.count(), 2);
+
+  // NOLINTNEXTLINE
   Helper::expectNear(((1ul * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
                      value, a.significantDigits());
 

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -210,8 +210,7 @@ TEST(StatisticTest, SimpleStatisticProtoOutputLargeValues) {
   const nighthawk::client::Statistic proto = a.toProto();
 
   EXPECT_EQ(proto.count(), 2);
-  // NOLINTNEXTLINE
-  Helper::expectNear(((1ul * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
+  Helper::expectNear(((1.0 * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
                      value, a.significantDigits() - 1);
   // 0 because std::nan() gets translated to that.
   EXPECT_EQ(proto.pstdev().nanos(), 0);
@@ -228,8 +227,7 @@ TEST(StatisticTest, HdrStatisticProtoOutputLargeValues) {
   // TODO(oschaaf): hdr doesn't seem to the promised precision in this scenario.
   // We substract one from the indicated significant digits to make this test pass.
   // TODO(oschaaf): revisit this to make sure there's not a different underlying problem.
-  // NOLINTNEXTLINE
-  Helper::expectNear(((1ul * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
+  Helper::expectNear(((1.0 * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
                      value, a.significantDigits() - 1);
   EXPECT_EQ(proto.pstdev().nanos(), 0);
 }
@@ -243,8 +241,7 @@ TEST(StatisticTest, StreamingStatProtoOutputLargeValues) {
 
   EXPECT_EQ(proto.count(), 2);
 
-  // NOLINTNEXTLINE
-  Helper::expectNear(((1ul * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
+  Helper::expectNear(((1.0 * proto.mean().seconds() * 1000 * 1000 * 1000) + proto.mean().nanos()),
                      value, a.significantDigits());
 
   EXPECT_EQ(proto.pstdev().nanos(), 0);


### PR DESCRIPTION
    - Update Envoy submodule to the latest
    - Use clang-8 for everything, including clang-tidy-8
    - Upgrade the CI image
    - Tidies up a few things, and drops the linker override hack (obsolete).

This ought to fail some CI tests, the next commit will fix that.
Fixes https://github.com/envoyproxy/nighthawk/issues/62

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>