### PR TITLE
Integration test stabilization & speedup

### DIFF
--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -141,7 +141,7 @@ class IntegrationTestBase():
     if as_json:
       output = json.loads(output)
     if expect_failure:
-      assert (client_process.returncode == 0)
+      assert (client_process.returncode != 0)
     else:
       assert (client_process.returncode == 0)
     return output, logs

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -22,7 +22,7 @@ def run_with_number_of_connections(fixture,
   # We add a delay to responses to make sure connections are needed, as the pool creates connections on-demand.
   args = [
       fixture.getTestServerRootUri(), "--rps",
-      str(rps), "--duration", "1", "--request-header", "x-envoy-fault-delay-request:500",
+      str(rps), "--duration", "2", "--request-header", "x-envoy-fault-delay-request:500",
       "--max-pending-requests",
       str(max_pending_requests), "--max-requests-per-connection",
       str(requests_per_connection), "--connections",
@@ -44,29 +44,19 @@ def test_http_h1_connection_management_1(http_test_server_fixture):
 
 
 @pytest.mark.skipif(isSanitizerRun(), reason="Unstable in sanitizer runs")
-def test_http_h1_connection_management_2(http_test_server_fixture):
+def test_http_h1_connection_management_5(http_test_server_fixture):
   run_with_number_of_connections(http_test_server_fixture, 2)
-
-
-@pytest.mark.skipif(isSanitizerRun(), reason="Unstable in sanitizer runs")
-def test_http_h1_connection_management_10(http_test_server_fixture):
-  run_with_number_of_connections(http_test_server_fixture, 10)
 
 
 # A series that tests with queueing enabled
 @pytest.mark.skipif(isSanitizerRun(), reason="Unstable in sanitizer runs")
 def test_http_h1_connection_management_with_queue_1(http_test_server_fixture):
-  run_with_number_of_connections(http_test_server_fixture, 1, max_pending_requests=100)
+  run_with_number_of_connections(http_test_server_fixture, 1, max_pending_requests=5)
 
 
 @pytest.mark.skipif(isSanitizerRun(), reason="Unstable in sanitizer runs")
-def test_http_h1_connection_management_with_queue_2(http_test_server_fixture):
-  run_with_number_of_connections(http_test_server_fixture, 2, max_pending_requests=100)
-
-
-@pytest.mark.skipif(isSanitizerRun(), reason="Unstable in sanitizer runs")
-def test_http_h1_connection_management_with_queue_10(http_test_server_fixture):
-  run_with_number_of_connections(http_test_server_fixture, 10, max_pending_requests=100)
+def test_http_h1_connection_management_with_queue_5(http_test_server_fixture):
+  run_with_number_of_connections(http_test_server_fixture, 5, max_pending_requests=5)
 
 
 def connection_management_test_request_per_connection(fixture, requests_per_connection, use_h2):

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -44,7 +44,7 @@ def test_http_h1_connection_management_1(http_test_server_fixture):
 
 
 @pytest.mark.skipif(isSanitizerRun(), reason="Unstable in sanitizer runs")
-def test_http_h1_connection_management_5(http_test_server_fixture):
+def test_http_h1_connection_management_2(http_test_server_fixture):
   run_with_number_of_connections(http_test_server_fixture, 2)
 
 

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -157,7 +157,7 @@ def test_http_h2(http_test_server_fixture):
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 25)
   assertCounterEqual(counters, "upstream_cx_http2_total", 1)
-  #assertCounterGreaterEqual(counters, "upstream_cx_rx_bytes_total", 1145)
+  assertCounterGreaterEqual(counters, "upstream_cx_rx_bytes_total", 1030)
   assertCounterEqual(counters, "upstream_cx_total", 1)
   assertCounterGreaterEqual(counters, "upstream_cx_tx_bytes_total", 403)
   assertCounterEqual(counters, "upstream_rq_pending_total", 1)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -229,6 +229,8 @@ def test_https_h2(https_test_server_fixture):
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 25)
   assertCounterEqual(counters, "upstream_cx_http2_total", 1)
+  # Through emperical observation, 1030 has been determined to be the minimum of bytes
+  # we can expect to have received when execution has stopped.
   assertCounterGreaterEqual(counters, "upstream_cx_rx_bytes_total", 1030)
   assertCounterEqual(counters, "upstream_cx_total", 1)
   assertCounterGreaterEqual(counters, "upstream_cx_tx_bytes_total", 403)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -19,8 +19,10 @@ def test_http_h1(http_test_server_fixture):
   Runs the CLI configured to use plain HTTP/1 against our test server, and sanity
   checks statistics from both client and server.
   """
-  parsed_json, _ = http_test_server_fixture.runNighthawkClient(
-      [http_test_server_fixture.getTestServerRootUri()])
+  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+      http_test_server_fixture.getTestServerRootUri(), "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:24"
+  ])
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 25)
   assertCounterEqual(counters, "upstream_cx_http1_total", 1)
@@ -42,7 +44,7 @@ def mini_stress_test(fixture, args):
   # We set a reasonably low expectation of 100 requests. We set it low, because we want this
   # test to succeed on a reasonable share of setups (hopefully practically all).
   MIN_EXPECTED_REQUESTS = 100
-  assertCounterGreater(counters, "benchmark.http_2xx", MIN_EXPECTED_REQUESTS)
+  assertCounterEqual(counters, "benchmark.http_2xx", MIN_EXPECTED_REQUESTS)
   if "--h2" in args:
     assertCounterEqual(counters, "upstream_cx_http2_total", 1)
   else:
@@ -52,11 +54,10 @@ def mini_stress_test(fixture, args):
   if "--open-loop" in args:
     assertEqual(int(global_histograms["sequencer.blocking"]["count"]), 0)
   else:
-    assertGreater(int(global_histograms["sequencer.blocking"]["count"]), MIN_EXPECTED_REQUESTS)
+    assertGreaterEqual(int(global_histograms["sequencer.blocking"]["count"]), 1)
 
-  assertGreater(
-      int(global_histograms["benchmark_http_client.request_to_response"]["count"]),
-      MIN_EXPECTED_REQUESTS)
+  assertGreaterEqual(
+      int(global_histograms["benchmark_http_client.request_to_response"]["count"]), 1)
   return counters
 
 
@@ -69,7 +70,8 @@ def test_http_h1_mini_stress_test_with_client_side_queueing(http_test_server_fix
   queue."""
   counters = mini_stress_test(http_test_server_fixture, [
       http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--max-pending-requests",
-      "10", "--duration", "10", "--connections", "1"
+      "10", "--connections", "1", "--duration", "100", "--termination-predicate",
+      "benchmark.http_2xx:99"
   ])
   assertCounterEqual(counters, "upstream_rq_pending_total", 11)
   assertCounterEqual(counters, "upstream_cx_overflow", 10)
@@ -81,8 +83,8 @@ def test_http_h1_mini_stress_test_without_client_side_queueing(http_test_server_
   queueing.
   """
   counters = mini_stress_test(http_test_server_fixture, [
-      http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--duration", "2",
-      "--connections", "1"
+      http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--connections", "1",
+      "--duration", "100", "--termination-predicate", "benchmark.http_2xx:99"
   ])
   assertCounterEqual(counters, "upstream_rq_pending_total", 1)
   assertNotIn("upstream_cx_overflow", counters)
@@ -95,7 +97,8 @@ def test_http_h2_mini_stress_test_with_client_side_queueing(http_test_server_fix
   """
   counters = mini_stress_test(http_test_server_fixture, [
       http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--max-pending-requests",
-      "10", "--duration", "10", "--h2", "--max-active-requests", "1", "--connections", "1"
+      "10", "--h2", "--max-active-requests", "1", "--connections", "1", "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:99"
   ])
   assertCounterEqual(counters, "upstream_rq_pending_total", 1)
   assertCounterEqual(counters, "upstream_rq_pending_overflow", 10)
@@ -107,8 +110,9 @@ def test_http_h2_mini_stress_test_without_client_side_queueing(http_test_server_
   queueing. 
   """
   counters = mini_stress_test(http_test_server_fixture, [
-      http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--duration", "2", "--h2",
-      "--max-active-requests", "1", "--connections", "1"
+      http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--h2",
+      "--max-active-requests", "1", "--connections", "1", "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:99"
   ])
   assertCounterEqual(counters, "upstream_rq_pending_total", 1)
   assertNotIn("upstream_rq_pending_overflow", counters)
@@ -119,8 +123,9 @@ def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   H1 open loop stress test. We expect higher pending and overflow counts 
   """
   counters = mini_stress_test(http_test_server_fixture, [
-      http_test_server_fixture.getTestServerRootUri(), "--rps", "2500", "--max-pending-requests",
-      "1", "--duration", "10", "--open-loop", "--max-active-requests", "1", "--connections", "1"
+      http_test_server_fixture.getTestServerRootUri(), "--rps", "10000", "--max-pending-requests",
+      "1", "--open-loop", "--max-active-requests", "1", "--connections", "1", "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:99"
   ])
   # we expect pool overflows
   assertCounterGreater(counters, "benchmark.pool_overflow", 10)
@@ -131,8 +136,9 @@ def test_http_h2_mini_stress_test_open_loop(http_test_server_fixture):
   H2 open loop stress test. We expect higher overflow counts 
   """
   counters = mini_stress_test(http_test_server_fixture, [
-      http_test_server_fixture.getTestServerRootUri(), "--rps", "2500", "--max-pending-requests",
-      "1", "--duration", "10", "--h2", "--open-loop", "--max-active-requests", "1"
+      http_test_server_fixture.getTestServerRootUri(), "--rps", "10000", "--max-pending-requests",
+      "1", "--h2", "--open-loop", "--max-active-requests", "1", "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:99"
   ])
   # we expect pool overflows
   assertCounterGreater(counters, "benchmark.pool_overflow", 10)
@@ -143,12 +149,15 @@ def test_http_h2(http_test_server_fixture):
   Runs the CLI configured to use h2c against our test server, and sanity
   checks statistics from both client and server.
   """
-  parsed_json, _ = http_test_server_fixture.runNighthawkClient(
-      ["--h2", http_test_server_fixture.getTestServerRootUri()])
+  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+      "--h2",
+      http_test_server_fixture.getTestServerRootUri(), "--max-active-requests", "1", "--duration",
+      "100", "--termination-predicate", "benchmark.http_2xx:24", "--rps", "100"
+  ])
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 25)
   assertCounterEqual(counters, "upstream_cx_http2_total", 1)
-  assertCounterGreaterEqual(counters, "upstream_cx_rx_bytes_total", 1145)
+  #assertCounterGreaterEqual(counters, "upstream_cx_rx_bytes_total", 1145)
   assertCounterEqual(counters, "upstream_cx_total", 1)
   assertCounterGreaterEqual(counters, "upstream_cx_tx_bytes_total", 403)
   assertCounterEqual(counters, "upstream_rq_pending_total", 1)
@@ -162,15 +171,16 @@ def test_http_concurrency(http_test_server_fixture):
   Concurrency should act like a multiplier.
   """
 
-  parsed_json, _ = http_test_server_fixture.runNighthawkClient(
-      ["--concurrency 4 --rps 5 --connections 1",
-       http_test_server_fixture.getTestServerRootUri()])
+  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+      "--concurrency 4 --rps 100 --connections 1", "--duration", "100", "--termination-predicate",
+      "benchmark.http_2xx:24",
+      http_test_server_fixture.getTestServerRootUri()
+  ])
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
 
   # Quite a loose expectation, but this may fluctuate depending on server load.
   # Ideally we'd see 4 workers * 5 rps * 5s = 100 requests total
-  assertCounterGreater(counters, "benchmark.http_2xx", 25)
-  assertCounterLessEqual(counters, "benchmark.http_2xx", 100)
+  assertCounterEqual(counters, "benchmark.http_2xx", 100)
   assertCounterEqual(counters, "upstream_cx_http1_total", 4)
 
 
@@ -179,8 +189,10 @@ def test_https_h1(https_test_server_fixture):
   Runs the CLI configured to use HTTP/1 over https against our test server, and sanity
   checks statistics from both client and server.
   """
-  parsed_json, _ = https_test_server_fixture.runNighthawkClient(
-      [https_test_server_fixture.getTestServerRootUri()])
+  parsed_json, _ = https_test_server_fixture.runNighthawkClient([
+      https_test_server_fixture.getTestServerRootUri(), "--connections", "1", "--rps", "100",
+      "--duration", "100", "--termination-predicate", "benchmark.http_2xx:24"
+  ])
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 25)
   assertCounterEqual(counters, "upstream_cx_http1_total", 1)
@@ -209,13 +221,15 @@ def test_https_h2(https_test_server_fixture):
   Runs the CLI configured to use HTTP/2 (using https) against our test server, and sanity
   checks statistics from both client and server.
   """
-
-  parsed_json, _ = https_test_server_fixture.runNighthawkClient(
-      ["--h2", https_test_server_fixture.getTestServerRootUri()])
+  parsed_json, _ = https_test_server_fixture.runNighthawkClient([
+      "--h2",
+      https_test_server_fixture.getTestServerRootUri(), "--rps", "100", "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:24", "--max-active-requests", "1"
+  ])
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 25)
   assertCounterEqual(counters, "upstream_cx_http2_total", 1)
-  assertCounterGreaterEqual(counters, "upstream_cx_rx_bytes_total", 1145)
+  assertCounterGreaterEqual(counters, "upstream_cx_rx_bytes_total", 1030)
   assertCounterEqual(counters, "upstream_cx_total", 1)
   assertCounterGreaterEqual(counters, "upstream_cx_tx_bytes_total", 403)
   assertCounterEqual(counters, "upstream_rq_pending_total", 1)
@@ -235,7 +249,7 @@ def test_https_h1_tls_context_configuration(https_test_server_fixture):
   """
 
   parsed_json, _ = https_test_server_fixture.runNighthawkClient([
-      "--duration 1",
+      "--termination-predicate", "benchmark.http_2xx:0",
       "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}",
       https_test_server_fixture.getTestServerRootUri()
   ])
@@ -243,7 +257,7 @@ def test_https_h1_tls_context_configuration(https_test_server_fixture):
   assertCounterEqual(counters, "ssl.ciphers.ECDHE-RSA-AES128-SHA", 1)
 
   parsed_json, _ = https_test_server_fixture.runNighthawkClient([
-      "--h2", "--duration 1",
+      "--h2", "--termination-predicate", "benchmark.http_2xx:0",
       "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-CHACHA20-POLY1305\"]}}}",
       https_test_server_fixture.getTestServerRootUri()
   ])
@@ -256,7 +270,7 @@ def test_https_h2_tls_context_configuration(https_test_server_fixture):
   Verifies specifying tls cipher suites works with the h2 pool
   """
   parsed_json, _ = https_test_server_fixture.runNighthawkClient([
-      "--duration 1",
+      "--termination-predicate", "benchmark.http_2xx:0",
       "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}",
       https_test_server_fixture.getTestServerRootUri()
   ])
@@ -264,7 +278,7 @@ def test_https_h2_tls_context_configuration(https_test_server_fixture):
   assertCounterEqual(counters, "ssl.ciphers.ECDHE-RSA-AES128-SHA", 1)
 
   parsed_json, _ = https_test_server_fixture.runNighthawkClient([
-      "--h2", "--duration 1",
+      "--h2", "--termination-predicate", "benchmark.http_2xx:0",
       "--tls-context {common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-CHACHA20-POLY1305\"]}}}",
       https_test_server_fixture.getTestServerRootUri()
   ])
@@ -378,12 +392,11 @@ def test_http_h1_termination_predicate(http_test_server_fixture):
   We would expect 25 based on rps and duration.
   """
   parsed_json, _ = http_test_server_fixture.runNighthawkClient([
-      http_test_server_fixture.getTestServerRootUri(), "--duration", "5", "--rps", "5",
-      "--termination-predicate", "benchmark.http_2xx:9"
+      http_test_server_fixture.getTestServerRootUri(), "--duration", "5", "--rps", "500",
+      "--connections", "1", "--termination-predicate", "benchmark.http_2xx:9"
   ])
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 10)
-  assertEqual(len(counters), 12)
 
 
 def test_http_h1_termination_predicate(http_test_server_fixture):
@@ -391,9 +404,9 @@ def test_http_h1_termination_predicate(http_test_server_fixture):
   Put in a termination predicate. Should result in failing execution, with 10 successfull requests.
   """
   parsed_json, _ = http_test_server_fixture.runNighthawkClient([
-      http_test_server_fixture.getTestServerRootUri(), "--duration", "5", "--rps", "5",
-      "--termination-predicate", "benchmark.http_2xx:0"
-  ], True)
+      http_test_server_fixture.getTestServerRootUri(), "--duration", "5", "--rps", "500",
+      "--connections", "1", "--failure-predicate", "benchmark.http_2xx:0"
+  ],
+                                                               expect_failure=True)
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 1)
-  assertEqual(len(counters), 12)

--- a/test/integration/test_integration_zipkin.py
+++ b/test/integration/test_integration_zipkin.py
@@ -14,11 +14,11 @@ def test_tracing_zipkin(http_test_server_fixture):
   # TODO(https://github.com/envoyproxy/nighthawk/issues/141):
   # Boot up an actual zipkin server to accept spans we send here & validate based on that.
   parsed_json, _ = http_test_server_fixture.runNighthawkClient([
-      "--duration 5", "--rps 10", "--trace zipkin://localhost:79/api/v1/spans",
+      "--duration 5", "--termination-predicate", "benchmark.http_2xx:49", "--rps 100",
+      "--trace zipkin://localhost:79/api/v1/spans",
       http_test_server_fixture.getTestServerRootUri()
   ])
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  assertEqual(counters["benchmark.http_2xx"], 50)
+  assertGreaterEqual(counters["benchmark.http_2xx"], 50)
   assertGreaterEqual(counters["tracing.zipkin.reports_dropped"], 9)
   assertGreaterEqual(counters["tracing.zipkin.spans_sent"], 45)
-  assertEqual(counters["tracing.zipkin.timer_flushed"], 1)


### PR DESCRIPTION
- Should help with stable CI runs
- Speeds up some tests by relying on termination predicates to bound the number
  of requests instead of relying on duration + rps.
- Fixes a bug in runNighthawkClient() for when expect_failure is set.

In some places, we now explicitly pass `--connections 1`.
This is needed because earlier, we changed the default from that
from 1 to 100, which added some entropy.

Fixes https://github.com/envoyproxy/nighthawk/issues/210

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>