### PR TITLE
Remove default.profraw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ envoy/
 __pycache__
 tools/pyformat
 test/coverage/BUILD
+default.profraw


### PR DESCRIPTION
Remove accidentally committed file & add it to .gitignore.

Split out from https://github.com/envoyproxy/nighthawk/pull/167

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>