### PR TITLE
CI/test stabilizations

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -149,6 +149,10 @@ case "$1" in
         exit 0
     ;;
     clang_tidy)
+        if [ -n "$CIRCLECI" ]; then
+            # Decrease parallelism to avoid running out of memory
+            NUM_CPUS=7
+        fi
         do_clang_tidy
         exit 0
     ;;

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -84,11 +84,13 @@ class TestServerBase(object):
       self.server_port = listeners["listener_statuses"][0]["local_address"]["socket_address"][
           "port_value"]
       return True
-    except ConnectionError:
+    except requests.exceptions.ConnectionError:
       return False
 
   def waitUntilServerListening(self):
-    timeout = time.time() + 5
+    # we allow 30 seconds for the server to have its listeners up.
+    # (It seems that in sanitizer-enabled runs this can take a little while)
+    timeout = time.time() + 30
     while time.time() < timeout:
       if self.tryUpdateFromAdminInterface():
         return True


### PR DESCRIPTION
Address observed flakes

- Decrease CircleCI parallelism, avoid OOM
- Fix a bug, catch the right ConnectionError
- Increase timeout for waiting on the test server to become available

Fixes https://github.com/envoyproxy/nighthawk/issues/161

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>