### PR TITLE
Fix typo's in options_impl.cc

### DIFF
--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -56,7 +56,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "", "concurrency",
       fmt::format(
           "The number of concurrent event loops that should be used. Specify 'auto' to let "
-          "Nighthawk leverage all vCPUs that have affinity to the Nighthawk process.Note that "
+          "Nighthawk leverage all vCPUs that have affinity to the Nighthawk process. Note that "
           "increasing this results in an effective load multiplier combined with the configured "
           "--rps and --connections values. Default: {}. ",
           concurrency_),
@@ -99,7 +99,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::ValuesConstraint<std::string> address_families_allowed(address_families);
   TCLAP::ValueArg<std::string> address_family(
       "", "address-family",
-      fmt::format("Network addres family preference. Possible values: [auto, v4, v6]. The "
+      fmt::format("Network address family preference. Possible values: [auto, v4, v6]. The "
                   "default output format is '{}'.",
                   nighthawk::client::AddressFamily::AddressFamilyOptions_Name(address_family_)),
       false, "", &address_families_allowed, cmd);


### PR DESCRIPTION
In https://github.com/envoyproxy/nighthawk/pull/123 some doc changes where proposed and merged.
As promised, reflect these in the options implementation as well.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>