### PR TITLE
Change header arg parsing to support ':' in values.

### DIFF
--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -430,12 +430,13 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
     // TODO(oschaaf): expose append option in CLI? For now we just set.
     header_value_option->mutable_append()->set_value(false);
     auto request_header = header_value_option->mutable_header();
-    std::vector<std::string> split_header = absl::StrSplit(
-        header, ':',
-        absl::SkipWhitespace()); // TODO(oschaaf): maybe throw when we find > 2 elements.
-    request_header->set_key(split_header[0]);
-    if (split_header.size() == 2) {
-      request_header->set_value(split_header[1]);
+    auto pos = header.find(':');
+    if (pos != std::string::npos) {
+      request_header->set_key(header.substr(0, pos));
+      // Any visible char, including ':', is allowed in header values.
+      request_header->set_value(header.substr(pos + 1));
+    } else {
+      throw MalformedArgvException("A ':' is required in a header.");
     }
   }
   request_options->mutable_request_body_size()->set_value(requestBodySize());

--- a/test/client/utility.cc
+++ b/test/client/utility.cc
@@ -12,6 +12,10 @@ std::unique_ptr<OptionsImpl> TestUtility::createOptionsImpl(absl::string_view ar
   for (const std::string& s : words) {
     argv.push_back(s.c_str());
   }
+  return createOptionsImpl(argv);
+}
+
+std::unique_ptr<OptionsImpl> TestUtility::createOptionsImpl(const std::vector<const char*>& argv) {
   return std::make_unique<OptionsImpl>(argv.size(), argv.data());
 }
 

--- a/test/client/utility.h
+++ b/test/client/utility.h
@@ -12,7 +12,12 @@ namespace Client {
 
 class TestUtility {
 public:
+  // Create OptionsImpl from a concatenation of arguments delimited by space.
+  // Use the overload below if any argument should contain embedded spaces.
   static std::unique_ptr<OptionsImpl> createOptionsImpl(absl::string_view args);
+
+  // Create OptionsImpl from a vector of argument strings.
+  static std::unique_ptr<OptionsImpl> createOptionsImpl(const std::vector<const char*>& args);
 
 private:
   TestUtility() = default;

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -42,7 +42,8 @@ TEST_F(OptionsImplTest, All) {
       "{} --rps 4 --connections 5 --duration 6 --timeout 7 --h2 "
       "--concurrency 8 --verbosity error --output-format yaml --prefetch-connections "
       "--burst-size 13 --address-family v6 --request-method POST --request-body-size 1234 "
-      "--tls-context {} --request-header f1:b1 --request-header f2:b2 {} --max-pending-requests 10 "
+      "--tls-context {} --request-header f1:b1 --request-header f2:b2 --request-header f3:b3:b4 {} "
+      "--max-pending-requests 10 "
       "--max-active-requests 11 --max-requests-per-connection 12 --sequencer-idle-strategy sleep "
       "--termination-predicate t1:1 --termination-predicate t2:2 --failure-predicate f1:1 "
       "--failure-predicate f2:2 ",
@@ -63,7 +64,7 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(nighthawk::client::AddressFamily::V6, options->addressFamily());
   EXPECT_EQ(good_test_uri_, options->uri());
   EXPECT_EQ(envoy::api::v2::core::RequestMethod::POST, options->requestMethod());
-  const std::vector<std::string> expected_headers = {"f1:b1", "f2:b2"};
+  const std::vector<std::string> expected_headers = {"f1:b1", "f2:b2", "f3:b3:b4"};
   EXPECT_EQ(expected_headers, options->requestHeaders());
   EXPECT_EQ(1234, options->requestBodySize());
   EXPECT_EQ("common_tls_context {\n  tls_params {\n    cipher_suites: "
@@ -377,6 +378,25 @@ TEST_F(OptionsImplTest, SequencerIdleStrategyValuesAreConstrained) {
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
                               "{} {} --sequencer-idle-strategy foo", client_name_, good_test_uri_)),
                           MalformedArgvException, "--sequencer-idle-strategy");
+}
+
+TEST_F(OptionsImplTest, RequestHeaderWithoutColon) {
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format("{} --request-header bar {}",
+                                                                     client_name_, good_test_uri_)),
+                          MalformedArgvException, "is required in a header");
+}
+
+TEST_F(OptionsImplTest, RequestHeaderValueWithColonsAndSpaces) {
+  const std::string header("foo"), value(R"({ "bar": "baz" })");
+  const std::string header_option = fmt::format("{}:{}", header, value);
+  std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(std::vector<const char*>{
+      client_name_.c_str(), "--request-header", header_option.c_str(), good_test_uri_.c_str()});
+  EXPECT_EQ(std::vector<std::string>{header_option}, options->requestHeaders());
+  auto optionsPtr = options->toCommandLineOptions();
+  const auto& headers = optionsPtr->request_options().request_headers();
+  EXPECT_EQ(1, headers.size());
+  EXPECT_EQ(header, headers[0].header().key());
+  EXPECT_EQ(value, headers[0].header().value());
 }
 
 } // namespace Client


### PR DESCRIPTION
(This is a redo of pull#194).

This is needed to send server configuration through the
`x-nighthawk-test-server-config` request header. Besides, ':' and
whitespace are allowed in header values.

A header argument must contain a ':' that delimits the name and value.

Tested using `bazel test test:options_test` and invoking
`nighthawk_client` with argument `--request-header
'x-nighthawk-test-server-config: { "response_body_size": 1 }'`.

Signed-off-by: Jay Ramamurthi <jramamurthi@google.com>