### PR TITLE
Use Envoy's OptionsImplPlatform::getCpuCount()

### DIFF
--- a/include/nighthawk/common/platform_util.h
+++ b/include/nighthawk/common/platform_util.h
@@ -22,11 +22,6 @@ public:
    * @param duration duration that the calling thread should sleep.
    */
   virtual void sleep(std::chrono::microseconds duration) const PURE;
-
-  /**
-   * @return uint32_t 0 #CPUs that the current thread has affinity with. 0 on failure.
-   */
-  virtual uint32_t determineCpuCoresWithAffinity() const PURE;
 };
 
 using PlatformUtilPtr = std::unique_ptr<PlatformUtil>;

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -67,6 +67,7 @@ envoy_cc_library(
         "@envoy//source/exe:process_wide_lib_with_external_headers",
         "@envoy//source/extensions/transport_sockets:well_known_names_with_external_headers",
         "@envoy//source/extensions/transport_sockets/tls:context_lib_with_external_headers",
+        "@envoy//source/server:options_lib_with_external_headers",
         "@envoy//source/server/config_validation:admin_lib_with_external_headers",
     ],
 )

--- a/source/client/client.cc
+++ b/source/client/client.cc
@@ -49,8 +49,7 @@ bool Main::run() {
           nighthawk::client::Verbosity::VerbosityOptions_Name(options_->verbosity())),
       "[%T.%f][%t][%L] %v", log_lock);
   Envoy::Event::RealTimeSystem time_system; // NO_CHECK_FORMAT(real_time)
-  PlatformUtilImpl platform_util;
-  ProcessImpl process(*options_, time_system, platform_util);
+  ProcessImpl process(*options_, time_system);
   OutputCollectorFactoryImpl output_format_factory(time_system, *options_);
   auto collector = output_format_factory.create();
   if (process.run(*collector)) {

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -45,8 +45,7 @@ namespace Client {
  */
 class ProcessImpl : public Process, public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
-  ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_system,
-              const PlatformUtil& platform_util);
+  ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_system);
 
   uint32_t determineConcurrency() const;
   bool run(OutputCollector& collector) override;
@@ -81,7 +80,6 @@ private:
   const BenchmarkClientFactoryImpl benchmark_client_factory_;
   const SequencerFactoryImpl sequencer_factory_;
   const Options& options_;
-  const PlatformUtil& platform_util_;
 
   Envoy::Init::ManagerImpl init_manager_;
   Envoy::LocalInfo::LocalInfoPtr local_info_;

--- a/source/client/service_impl.cc
+++ b/source/client/service_impl.cc
@@ -24,8 +24,7 @@ void ServiceImpl::handleExecutionRequest(const nighthawk::client::ExecutionReque
   // We scope here because the ProcessImpl instance must be destructed before we write the response
   // and set running to false.
   {
-    PlatformUtilImpl platform_util;
-    ProcessImpl process(*options, time_system_, platform_util);
+    ProcessImpl process(*options, time_system_);
     OutputCollectorFactoryImpl output_format_factory(time_system_, *options);
     auto logging_context = std::make_unique<Envoy::Logger::Context>(
         spdlog::level::from_str(

--- a/source/common/platform_util_impl.h
+++ b/source/common/platform_util_impl.h
@@ -16,20 +16,6 @@ public:
   void sleep(std::chrono::microseconds duration) const override {
     std::this_thread::sleep_for(duration); // NO_CHECK_FORMAT(real_time)
   };
-
-  uint32_t determineCpuCoresWithAffinity() const override {
-    // TODO(oschaaf): mull over what to do w/regard to hyperthreading.
-    const pthread_t thread = pthread_self();
-    cpu_set_t cpuset;
-    int i;
-
-    CPU_ZERO(&cpuset);
-    i = pthread_getaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
-    if (i == 0) {
-      return CPU_COUNT(&cpuset);
-    }
-    return 0;
-  }
 };
 
 } // namespace Nighthawk

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -38,7 +38,6 @@ public:
 
   MOCK_CONST_METHOD0(yieldCurrentThread, void());
   MOCK_CONST_METHOD1(sleep, void(std::chrono::microseconds));
-  MOCK_CONST_METHOD0(determineCpuCoresWithAffinity, uint32_t());
 };
 
 class MockRateLimiter : public RateLimiter {

--- a/test/platform_util_test.cc
+++ b/test/platform_util_test.cc
@@ -11,7 +11,6 @@ namespace Nighthawk {
 
 class PlatformUtilTest : public Test {
 public:
-  int32_t getCpuCountFromSet(cpu_set_t& set) { return CPU_COUNT(&set); }
   PlatformUtilImpl platform_util_;
 };
 
@@ -21,28 +20,6 @@ TEST_F(PlatformUtilTest, NoFatalFailureForYield) {
 
 TEST_F(PlatformUtilTest, NoFatalFailureForSleep) {
   EXPECT_NO_FATAL_FAILURE(platform_util_.sleep(1us));
-}
-
-// TODO(oschaaf): we probably want to move this out to another file.
-TEST_F(PlatformUtilTest, CpusWithAffinity) {
-  cpu_set_t original_set;
-  CPU_ZERO(&original_set);
-  EXPECT_EQ(0, sched_getaffinity(0, sizeof(original_set), &original_set));
-
-  uint32_t original_cpu_count = platform_util_.determineCpuCoresWithAffinity();
-  EXPECT_EQ(original_cpu_count, getCpuCountFromSet(original_set));
-
-  // Now the test, we set affinity to just the first cpu. We expect that to be reflected.
-  // This will be a no-op on a single core system.
-  cpu_set_t test_set;
-  CPU_ZERO(&test_set);
-  CPU_SET(0, &test_set);
-  EXPECT_EQ(0, sched_setaffinity(0, sizeof(test_set), &test_set));
-  EXPECT_EQ(1, platform_util_.determineCpuCoresWithAffinity());
-
-  // Restore affinity to what it was.
-  EXPECT_EQ(0, sched_setaffinity(0, sizeof(original_set), &original_set));
-  EXPECT_EQ(original_cpu_count, platform_util_.determineCpuCoresWithAffinity());
 }
 
 } // namespace Nighthawk

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -26,8 +26,7 @@ public:
 
         };
   void runProcess() {
-    PlatformUtilImpl platform_util;
-    ProcessPtr process = std::make_unique<ProcessImpl>(*options_, time_system_, platform_util);
+    ProcessPtr process = std::make_unique<ProcessImpl>(*options_, time_system_);
     OutputCollectorFactoryImpl output_format_factory(time_system_, *options_);
     auto collector = output_format_factory.create();
     EXPECT_TRUE(process->run(*collector));
@@ -43,18 +42,6 @@ TEST_F(ProcessTest, TwoProcessInSequence) {
   options_ = TestUtility::createOptionsImpl(
       fmt::format("foo --h2 --duration 1 --rps 10 https://127.0.0.1/"));
   runProcess();
-}
-
-TEST_F(ProcessTest, CpuAffinityDetectionFailure) {
-  MockPlatformUtil platform_util;
-  ProcessPtr process = std::make_unique<ProcessImpl>(*options_, time_system_, platform_util);
-  OutputCollectorFactoryImpl output_format_factory(time_system_, *options_);
-  auto collector = output_format_factory.create();
-  // Will return 0, which happens on failure in the implementation.
-  EXPECT_CALL(platform_util, determineCpuCoresWithAffinity);
-  EXPECT_TRUE(process->run(*collector));
-  // TODO(oschaaf): check the proto output that we reflect the concurrency we actually used.
-  // I'm not sure we do so right now.
 }
 
 } // namespace Client


### PR DESCRIPTION
Remove `PlatformUtil::determineCpuCoresWithAffinity()` in favor
of `Envoy::OptionsImplPlatform::getCpuCount()`

Fixes https://github.com/envoyproxy/nighthawk/issues/120

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>