### PR TITLE
build: switch Envoy to an http_archive.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,68 @@
-import %workspace%/envoy/.bazelrc
+# The following .bazelrc content is forked from the main Envoy repository. This is necessary since
+# this needs to be available before we can access the Envoy repository contents via Bazel.
+
+# Envoy specific Bazel build/test options.
+
+# Bazel doesn't need more than 200MB of memory based on memory profiling:
+# https://docs.bazel.build/versions/master/skylark/performance.html#memory-profiling
+# Limiting JVM heapsize here to let it do GC more when approaching the limit to
+# leave room for compiler/linker.
+startup --host_jvm_args=-Xmx512m
+build --workspace_status_command=bazel/get_workspace_status
+build --experimental_remap_main_repo
+
+# Basic ASAN/UBSAN that works for gcc
+build:asan --define ENVOY_CONFIG_ASAN=1
+build:asan --copt -fsanitize=address,undefined
+build:asan --linkopt -fsanitize=address,undefined
+build:asan --copt -fno-sanitize=vptr
+build:asan --linkopt -fno-sanitize=vptr
+build:asan --linkopt -fuse-ld=lld
+build:asan --linkopt -ldl
+build:asan --define tcmalloc=disabled
+build:asan --build_tag_filters=-no_asan
+build:asan --test_tag_filters=-no_asan
+build:asan --define signal_trace=disabled
+build:asan --copt -DADDRESS_SANITIZER=1
+build:asan --copt -D__SANITIZE_ADDRESS__
+build:asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true:check_initialization_order=true:strict_init_order=true:detect_odr_violation=1
+build:asan --test_env=UBSAN_OPTIONS=halt_on_error=true:print_stacktrace=1
+build:asan --test_env=ASAN_SYMBOLIZER_PATH
+
+# Clang ASAN/UBSAN
+build:clang-asan --config=asan
+
+# macOS ASAN/UBSAN
+build:macos-asan --config=asan
+# Workaround, see https://github.com/bazelbuild/bazel/issues/6932
+build:macos-asan --copt -Wno-macro-redefined
+build:macos-asan --copt -D_FORTIFY_SOURCE=0
+
+# Clang TSAN
+build:clang-tsan --define ENVOY_CONFIG_TSAN=1
+build:clang-tsan --copt -fsanitize=thread
+build:clang-tsan --linkopt -fsanitize=thread
+build:clang-tsan --linkopt -fuse-ld=lld
+build:clang-tsan --define tcmalloc=disabled
+# Needed due to https://github.com/libevent/libevent/issues/777
+build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
+
+# Clang MSAN - broken today since we need to rebuild lib[std]c++ and external deps with MSAN
+# support (see https://github.com/envoyproxy/envoy/issues/443).
+build:clang-msan --define ENVOY_CONFIG_MSAN=1
+build:clang-msan --copt -fsanitize=memory
+build:clang-msan --linkopt -fsanitize=memory
+build:clang-msan --define tcmalloc=disabled
+build:clang-msan --copt -fsanitize-memory-track-origins=2
+
+# Clang with libc++
+# TODO(cmluciano) fix and re-enable _LIBCPP_VERSION testing for TCMALLOC in Envoy::Stats::TestUtil::hasDeterministicMallocStats
+# and update stats_integration_test with appropriate m_per_cluster value
+build:libc++ --action_env=CC
+build:libc++ --action_env=CXX
+build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
+build:libc++ --action_env=PATH
+build:libc++ --define force_libcpp=enabled
+
+# Test options
+test --test_env=HEAPCHECK=normal --test_env=PPROF_PATH

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "envoy"]
-	path = envoy
-	url = https://github.com/envoyproxy/envoy.git

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,14 @@ workspace(name = "nighthawk")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+ENVOY_COMMIT="b8325ac4167284b4d566c2779c15ec3c8473dc66"
+ENVOY_SHA="9c19940b25d87ab122bf904b5b8534f42f5aea730d0b09e810605e0c388ddbc0"
+
 http_archive(
     name = "envoy",
-    sha256 = "9c19940b25d87ab122bf904b5b8534f42f5aea730d0b09e810605e0c388ddbc0",
-    strip_prefix = "envoy-b8325ac4167284b4d566c2779c15ec3c8473dc66",
-    url = "https://github.com/envoyproxy/envoy/archive/b8325ac4167284b4d566c2779c15ec3c8473dc66.tar.gz"
+    sha256 = ENVOY_SHA,
+    strip_prefix = "envoy-%s" % ENVOY_COMMIT,
+    url = "https://github.com/envoyproxy/envoy/archive/%s.tar.gz" % ENVOY_COMMIT,
 )
 
 load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,17 +1,19 @@
 workspace(name = "nighthawk")
 
-local_repository(
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
     name = "envoy",
-    path = "envoy",
+    sha256 = "9c19940b25d87ab122bf904b5b8534f42f5aea730d0b09e810605e0c388ddbc0",
+    strip_prefix = "envoy-b8325ac4167284b4d566c2779c15ec3c8473dc66",
+    url = "https://github.com/envoyproxy/envoy/archive/b8325ac4167284b4d566c2779c15ec3c8473dc66.tar.gz"
 )
 
 load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")
-
 envoy_api_dependencies()
 
 load("@envoy//bazel:repositories.bzl", "envoy_dependencies")
 load("@envoy//bazel:cc_configure.bzl", "cc_configure")
-
 envoy_dependencies()
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
@@ -19,8 +21,6 @@ load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependen
 rules_foreign_cc_dependencies()
 
 cc_configure()
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "dep_hdrhistogram_c",
@@ -54,7 +54,7 @@ cc_library(
         "-Wno-error",
     ],
     visibility = ["//visibility:public"],
-)        
+)
 """,
     sha256 = "6928ba22634d9a5b2752227309c9097708e790db6a285fa5c3f40a219bf7ee98",
     strip_prefix = "HdrHistogram_c-0.9.8",


### PR DESCRIPTION
This makes the build/VCS situation more consistent. It was necessary
to fork .bazelrc.

It is still possible to use a local Envoy directory via the CLI
--override_repository envoy=<path to your Envoy tree> Bazel build/test
flag, e.g.

bazel test -c fastbuild --override_repository \
  envoy=/some/local/path/envoy //test:nighthawk_test

Signed-off-by: Harvey Tuch <htuch@google.com>