### PR TITLE
Fix the test we have for respecting log verbosity

### DIFF
--- a/integration/integration_test_fixtures.py
+++ b/integration/integration_test_fixtures.py
@@ -118,8 +118,8 @@ class IntegrationTestBase(unittest.TestCase):
 
   def runNighthawkClient(self, args, expect_failure=False, timeout=30):
     """
-    Runs Nighthawk against the test server, returning a json-formatted result.
-    If the timeout is exceeded an exception will be raised.
+    Runs Nighthawk against the test server, returning a json-formatted result
+    and logs. If the timeout is exceeded an exception will be raised.
     """
     if IntegrationTestBase.ip_version == IpVersion.IPV6:
       args.insert(0, "--address-family v6")
@@ -128,13 +128,13 @@ class IntegrationTestBase(unittest.TestCase):
     logging.info("Nighthawk client popen() args: [%s]" % args)
     client_process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = client_process.communicate()
-    logging.info(stderr.decode('utf-8'))
+    logs = stderr.decode('utf-8')
     json_string = stdout.decode('utf-8')
     if expect_failure:
       self.assertNotEqual(0, client_process.returncode)
     else:
       self.assertEqual(0, client_process.returncode)
-      return json.loads(json_string)
+      return json.loads(json_string), logs
 
 
 # We don't have a straightforward way to do parameterized tests yet.

--- a/integration/test_integration_basics.py
+++ b/integration/test_integration_basics.py
@@ -21,7 +21,7 @@ class TestHttp(HttpIntegrationTestBase):
     Runs the CLI configured to use plain HTTP/1 against our test server, and sanity
     checks statistics from both client and server.
     """
-    parsed_json, logs = self.runNighthawkClient([self.getTestServerRootUri()])
+    parsed_json, _ = self.runNighthawkClient([self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["benchmark.http_2xx"], 25)
     self.assertEqual(counters["upstream_cx_destroy"], 1)
@@ -38,7 +38,7 @@ class TestHttp(HttpIntegrationTestBase):
   def mini_stress_test_h1(self, args):
     # run a test with more rps then we can handle, and a very small client-side queue.
     # we should observe both lots of successfull requests as well as time spend in blocking mode.,
-    parsed_json, logs = self.runNighthawkClient(args)
+    parsed_json, _ = self.runNighthawkClient(args)
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     # We set a reasonably low expecation of 1000 requests. We set it low, because we want this
     # test to succeed on a reasonable share of setups (hopefully practically all).
@@ -85,7 +85,7 @@ class TestHttp(HttpIntegrationTestBase):
     Runs the CLI configured to use h2c against our test server, and sanity
     checks statistics from both client and server.
     """
-    parsed_json, logs = self.runNighthawkClient(["--h2", self.getTestServerRootUri()])
+    parsed_json, _ = self.runNighthawkClient(["--h2", self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["benchmark.http_2xx"], 25)
     self.assertEqual(counters["upstream_cx_destroy"], 1)
@@ -103,7 +103,7 @@ class TestHttp(HttpIntegrationTestBase):
     Concurrency should act like a multiplier.
     """
 
-    parsed_json, logs = self.runNighthawkClient(
+    parsed_json, _ = self.runNighthawkClient(
         ["--concurrency 4 --rps 5 --connections 1",
          self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
@@ -120,7 +120,7 @@ class TestHttps(HttpsIntegrationTestBase):
     Runs the CLI configured to use HTTP/1 over https against our test server, and sanity
     checks statistics from both client and server.
     """
-    parsed_json, logs = self.runNighthawkClient([self.getTestServerRootUri()])
+    parsed_json, _ = self.runNighthawkClient([self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["benchmark.http_2xx"], 25)
     self.assertEqual(counters["upstream_cx_destroy"], 1)
@@ -149,7 +149,7 @@ class TestHttps(HttpsIntegrationTestBase):
     checks statistics from both client and server.
     """
 
-    parsed_json, logs = self.runNighthawkClient(["--h2", self.getTestServerRootUri()])
+    parsed_json, _ = self.runNighthawkClient(["--h2", self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["benchmark.http_2xx"], 25)
     self.assertEqual(counters["upstream_cx_destroy"], 1)
@@ -172,7 +172,7 @@ class TestHttps(HttpsIntegrationTestBase):
     Verifies specifying tls cipher suites works with the h1 pool
     """
 
-    parsed_json, logs = self.runNighthawkClient([
+    parsed_json, _ = self.runNighthawkClient([
         "--duration 1",
         "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}",
         self.getTestServerRootUri()
@@ -180,7 +180,7 @@ class TestHttps(HttpsIntegrationTestBase):
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["ssl.ciphers.ECDHE-RSA-AES128-SHA"], 1)
 
-    parsed_json, logs = self.runNighthawkClient([
+    parsed_json, _ = self.runNighthawkClient([
         "--h2", "--duration 1",
         "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}",
         self.getTestServerRootUri()
@@ -192,7 +192,7 @@ class TestHttps(HttpsIntegrationTestBase):
     """
     Verifies specifying tls cipher suites works with the h2 pool
     """
-    parsed_json, logs = self.runNighthawkClient([
+    parsed_json, _ = self.runNighthawkClient([
         "--duration 1",
         "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}",
         self.getTestServerRootUri()
@@ -200,7 +200,7 @@ class TestHttps(HttpsIntegrationTestBase):
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["ssl.ciphers.ECDHE-RSA-AES128-SHA"], 1)
 
-    parsed_json, logs = self.runNighthawkClient([
+    parsed_json, _ = self.runNighthawkClient([
         "--h2", "--duration 1",
         "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}",
         self.getTestServerRootUri()
@@ -214,7 +214,7 @@ class TestHttps(HttpsIntegrationTestBase):
     result in 1 connection max without prefetching. However, we specify 50 connections
     and the prefetching flag, so we ought to see 50 http1 connections created.
     """
-    parsed_json, logs = self.runNighthawkClient([
+    parsed_json, _ = self.runNighthawkClient([
         "--duration 1", "--rps 1", "--prefetch-connections", "--connections 50",
         self.getTestServerRootUri()
     ])
@@ -224,7 +224,7 @@ class TestHttps(HttpsIntegrationTestBase):
   def test_log_verbosity(self):
     """
     Test that that the specified log verbosity level is respected.
-    This tests for a sentinel we know is only writter when the level
+    This tests for a sentinel we know is only right when the level
     is set to 'trace'.
     """
     # TODO(oschaaf): this is kind of fragile. Can we improve?

--- a/integration/test_integration_basics.py
+++ b/integration/test_integration_basics.py
@@ -229,14 +229,12 @@ class TestHttps(HttpsIntegrationTestBase):
     """
     # TODO(oschaaf): this is kind of fragile. Can we improve?
     trace_level_sentinel = "nighthawk_service_zone"
-    parsed_json, logs = self.runNighthawkClient([
-        "--duration 1", "--rps 1", "-v debug",
-        self.getTestServerRootUri()
-    ])
+    parsed_json, logs = self.runNighthawkClient(
+        ["--duration 1", "--rps 1", "-v debug",
+         self.getTestServerRootUri()])
     self.assertNotIn(trace_level_sentinel, logs)
 
-    parsed_json, logs = self.runNighthawkClient([
-        "--duration 1", "--rps 1", "-v trace",
-        self.getTestServerRootUri()
-    ])
+    parsed_json, logs = self.runNighthawkClient(
+        ["--duration 1", "--rps 1", "-v trace",
+         self.getTestServerRootUri()])
     self.assertIn(trace_level_sentinel, logs)

--- a/integration/test_integration_basics.py
+++ b/integration/test_integration_basics.py
@@ -21,7 +21,7 @@ class TestHttp(HttpIntegrationTestBase):
     Runs the CLI configured to use plain HTTP/1 against our test server, and sanity
     checks statistics from both client and server.
     """
-    parsed_json = self.runNighthawkClient([self.getTestServerRootUri()])
+    parsed_json, logs = self.runNighthawkClient([self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["benchmark.http_2xx"], 25)
     self.assertEqual(counters["upstream_cx_destroy"], 1)
@@ -38,7 +38,7 @@ class TestHttp(HttpIntegrationTestBase):
   def mini_stress_test_h1(self, args):
     # run a test with more rps then we can handle, and a very small client-side queue.
     # we should observe both lots of successfull requests as well as time spend in blocking mode.,
-    parsed_json = self.runNighthawkClient(args)
+    parsed_json, logs = self.runNighthawkClient(args)
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     # We set a reasonably low expecation of 1000 requests. We set it low, because we want this
     # test to succeed on a reasonable share of setups (hopefully practically all).
@@ -85,7 +85,7 @@ class TestHttp(HttpIntegrationTestBase):
     Runs the CLI configured to use h2c against our test server, and sanity
     checks statistics from both client and server.
     """
-    parsed_json = self.runNighthawkClient(["--h2", self.getTestServerRootUri()])
+    parsed_json, logs = self.runNighthawkClient(["--h2", self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["benchmark.http_2xx"], 25)
     self.assertEqual(counters["upstream_cx_destroy"], 1)
@@ -103,7 +103,7 @@ class TestHttp(HttpIntegrationTestBase):
     Concurrency should act like a multiplier.
     """
 
-    parsed_json = self.runNighthawkClient(
+    parsed_json, logs = self.runNighthawkClient(
         ["--concurrency 4 --rps 5 --connections 1",
          self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
@@ -120,7 +120,7 @@ class TestHttps(HttpsIntegrationTestBase):
     Runs the CLI configured to use HTTP/1 over https against our test server, and sanity
     checks statistics from both client and server.
     """
-    parsed_json = self.runNighthawkClient([self.getTestServerRootUri()])
+    parsed_json, logs = self.runNighthawkClient([self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["benchmark.http_2xx"], 25)
     self.assertEqual(counters["upstream_cx_destroy"], 1)
@@ -149,7 +149,7 @@ class TestHttps(HttpsIntegrationTestBase):
     checks statistics from both client and server.
     """
 
-    parsed_json = self.runNighthawkClient(["--h2", self.getTestServerRootUri()])
+    parsed_json, logs = self.runNighthawkClient(["--h2", self.getTestServerRootUri()])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["benchmark.http_2xx"], 25)
     self.assertEqual(counters["upstream_cx_destroy"], 1)
@@ -172,7 +172,7 @@ class TestHttps(HttpsIntegrationTestBase):
     Verifies specifying tls cipher suites works with the h1 pool
     """
 
-    parsed_json = self.runNighthawkClient([
+    parsed_json, logs = self.runNighthawkClient([
         "--duration 1",
         "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}",
         self.getTestServerRootUri()
@@ -180,7 +180,7 @@ class TestHttps(HttpsIntegrationTestBase):
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["ssl.ciphers.ECDHE-RSA-AES128-SHA"], 1)
 
-    parsed_json = self.runNighthawkClient([
+    parsed_json, logs = self.runNighthawkClient([
         "--h2", "--duration 1",
         "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}",
         self.getTestServerRootUri()
@@ -192,7 +192,7 @@ class TestHttps(HttpsIntegrationTestBase):
     """
     Verifies specifying tls cipher suites works with the h2 pool
     """
-    parsed_json = self.runNighthawkClient([
+    parsed_json, logs = self.runNighthawkClient([
         "--duration 1",
         "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}",
         self.getTestServerRootUri()
@@ -200,7 +200,7 @@ class TestHttps(HttpsIntegrationTestBase):
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["ssl.ciphers.ECDHE-RSA-AES128-SHA"], 1)
 
-    parsed_json = self.runNighthawkClient([
+    parsed_json, logs = self.runNighthawkClient([
         "--h2", "--duration 1",
         "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}",
         self.getTestServerRootUri()
@@ -214,9 +214,29 @@ class TestHttps(HttpsIntegrationTestBase):
     result in 1 connection max without prefetching. However, we specify 50 connections
     and the prefetching flag, so we ought to see 50 http1 connections created.
     """
-    parsed_json = self.runNighthawkClient([
+    parsed_json, logs = self.runNighthawkClient([
         "--duration 1", "--rps 1", "--prefetch-connections", "--connections 50",
         self.getTestServerRootUri()
     ])
     counters = self.getNighthawkCounterMapFromJson(parsed_json)
     self.assertEqual(counters["upstream_cx_http1_total"], 50)
+
+  def test_log_verbosity(self):
+    """
+    Test that that the specified log verbosity level is respected.
+    This tests for a sentinel we know is only writter when the level
+    is set to 'trace'.
+    """
+    # TODO(oschaaf): this is kind of fragile. Can we improve?
+    trace_level_sentinel = "nighthawk_service_zone"
+    parsed_json, logs = self.runNighthawkClient([
+        "--duration 1", "--rps 1", "-v debug",
+        self.getTestServerRootUri()
+    ])
+    self.assertNotIn(trace_level_sentinel, logs)
+
+    parsed_json, logs = self.runNighthawkClient([
+        "--duration 1", "--rps 1", "-v trace",
+        self.getTestServerRootUri()
+    ])
+    self.assertIn(trace_level_sentinel, logs)

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -21,7 +21,7 @@ class ProcessTest : public testing::Test {
 public:
   ProcessTest()
       : options_(TestUtility::createOptionsImpl(
-            fmt::format("foo --duration 1 --rps 10 https://127.0.0.1/"))){
+            fmt::format("foo --duration 1 -v error --rps 10 https://127.0.0.1/"))){
 
         };
   void runProcess() {
@@ -37,7 +37,7 @@ public:
   Envoy::Event::RealTimeSystem time_system_; // NO_CHECK_FORMAT(real_time)
 };
 
-TEST_F(ProcessTest, TwoProcesssInSequence) {
+TEST_F(ProcessTest, TwoProcessInSequence) {
   runProcess();
   runProcess();
 }

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -54,20 +54,5 @@ TEST_F(ProcessTest, CpuAffinityDetectionFailure) {
   // I'm not sure we do so right now.
 }
 
-TEST_F(ProcessTest, LogVerbosity) {
-  std::stringstream buffer;
-  std::streambuf* sbuf = std::cout.rdbuf();
-  std::cerr.rdbuf(buffer.rdbuf());
-  options_ = TestUtility::createOptionsImpl(
-      fmt::format("foo --duration 1 --rps 10 -v error https://127.0.0.1/"));
-  runProcess();
-  EXPECT_EQ(buffer.str(), "");
-  options_ = TestUtility::createOptionsImpl(
-      fmt::format("foo --duration 1 --rps 10 -v trace https://127.0.0.1/"));
-  runProcess();
-  EXPECT_NE(buffer.str(), "");
-  std::cerr.rdbuf(sbuf);
-}
-
 } // namespace Client
 } // namespace Nighthawk

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -39,6 +39,8 @@ public:
 
 TEST_F(ProcessTest, TwoProcessInSequence) {
   runProcess();
+  options_ = TestUtility::createOptionsImpl(
+      fmt::format("foo --h2 --duration 1 --rps 10 https://127.0.0.1/"));
   runProcess();
 }
 


### PR DESCRIPTION
The c++ test started failing when landing on master, because
it conflicts with the new test methology which uses sharding.
(The stderr capturing we used breaks when running in sharded mode)

Move the test to a python-based integration-test equivalent.
Also, reduce log noise in the tests.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>