### PR TITLE
exceptions: Catch all exceptions by const reference

### DIFF
--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -254,7 +254,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
     try {
       Envoy::MessageUtil::loadFromJson(tls_context.getValue(), tls_context_,
                                        Envoy::ProtobufMessage::getStrictValidationVisitor());
-    } catch (Envoy::EnvoyException e) {
+    } catch (const Envoy::EnvoyException& e) {
       throw MalformedArgvException(e.what());
     }
   }
@@ -329,7 +329,7 @@ void OptionsImpl::validate() const {
   }
   try {
     UriImpl uri(uri_);
-  } catch (const UriException) {
+  } catch (const UriException&) {
     throw MalformedArgvException("Invalid URI");
   }
   try {

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -327,7 +327,7 @@ bool ProcessImpl::run(OutputCollector& collector) {
       tracing_uri->resolve(*dispatcher_,
                            Utility::translateFamilyOptionString(options_.addressFamily()));
     }
-  } catch (UriException) {
+  } catch (const UriException&) {
     return false;
   }
   int number_of_workers = determineConcurrency();

--- a/source/client/service_impl.cc
+++ b/source/client/service_impl.cc
@@ -25,7 +25,7 @@ void ServiceImpl::handleExecutionRequest(const nighthawk::client::ExecutionReque
   OptionsPtr options;
   try {
     options = std::make_unique<OptionsImpl>(request.start_request().options());
-  } catch (MalformedArgvException e) {
+  } catch (const MalformedArgvException& e) {
     response.mutable_error_detail()->set_message(e.what());
     writeResponse(response);
     return;

--- a/source/server/http_test_server_filter.cc
+++ b/source/server/http_test_server_filter.cc
@@ -34,7 +34,7 @@ bool HttpTestServerDecoderFilter::mergeJsonConfig(absl::string_view json,
     Envoy::MessageUtil::loadFromJson(std::string(json), json_config, validation_visitor);
     config.MergeFrom(json_config);
     Envoy::MessageUtil::validate(config, validation_visitor);
-  } catch (Envoy::EnvoyException exception) {
+  } catch (const Envoy::EnvoyException& exception) {
     error_message.emplace(fmt::format("Error merging json config: {}", exception.what()));
   }
   return error_message == absl::nullopt;


### PR DESCRIPTION
Currently, `bazel build //:nighthawk` fails with the error below. The changes in this commit allow bazel build to pass by catching all exceptions as const references. This also follows standard practices for C++.

```
error: catching polymorphic type 'class Nighthawk::Client::MalformedArgvException' by value [-Werror=catch-value=]
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>