### PR TITLE
Fix log level argument parsing

### DIFF
--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -64,8 +64,9 @@ ProcessImpl::ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_
       access_log_manager_(std::chrono::milliseconds(1000), api_, *dispatcher_, fakelock_,
                           store_root_),
       init_watcher_("Nighthawk", []() {}) {
-  configureComponentLogLevels(spdlog::level::from_str(
-      nighthawk::client::Verbosity::VerbosityOptions_Name(options_.verbosity())));
+  std::string lower = absl::AsciiStrToLower(
+      nighthawk::client::Verbosity::VerbosityOptions_Name(options_.verbosity()));
+  configureComponentLogLevels(spdlog::level::from_str(lower));
 }
 
 const std::vector<ClientWorkerPtr>& ProcessImpl::createWorkers(const UriImpl& uri,

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -19,17 +19,21 @@ namespace Client {
 // want those tests in here, and mock Process in client_test.
 class ProcessTest : public testing::Test {
 public:
+  ProcessTest()
+      : options_(TestUtility::createOptionsImpl(
+            fmt::format("foo --duration 1 --rps 10 https://127.0.0.1/"))){
+
+        };
   void runProcess() {
-    OptionsPtr options = TestUtility::createOptionsImpl(
-        fmt::format("foo --address-family v4 --duration 2 --rps 10 https://127.0.0.1/"));
     PlatformUtilImpl platform_util;
-    ProcessPtr process = std::make_unique<ProcessImpl>(*options, time_system_, platform_util);
-    OutputCollectorFactoryImpl output_format_factory(time_system_, *options);
+    ProcessPtr process = std::make_unique<ProcessImpl>(*options_, time_system_, platform_util);
+    OutputCollectorFactoryImpl output_format_factory(time_system_, *options_);
     auto collector = output_format_factory.create();
     EXPECT_TRUE(process->run(*collector));
     process.reset();
   }
 
+  OptionsPtr options_;
   Envoy::Event::RealTimeSystem time_system_; // NO_CHECK_FORMAT(real_time)
 };
 
@@ -39,17 +43,30 @@ TEST_F(ProcessTest, TwoProcesssInSequence) {
 }
 
 TEST_F(ProcessTest, CpuAffinityDetectionFailure) {
-  OptionsPtr options = TestUtility::createOptionsImpl(
-      fmt::format("foo --address-family v4 --duration 2 --rps 10 http://127.0.0.1/"));
   MockPlatformUtil platform_util;
-  ProcessPtr process = std::make_unique<ProcessImpl>(*options, time_system_, platform_util);
-  OutputCollectorFactoryImpl output_format_factory(time_system_, *options);
+  ProcessPtr process = std::make_unique<ProcessImpl>(*options_, time_system_, platform_util);
+  OutputCollectorFactoryImpl output_format_factory(time_system_, *options_);
   auto collector = output_format_factory.create();
   // Will return 0, which happens on failure in the implementation.
   EXPECT_CALL(platform_util, determineCpuCoresWithAffinity);
   EXPECT_TRUE(process->run(*collector));
-  // TODO(oschaaf): check the proto output that we reflect the concurreny we actually used.
+  // TODO(oschaaf): check the proto output that we reflect the concurrency we actually used.
   // I'm not sure we do so right now.
+}
+
+TEST_F(ProcessTest, LogVerbosity) {
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cerr.rdbuf(buffer.rdbuf());
+  options_ = TestUtility::createOptionsImpl(
+      fmt::format("foo --duration 1 --rps 10 -v error https://127.0.0.1/"));
+  runProcess();
+  EXPECT_EQ(buffer.str(), "");
+  options_ = TestUtility::createOptionsImpl(
+      fmt::format("foo --duration 1 --rps 10 -v trace https://127.0.0.1/"));
+  runProcess();
+  EXPECT_NE(buffer.str(), "");
+  std::cerr.rdbuf(sbuf);
 }
 
 } // namespace Client


### PR DESCRIPTION
We should lowercase the input to `spdlog::level::from_str`.
Fix that, and add tests to ensure this stays put.

Fixes https://github.com/envoyproxy/nighthawk/issues/108

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>