### PR TITLE
Add back the connection prefetching feature

### DIFF
--- a/integration/test_integration_basics.py
+++ b/integration/test_integration_basics.py
@@ -207,3 +207,14 @@ class TestHttps(HttpsIntegrationTestBase):
     ])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["ssl.ciphers.ECDHE-RSA-AES256-GCM-SHA384"], 1)
+
+  def test_prefetching(self):
+    """
+    Test we prefetch connections.
+    """
+    parsed_json = self.runNighthawkClient([
+        "--duration 1", "--rps 1", "--prefetch-connections", "--connections 50",
+        self.getTestServerRootUri()
+    ])
+    counters = self.getNighthawkCounterMapFromJson(parsed_json)
+    self.assertEqual(counters["upstream_cx_http1_total"], 50)

--- a/integration/test_integration_basics.py
+++ b/integration/test_integration_basics.py
@@ -210,7 +210,9 @@ class TestHttps(HttpsIntegrationTestBase):
 
   def test_prefetching(self):
     """
-    Test we prefetch connections.
+    Test we prefetch connections. We test for 1 second at 1 rps, which should
+    result in 1 connection max without prefetching. However, we specify 50 connections
+    and the prefetching flag, so we ought to see 50 http1 connections created.
     """
     parsed_json = self.runNighthawkClient([
         "--duration 1", "--rps 1", "--prefetch-connections", "--connections 50",

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -19,6 +19,13 @@ using namespace std::chrono_literals;
 namespace Nighthawk {
 namespace Client {
 
+void Http1PoolImpl::createConnections(const uint32_t connection_limit) {
+  ENVOY_LOG(error, "Prefetching {} connections.", connection_limit);
+  for (uint32_t i = 0; i < connection_limit; i++) {
+    createNewConnection();
+  }
+}
+
 BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(
     Envoy::Api::Api& api, Envoy::Event::Dispatcher& dispatcher, Envoy::Stats::Store& store,
     StatisticPtr&& connect_statistic, StatisticPtr&& response_statistic, UriPtr&& uri, bool use_h2,
@@ -42,8 +49,12 @@ BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(
 }
 
 void BenchmarkClientHttpImpl::prefetchPoolConnections() {
-  // XXX(oschaaf): when switching to base off from cluster manager
-  // we lost this feature. restore!
+  Http1PoolImpl* prefetchable_pool = dynamic_cast<Http1PoolImpl*>(pool());
+  if (prefetchable_pool == nullptr) {
+    ENVOY_LOG(error, "prefetchPoolConnections() pool not prefetchable");
+    return;
+  }
+  prefetchable_pool->createConnections(connection_limit_);
 }
 
 void BenchmarkClientHttpImpl::terminate() {

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -49,7 +49,7 @@ BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(
 }
 
 void BenchmarkClientHttpImpl::prefetchPoolConnections() {
-  Http1PoolImpl* prefetchable_pool = dynamic_cast<Http1PoolImpl*>(pool());
+  auto* prefetchable_pool = dynamic_cast<Http1PoolImpl*>(pool());
   if (prefetchable_pool == nullptr) {
     ENVOY_LOG(error, "prefetchPoolConnections() pool not prefetchable");
     return;

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -16,6 +16,7 @@
 
 #include "common/common/logger.h"
 #include "common/http/header_map_impl.h"
+#include "common/http/http1/conn_pool.h"
 #include "common/runtime/runtime_impl.h"
 
 #include "client/stream_decoder.h"
@@ -42,6 +43,12 @@ using namespace Envoy; // We need this because of macro expectations.
 
 struct BenchmarkClientStats {
   ALL_BENCHMARK_CLIENT_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+class Http1PoolImpl : public Envoy::Http::Http1::ProdConnPoolImpl {
+public:
+  using Envoy::Http::Http1::ProdConnPoolImpl::ProdConnPoolImpl;
+  void createConnections(const uint32_t connection_limit);
 };
 
 class BenchmarkClientHttpImpl : public BenchmarkClient,

--- a/source/client/client_worker_impl.h
+++ b/source/client/client_worker_impl.h
@@ -27,7 +27,7 @@ public:
                    const BenchmarkClientFactory& benchmark_client_factory,
                    const SequencerFactory& sequencer_factory, UriPtr&& uri,
                    Envoy::Stats::Store& store, const int worker_number,
-                   const Envoy::MonotonicTime starting_time);
+                   const Envoy::MonotonicTime starting_time, bool prefetch_connections);
 
   StatisticPtrMap statistics() const override;
   Envoy::Stats::Store& store() const override { return store_; }
@@ -44,6 +44,7 @@ private:
   BenchmarkClientPtr benchmark_client_;
   const SequencerPtr sequencer_;
   Envoy::LocalInfo::LocalInfoPtr local_info_;
+  const bool prefetch_connections_;
 };
 
 using ClientWorkerImplPtr = std::unique_ptr<ClientWorkerImpl>;

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -30,6 +30,7 @@
 #include "common/uri_impl.h"
 #include "common/utility.h"
 
+#include "client/benchmark_client_impl.h"
 #include "client/client.h"
 #include "client/client_worker_impl.h"
 #include "client/factories_impl.h"
@@ -45,6 +46,25 @@ using namespace std::chrono_literals;
 
 namespace Nighthawk {
 namespace Client {
+
+// We customize ProdClusterManagerFactory for the sole purpose of returning our specialized
+// http1 pool to the benchmark client, which allows us to offer connection prefetching.
+class ClusterManagerFactory : public Envoy::Upstream::ProdClusterManagerFactory {
+public:
+  using Envoy::Upstream::ProdClusterManagerFactory::ProdClusterManagerFactory;
+
+  Envoy::Http::ConnectionPool::InstancePtr
+  allocateConnPool(Envoy::Event::Dispatcher& dispatcher, Envoy::Upstream::HostConstSharedPtr host,
+                   Envoy::Upstream::ResourcePriority priority, Envoy::Http::Protocol protocol,
+                   const Envoy::Network::ConnectionSocket::OptionsSharedPtr& options) override {
+    if (protocol == Envoy::Http::Protocol::Http11 || protocol == Envoy::Http::Protocol::Http11) {
+      return Envoy::Http::ConnectionPool::InstancePtr{
+          new Http1PoolImpl(dispatcher, host, priority, options)};
+    }
+    return Envoy::Upstream::ProdClusterManagerFactory::allocateConnPool(dispatcher, host, priority,
+                                                                        protocol, options);
+  }
+};
 
 ProcessImpl::ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_system,
                          const PlatformUtil& platform_util)
@@ -69,7 +89,8 @@ ProcessImpl::ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_
 }
 
 const std::vector<ClientWorkerPtr>& ProcessImpl::createWorkers(const UriImpl& uri,
-                                                               const uint32_t concurrency) {
+                                                               const uint32_t concurrency,
+                                                               const bool prefetch_connections) {
   // TODO(oschaaf): Expose kMinimalDelay in configuration.
   const std::chrono::milliseconds kMinimalWorkerDelay = 500ms;
   ASSERT(workers_.size() == 0);
@@ -94,7 +115,7 @@ const std::vector<ClientWorkerPtr>& ProcessImpl::createWorkers(const UriImpl& ur
     workers_.push_back(std::make_unique<ClientWorkerImpl>(
         api_, tls_, cluster_manager_, benchmark_client_factory_, sequencer_factory_,
         std::make_unique<UriImpl>(uri), store_root_, worker_number,
-        first_worker_start + worker_delay));
+        first_worker_start + worker_delay, prefetch_connections));
     worker_number++;
   }
   return workers_;
@@ -243,7 +264,8 @@ bool ProcessImpl::run(OutputCollector& collector) {
   } catch (UriException) {
     return false;
   }
-  const std::vector<ClientWorkerPtr>& workers = createWorkers(uri, determineConcurrency());
+  const std::vector<ClientWorkerPtr>& workers =
+      createWorkers(uri, determineConcurrency(), options_.prefetchConnections());
 
   tls_.registerThread(*dispatcher_, true);
   store_root_.initializeThreading(*dispatcher_, tls_);
@@ -253,7 +275,7 @@ bool ProcessImpl::run(OutputCollector& collector) {
           Envoy::ProtobufMessage::getStrictValidationVisitor(), api_)});
   ssl_context_manager_ =
       std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(time_system_);
-  cluster_manager_factory_ = std::make_unique<Envoy::Upstream::ProdClusterManagerFactory>(
+  cluster_manager_factory_ = std::make_unique<ClusterManagerFactory>(
       admin_, Envoy::Runtime::LoaderSingleton::get(), store_root_, tls_, generator_,
       dispatcher_->createDnsResolver({}), *ssl_context_manager_, *dispatcher_, *local_info_,
       secret_manager_, Envoy::ProtobufMessage::getStrictValidationVisitor(), api_, http_context_,

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -57,7 +57,7 @@ public:
   allocateConnPool(Envoy::Event::Dispatcher& dispatcher, Envoy::Upstream::HostConstSharedPtr host,
                    Envoy::Upstream::ResourcePriority priority, Envoy::Http::Protocol protocol,
                    const Envoy::Network::ConnectionSocket::OptionsSharedPtr& options) override {
-    if (protocol == Envoy::Http::Protocol::Http11 || protocol == Envoy::Http::Protocol::Http11) {
+    if (protocol == Envoy::Http::Protocol::Http11 || protocol == Envoy::Http::Protocol::Http10) {
       return Envoy::Http::ConnectionPool::InstancePtr{
           new Http1PoolImpl(dispatcher, host, priority, options)};
     }

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -55,7 +55,8 @@ public:
 
 private:
   void configureComponentLogLevels(spdlog::level::level_enum level);
-  const std::vector<ClientWorkerPtr>& createWorkers(const UriImpl& uri, const uint32_t concurrency);
+  const std::vector<ClientWorkerPtr>& createWorkers(const UriImpl& uri, const uint32_t concurrency,
+                                                    bool prefetch_connections);
   std::vector<StatisticPtr> vectorizeStatisticPtrMap(const StatisticFactory& statistic_factory,
                                                      const StatisticPtrMap& statistics) const;
   std::vector<StatisticPtr>

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -195,11 +195,16 @@ TEST_F(BenchmarkClientHttpTest, StatusTrackingInOnComplete) {
 }
 
 TEST_F(BenchmarkClientHttpTest, ConnectionPrefetching) {
-  setupBenchmarkClient();
+  auto uri = std::make_unique<UriImpl>("http://foo/");
+  auto store = std::make_unique<Envoy::Stats::IsolatedStoreImpl>();
+  client_ = std::make_unique<Client::BenchmarkClientHttpImpl>(
+      *api_, *dispatcher_, *store, std::make_unique<StreamingStatistic>(),
+      std::make_unique<StreamingStatistic>(), std::move(uri), false, cluster_manager_);
+
   client_->setConnectionLimit(50);
   client_->prefetchPoolConnections();
   dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
-  // XXX(oschaaf): create expectations once implemented
+  client_.reset();
 }
 
 TEST_F(BenchmarkClientHttpTest, PoolFailures) {

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -93,6 +93,7 @@ TEST_F(ClientWorkerTest, BasicTest) {
     InSequence dummy;
 
     // warmup
+    EXPECT_CALL(*benchmark_client_, prefetchPoolConnections()).Times(1);
     EXPECT_CALL(*benchmark_client_, tryStartOne(_))
         .Times(1)
         .WillRepeatedly(Invoke(this, &ClientWorkerTest::CheckThreadChanged));
@@ -106,7 +107,7 @@ TEST_F(ClientWorkerTest, BasicTest) {
   auto worker = std::make_unique<ClientWorkerImpl>(
       api_, tls_, cluster_manager_ptr_, benchmark_client_factory_, sequencer_factory_,
       std::make_unique<Nighthawk::UriImpl>("http://foo"), store_, worker_number,
-      time_system_.monotonicTime());
+      time_system_.monotonicTime(), true);
 
   worker->start();
   worker->waitForCompletion();


### PR DESCRIPTION
As promised in https://github.com/envoyproxy/nighthawk/pull/105
This restores functionality of the connection prefetching feature

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>