### PR TITLE
Sequencer: don't assert when starting late.

### DIFF
--- a/source/common/sequencer_impl.cc
+++ b/source/common/sequencer_impl.cc
@@ -150,8 +150,10 @@ void SequencerImpl::run(bool from_periodic_timer) {
 }
 
 void SequencerImpl::waitForCompletion() {
-  ASSERT(running_);
-  dispatcher_.run(Envoy::Event::Dispatcher::RunType::Block);
+  // It's possible that we have already finished when we get here.
+  if (running_) {
+    dispatcher_.run(Envoy::Event::Dispatcher::RunType::Block);
+  }
   // We should guarantee the flow terminates, so:
   ASSERT(!running_);
 }


### PR DESCRIPTION
Noticed this when generating a test coverage report on a machine with many cores.
Apparently that ran into some more extreme drifts in expected timings, which triggered
an assert. Looking into this, we can and should just handle this case.
(Note: not visible in this PR, but the code will log an error as well when this happens).

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>
