### PR TITLE
Sequencer:  improve initial loop resolution

### DIFF
--- a/source/common/sequencer_impl.cc
+++ b/source/common/sequencer_impl.cc
@@ -36,7 +36,10 @@ void SequencerImpl::start() {
   if (start_time_ < time_source_.monotonicTime()) {
     ENVOY_LOG(error, "Sequencer start called too late");
   }
-  run(true);
+  // Initiate the periodic timer loop.
+  scheduleRun();
+  // Immediately run.
+  run(false);
 }
 
 void SequencerImpl::scheduleRun() { periodic_timer_->enableTimer(EnvoyTimerMinResolution); }

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -157,6 +157,7 @@ TEST_F(SequencerTestWithTimerEmulation, RateLimiterInteraction) {
       .WillRepeatedly(Return(false));
   EXPECT_CALL(*target(), callback(_)).Times(2).WillOnce(Return(true)).WillOnce(Return(true));
   expectDispatcherRun();
+  EXPECT_CALL(platform_util_, sleep(_)).Times(AtLeast(1));
   sequencer.start();
   sequencer.waitForCompletion();
 }
@@ -197,6 +198,7 @@ TEST_F(SequencerTestWithTimerEmulation, RateLimiterSaturatedTargetInteraction) {
   EXPECT_CALL(rate_limiter_unsafe_ref_, releaseOne()).Times(1);
   expectDispatcherRun();
 
+  EXPECT_CALL(platform_util_, sleep(_)).Times(AtLeast(1));
   sequencer.start();
   sequencer.waitForCompletion();
 }
@@ -263,7 +265,7 @@ TEST_F(SequencerIntegrationTest, AlwaysSaturatedTargetTest) {
                           std::make_unique<StreamingStatistic>(),
                           std::make_unique<StreamingStatistic>(), SequencerIdleStrategy::SLEEP,
                           termination_predicate, store_);
-
+  EXPECT_CALL(platform_util_, sleep(_)).Times(AtLeast(1));
   sequencer.start();
   sequencer.waitForCompletion();
 
@@ -282,7 +284,7 @@ TEST_F(SequencerIntegrationTest, CallbacksDoNotInfluenceTestDuration) {
                           std::make_unique<StreamingStatistic>(),
                           std::make_unique<StreamingStatistic>(), SequencerIdleStrategy::SLEEP,
                           termination_predicate, store_);
-
+  EXPECT_CALL(platform_util_, sleep(_)).Times(AtLeast(1));
   auto pre_timeout = time_system_.monotonicTime();
   sequencer.start();
   sequencer.waitForCompletion();


### PR DESCRIPTION
When it is time to start releasing requests, don't initiate
work via the deferred path (e.g. timers, sleep), but enter the tight
loop right away. 

Filed https://github.com/envoyproxy/nighthawk/issues/203 for tracking a good follow up to this.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>