### PR TITLE
Wire up encoder callbacks

### DIFF
--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -76,6 +76,8 @@ void StreamDecoder::onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason
 void StreamDecoder::onPoolReady(Envoy::Http::StreamEncoder& encoder,
                                 Envoy::Upstream::HostDescriptionConstSharedPtr,
                                 const Envoy::StreamInfo::StreamInfo&) {
+  // Make sure we hear about stream resets on the encoder.
+  encoder.getStream().addCallbacks(*this);
   upstream_timing_.onFirstUpstreamTxByteSent(time_source_); // XXX(oschaaf): is this correct?
   encoder.encodeHeaders(*request_headers_, request_body_size_ == 0);
   if (request_body_size_ > 0) {

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -143,7 +143,7 @@ public:
   Envoy::Http::ConnectionPool::MockInstance pool_;
   Envoy::ProcessWide process_wide;
   std::vector<Envoy::Http::StreamDecoder*> decoders_;
-  Envoy::Http::MockStreamEncoder stream_encoder_;
+  NiceMock<Envoy::Http::MockStreamEncoder> stream_encoder_;
   Envoy::Upstream::MockThreadLocalCluster thread_local_cluster_;
   Envoy::Upstream::ClusterInfoConstSharedPtr cluster_info_;
   Envoy::Tracing::HttpTracerPtr http_tracer_;

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -104,6 +104,7 @@ TEST_F(StreamDecoderTest, LatencyIsNotMeasured) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   EXPECT_CALL(stream_encoder,
               encodeHeaders(Envoy::HeaderMapEqualRef(request_headers_.get()), true));
+  EXPECT_CALL(stream_encoder, getStream());
   decoder->onPoolReady(stream_encoder, ptr, stream_info);
   decoder->decodeHeaders(std::move(test_header_), true);
   EXPECT_EQ(0, connect_statistic_.count());
@@ -137,6 +138,7 @@ TEST_F(StreamDecoderTest, LatencyIsMeasured) {
       request_header, true, 0, TEST_TRACER_UID, http_tracer_);
 
   Envoy::Http::MockStreamEncoder stream_encoder;
+  EXPECT_CALL(stream_encoder, getStream());
   Envoy::Upstream::HostDescriptionConstSharedPtr ptr;
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   EXPECT_CALL(stream_encoder,


### PR DESCRIPTION
Stream decoders we create should be aware of any stream reset callbacks on the
associated encoder.

This change resolves a stall when the target server being tested
terminates mid-execution.
This was discovered while testing if the termination predicates
would timely trigger workers to exit.

Split out from https://github.com/envoyproxy/nighthawk/pull/167

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>