### PR TITLE
A couple of fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ generated/
 .rnd
 .vscode/
 bazel.output.txt
+envoy/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First, follow steps 1 and 2 over at [Quick start Bazel build for developers](htt
 
 ```bash
 # test it
-bazel test -c fastbuild //test:nighthawk_test
+bazel test -c dbg //test:nighthawk_test
 ```
 
 ### Build it

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -70,7 +70,7 @@ function do_tsan() {
     run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan //test:nighthawk_test //test/server:http_test_server_filter_integration_test
 }
 
-[ -z "${NUM_CPUS}" ] && NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
+[ -z "${NUM_CPUS}" ] && export NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
 
 if [ -n "$CIRCLECI" ]; then
     if [[ -f "${HOME:-/root}/.gitconfig" ]]; then

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -10,4 +10,5 @@ echo "build ${BAZEL_BUILD_OPTIONS}" >> .bazelrc
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
 tools/gen_compilation_database.py --run_bazel_build --include_headers
-run-clang-tidy-8 -extra-arg-before=-xc++ -quiet
+set -x
+run-clang-tidy-8 -extra-arg-before=-xc++ -quiet -j "${NUM_CPUS}"

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -10,5 +10,4 @@ echo "build ${BAZEL_BUILD_OPTIONS}" >> .bazelrc
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
 tools/gen_compilation_database.py --run_bazel_build --include_headers
-set -x
 run-clang-tidy-8 -extra-arg-before=-xc++ -quiet -j "${NUM_CPUS}"

--- a/source/client/client.cc
+++ b/source/client/client.cc
@@ -234,7 +234,7 @@ public:
 private:
   Envoy::Thread::ThreadFactoryImplPosix thread_factory_;
   Envoy::Filesystem::InstanceImplPosix file_system_;
-  Envoy::Event::RealTimeSystem time_system_;
+  Envoy::Event::RealTimeSystem time_system_; // NO_CHECK_FORMAT(real_time)
   StoreFactoryImpl store_factory_;
   Envoy::Stats::StorePtr store_;
   Envoy::Api::Impl api_;

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -61,7 +61,7 @@ public:
   MockSequencerFactory sequencer_factory_;
   Envoy::Stats::IsolatedStoreImpl store_;
   NiceMock<Envoy::ThreadLocal::MockInstance> tls_;
-  Envoy::Event::RealTimeSystem time_system_;
+  Envoy::Event::TestRealTimeSystem time_system_;
   MockBenchmarkClient* benchmark_client_;
   MockSequencer* sequencer_;
   Envoy::Runtime::RandomGeneratorImpl rand_;

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -75,7 +75,7 @@ TEST_F(FactoriesTest, CreateStatistic) {
 class OutputFormatterFactoryTest : public FactoriesTest, public WithParamInterface<const char*> {
 public:
   void testOutputFormatter(absl::string_view type) {
-    Envoy::RealTimeSource time_source;
+    Envoy::Event::SimulatedTimeSystem time_source;
     EXPECT_CALL(options_, toCommandLineOptions());
     EXPECT_CALL(options_, outputFormat()).WillOnce(Return(std::string(type)));
     OutputFormatterFactoryImpl factory(time_source, options_);

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -36,7 +36,7 @@ public:
   void onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason) override { pool_failures_++; }
 
   Envoy::Thread::ThreadFactoryImplPosix thread_factory_;
-  Envoy::Event::RealTimeSystem time_system_;
+  Envoy::Event::TestRealTimeSystem time_system_;
   Envoy::Stats::IsolatedStoreImpl store_;
   Envoy::Api::Impl api_;
   Envoy::Event::DispatcherPtr dispatcher_;

--- a/test/worker_test.cc
+++ b/test/worker_test.cc
@@ -40,7 +40,7 @@ public:
   Envoy::Api::Impl api_;
   Envoy::ThreadLocal::MockInstance tls_;
   Envoy::Stats::IsolatedStoreImpl store_;
-  Envoy::Event::RealTimeSystem time_system_;
+  Envoy::Event::TestRealTimeSystem time_system_;
   Envoy::Runtime::RandomGeneratorImpl rand_;
 };
 


### PR DESCRIPTION
- Don't reference real-world time sources from production code
- Undo accidental add of Envoy submodule in d67558a
- Add `envoy/` to `.gitignore` to prevent that from happening again.
- Doc: Use `-c dbg` when testing
- CI: Reduce parallelism for `clang-tidy`