### PR TITLE
[WIP] Experimental latency low pass filter

### DIFF
--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -106,4 +106,6 @@ message CommandLineOptions {
   google.protobuf.StringValue uri = 18; // [(validate.rules).string.uri = true];
   // See :option:`--trace` for details.
   google.protobuf.StringValue trace = 19; // [(validate.rules).string.uri = true];
+  // See :option:`--latency-low-pass` for details.
+  google.protobuf.Duration latency_sampling_global_low_pass = 20 [(validate.rules).duration.gte.seconds = 0];
 }

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -107,5 +107,6 @@ message CommandLineOptions {
   // See :option:`--trace` for details.
   google.protobuf.StringValue trace = 19; // [(validate.rules).string.uri = true];
   // See :option:`--latency-low-pass` for details.
-  google.protobuf.Duration latency_sampling_global_low_pass = 20 [(validate.rules).duration.gte.seconds = 0];
+  google.protobuf.Duration latency_sampling_global_low_pass = 20
+      [(validate.rules).duration.gte.seconds = 0];
 }

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -43,6 +43,7 @@ public:
   virtual nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions
   sequencerIdleStrategy() const PURE;
   virtual std::string trace() const PURE;
+  virtual std::chrono::nanoseconds latencySamplingGlobalLowPass() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/include/nighthawk/common/statistic.h
+++ b/include/nighthawk/common/statistic.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -19,7 +20,7 @@ class Statistic;
 
 using StatisticPtr = std::unique_ptr<Statistic>;
 using StatisticPtrMap = std::map<std::string, Statistic const*>;
-
+using InputFilterDelegate = std::function<bool(uint64_t)>;
 /**
  * Abstract interface for a statistic.
  */
@@ -31,6 +32,7 @@ public:
    * @param value the value of the sample to add
    */
   virtual void addValue(uint64_t sample_value) PURE;
+  virtual void setInputFilter(const InputFilterDelegate input_filter) PURE;
 
   virtual uint64_t count() const PURE;
   virtual double mean() const PURE;

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -51,6 +51,9 @@ public:
     return sequencer_idle_strategy_;
   }
   std::string trace() const override { return trace_; }
+  std::chrono::nanoseconds latencySamplingGlobalLowPass() const override {
+    return std::chrono::nanoseconds(latency_sampling_global_low_pass_);
+  }
 
 private:
   void setNonTrivialDefaults();
@@ -80,6 +83,7 @@ private:
   nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions sequencer_idle_strategy_{
       nighthawk::client::SequencerIdleStrategy::SPIN};
   std::string trace_;
+  uint64_t latency_sampling_global_low_pass_{0};
 };
 
 } // namespace Client

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -18,7 +18,17 @@ public:
   nighthawk::client::Statistic toProto() override;
   std::string id() const override;
   void setId(absl::string_view id) override;
+  void setInputFilter(const InputFilterDelegate input_filter) override;
+  void addValue(uint64_t value) override {
+    if (input_filter_ == nullptr || input_filter_(value)) {
+      addValueImpl(value);
+    }
+  }
+
+protected:
+  virtual void addValueImpl(uint64_t value) PURE;
   std::string id_;
+  InputFilterDelegate input_filter_;
 };
 
 /**
@@ -28,7 +38,7 @@ public:
 class SimpleStatistic : public StatisticImpl {
 public:
   SimpleStatistic();
-  void addValue(uint64_t value) override;
+  void addValueImpl(uint64_t value) override;
   uint64_t count() const override;
   double mean() const override;
   double pvariance() const override;
@@ -53,7 +63,7 @@ private:
 class StreamingStatistic : public StatisticImpl {
 public:
   StreamingStatistic();
-  void addValue(uint64_t value) override;
+  void addValueImpl(uint64_t value) override;
   uint64_t count() const override;
   double mean() const override;
   double pvariance() const override;
@@ -75,7 +85,7 @@ private:
 class InMemoryStatistic : public StatisticImpl {
 public:
   InMemoryStatistic();
-  void addValue(uint64_t sample_value) override;
+  void addValueImpl(uint64_t sample_value) override;
   uint64_t count() const override;
   double mean() const override;
   double pvariance() const override;
@@ -98,7 +108,7 @@ class HdrStatistic : public StatisticImpl {
 public:
   HdrStatistic();
   ~HdrStatistic() override;
-  void addValue(uint64_t sample_value) override;
+  void addValueImpl(uint64_t sample_value) override;
   uint64_t count() const override;
   double mean() const override;
   double pvariance() const override;

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -42,6 +42,7 @@ TEST_F(FactoriesTest, CreateBenchmarkClient) {
   EXPECT_CALL(options_, maxPendingRequests()).Times(1);
   EXPECT_CALL(options_, maxActiveRequests()).Times(1);
   EXPECT_CALL(options_, maxRequestsPerConnection()).Times(1);
+  EXPECT_CALL(options_, latencySamplingGlobalLowPass()).Times(2);
   auto cmd = std::make_unique<nighthawk::client::CommandLineOptions>();
   EXPECT_CALL(options_, toCommandLineOptions()).Times(1).WillOnce(Return(ByMove(std::move(cmd))));
   StaticHeaderSourceImpl header_generator(std::make_unique<Envoy::Http::TestHeaderMapImpl>());
@@ -83,6 +84,7 @@ public:
         .Times(1)
         .WillOnce(Return(sequencer_idle_strategy));
     EXPECT_CALL(dispatcher_, createTimer_(_)).Times(2);
+    EXPECT_CALL(options_, latencySamplingGlobalLowPass()).Times(2);
     Envoy::Event::SimulatedTimeSystem time_system;
     auto sequencer = factory.create(api_->timeSource(), dispatcher_, time_system.monotonicTime(),
                                     benchmark_client);
@@ -103,6 +105,7 @@ TEST_F(FactoriesTest, CreateStore) {
 }
 
 TEST_F(FactoriesTest, CreateStatistic) {
+  EXPECT_CALL(options_, latencySamplingGlobalLowPass()).Times(1);
   StatisticFactoryImpl factory(options_);
   EXPECT_NE(nullptr, factory.create().get());
 }

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -87,6 +87,7 @@ public:
   MOCK_CONST_METHOD0(sequencerIdleStrategy,
                      nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions());
   MOCK_CONST_METHOD0(trace, std::string());
+  MOCK_CONST_METHOD0(latencySamplingGlobalLowPass, std::chrono::nanoseconds());
 };
 
 class MockBenchmarkClientFactory : public Client::BenchmarkClientFactory {


### PR DESCRIPTION
Based on some experimental older code I found, I thought I'd update it to
work with the current state to see if there is interest.

Allows one to filter latency samples before they enter statistics
processing, hopefully improving resolution of the signal by cutting
out noise.

Example usage, dropping samples below 500us:

```
./nighthawk_client -latency-sampling-global-low-pass 500000 ...
```

The filtering is global, it would apply to all histograms.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>