### PR TITLE
build: fix zlib dependency for hdr histogram.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -42,6 +42,7 @@ cc_library(
         "-Wno-implicit-function-declaration",
         "-Wno-error",
     ],
+    deps = ["//external:zlib"],
     visibility = ["//visibility:public"],
 )
   """,


### PR DESCRIPTION
Fixes #67.

Signed-off-by: Harvey Tuch <htuch@google.com>