### PR TITLE
do-ci.sh: make docker-specific setup conditional

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -98,25 +98,27 @@ if [ -n "$CIRCLECI" ]; then
     fi
 fi
 
-# Create a fake home. Python site libs tries to do getpwuid(3) if we don't and the CI
-# Docker image gets confused as it has no passwd entry when running non-root
-# unless we do this.
-FAKE_HOME=/tmp/fake_home
-mkdir -p "${FAKE_HOME}"
-export HOME="${FAKE_HOME}"
-export PYTHONUSERBASE="${FAKE_HOME}"
+ if grep 'docker\|lxc' /proc/1/cgroup; then
+    # Create a fake home. Python site libs tries to do getpwuid(3) if we don't and the CI
+    # Docker image gets confused as it has no passwd entry when running non-root
+    # unless we do this.
+    FAKE_HOME=/tmp/fake_home
+    mkdir -p "${FAKE_HOME}"
+    export HOME="${FAKE_HOME}"
+    export PYTHONUSERBASE="${FAKE_HOME}"
 
-export BUILD_DIR=/build
-if [[ ! -d "${BUILD_DIR}" ]]
-then
-  echo "${BUILD_DIR} mount missing - did you forget -v <something>:${BUILD_DIR}? Creating."
-  mkdir -p "${BUILD_DIR}"
+    export BUILD_DIR=/build
+    if [[ ! -d "${BUILD_DIR}" ]]
+    then
+        echo "${BUILD_DIR} mount missing - did you forget -v <something>:${BUILD_DIR}? Creating."
+        mkdir -p "${BUILD_DIR}"
+    fi
+
+    # Environment setup.
+    export USER=bazel
+    export TEST_TMPDIR=/build/tmp
+    export BAZEL="bazel"
 fi
-
-# Environment setup.
-export USER=bazel
-export TEST_TMPDIR=/build/tmp
-export BAZEL="bazel"
 
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"
 export BAZEL_BUILD_OPTIONS=" \


### PR DESCRIPTION
This change allows `do_ci.sh` to detect when it is being run in a Docker container,
and conditionally executes setup code specific to that. This is useful for when one
wants to run `do_ci.sh` directly on a system.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>
