### PR TITLE
TSAN: exclude test which relies on fork()

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,8 +44,6 @@ build:clang-tsan --copt -fsanitize=thread
 build:clang-tsan --linkopt -fsanitize=thread
 build:clang-tsan --linkopt -fuse-ld=lld
 build:clang-tsan --define tcmalloc=disabled
-# The line below is Nighthawk-specific, and can be backed out when we no longer in the client integration test. 
-build:clang-tsan --test_env=TSAN_OPTIONS=die_after_fork=0
 # Needed due to https://github.com/libevent/libevent/issues/777
 build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
 

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -6,7 +6,10 @@
 // soon in favor of either https://github.com/envoyproxy/nighthawk/pull/60 or moving this end-to-end
 // testing to python.
 // Thus we just disable this test when we detect we are running under TSAN.
-#ifndef ENVOY_CONFIG_TSAN
+#ifndef __has_feature
+#define __has_feature(x) 0 // Compatibility with non-clang compilers.
+#endif
+#if defined(__has_feature) && !__has_feature(thread_sanitizer)
 
 #include <chrono>
 

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -1,3 +1,13 @@
+// This test relies on fork(). Somehow the integration test server excepts when running
+// under TSAN because of Envoy not being able to find its configuration file with die_after_fork
+// disabled. The code below seems to suggest that TSAN doesn't support this scenario.
+// https://github.com/llvm-mirror/compiler-rt/blob/master/lib/tsan/rtl/tsan_interceptors.cc#L999
+// Further root cause analysis is not worth it at this point, because this code will be deprecated
+// soon in favor of either https://github.com/envoyproxy/nighthawk/pull/60 or moving this end-to-end
+// testing to python.
+// Thus we just disable this test when we detect we are running under TSAN.
+#if defined(__has_feature) && !__has_feature(thread_sanitizer)
+
 #include <chrono>
 
 #include "gtest/gtest.h"
@@ -149,3 +159,5 @@ TEST_P(ClientTest, BadRun) {
 
 } // namespace Client
 } // namespace Nighthawk
+
+#endif // defined(__has_feature) && !__has_feature(thread_sanitizer)

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -6,6 +6,9 @@
 // soon in favor of either https://github.com/envoyproxy/nighthawk/pull/60 or moving this end-to-end
 // testing to python.
 // Thus we just disable this test when we detect we are running under TSAN.
+#ifndef __has_feature
+#define __has_feature(x) 0 // Compatibility with non-clang compilers.
+#endif
 #if defined(__has_feature) && !__has_feature(thread_sanitizer)
 
 #include <chrono>

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -6,10 +6,7 @@
 // soon in favor of either https://github.com/envoyproxy/nighthawk/pull/60 or moving this end-to-end
 // testing to python.
 // Thus we just disable this test when we detect we are running under TSAN.
-#ifndef __has_feature
-#define __has_feature(x) 0 // Compatibility with non-clang compilers.
-#endif
-#if defined(__has_feature) && !__has_feature(thread_sanitizer)
+#ifndef ENVOY_CONFIG_TSAN
 
 #include <chrono>
 

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -6,10 +6,7 @@
 // soon in favor of either https://github.com/envoyproxy/nighthawk/pull/60 or moving this end-to-end
 // testing to python.
 // Thus we just disable this test when we detect we are running under TSAN.
-#ifndef __has_feature
-#define __has_feature(x) 0 // Compatibility with non-clang compilers.
-#endif
-#if defined(__has_feature) && !__has_feature(thread_sanitizer)
+#ifndef ENVOY_CONFIG_TSAN
 
 #include <chrono>
 
@@ -163,4 +160,4 @@ TEST_P(ClientTest, BadRun) {
 } // namespace Client
 } // namespace Nighthawk
 
-#endif // defined(__has_feature) && !__has_feature(thread_sanitizer)
+#endif // ifndef ENVOY_CONFIG_TSAN


### PR DESCRIPTION
Somehow the integration test server excepts when running under TSAN because of Envoy
not being able to find its configuration file (with TSANs `die_after_fork disabled`). 

The code below seems to suggest that TSAN doesn't support this scenario.
https://github.com/llvm-mirror/compiler-rt/blob/master/lib/tsan/rtl/tsan_interceptors.cc#L999

Further root cause analysis is not worth it at this point, because this code will be deprecated
soon in favor of either https://github.com/envoyproxy/nighthawk/pull/60 or moving this end-to-end testing to python.

So I propose we disable this test when we detect we are running under TSAN for now.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>