### PR TITLE
Request header option: fix a bug in handling ':'

### DIFF
--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -10,6 +10,7 @@
 
 #include "client/output_formatter_impl.h"
 
+#include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "fmt/ranges.h"
 #include "tclap/CmdLine.h"
@@ -364,13 +365,10 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
     // TODO(oschaaf): expose append option in CLI? For now we just set.
     header_value_option->mutable_append()->set_value(false);
     auto request_header = header_value_option->mutable_header();
-    std::vector<std::string> split_header = absl::StrSplit(
-        header, ':',
-        absl::SkipWhitespace()); // TODO(oschaaf): maybe throw when we find > 2 elements.
+    std::vector<std::string> split_header = absl::StrSplit(header, ':', absl::SkipWhitespace());
     request_header->set_key(split_header[0]);
-    if (split_header.size() == 2) {
-      request_header->set_value(split_header[1]);
-    }
+    split_header.erase(split_header.begin(), split_header.begin() + 1);
+    request_header->set_value(absl::StrJoin(split_header, ":"));
   }
   request_options->mutable_request_body_size()->set_value(requestBodySize());
   *(command_line_options->mutable_tls_context()) = tlsContext();

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -42,7 +42,8 @@ TEST_F(OptionsImplTest, All) {
       "{} --rps 4 --connections 5 --duration 6 --timeout 7 --h2 "
       "--concurrency 8 --verbosity error --output-format yaml --prefetch-connections "
       "--burst-size 13 --address-family v6 --request-method POST --request-body-size 1234 "
-      "--tls-context {} --request-header f1:b1 --request-header f2:b2 {} --max-pending-requests 10 "
+      "--tls-context {} --request-header f1:b1 --request-header f2:b2:a {} --max-pending-requests "
+      "10 "
       "--max-active-requests 11 --max-requests-per-connection 12 --sequencer-idle-strategy sleep",
       client_name_,
       "{common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}",
@@ -61,7 +62,7 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(nighthawk::client::AddressFamily::V6, options->addressFamily());
   EXPECT_EQ(good_test_uri_, options->uri());
   EXPECT_EQ(envoy::api::v2::core::RequestMethod::POST, options->requestMethod());
-  const std::vector<std::string> expected_headers = {"f1:b1", "f2:b2"};
+  const std::vector<std::string> expected_headers = {"f1:b1", "f2:b2:a"};
   EXPECT_EQ(expected_headers, options->requestHeaders());
   EXPECT_EQ(1234, options->requestBodySize());
   EXPECT_EQ("common_tls_context {\n  tls_params {\n    cipher_suites: "


### PR DESCRIPTION
Noticed while drafting https://github.com/envoyproxy/nighthawk/pull/192
We handle `:` badly in request header values when interpreting `--request-header`.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>