### PR TITLE
Introduce Request / prepare dynamic request generation

### DIFF
--- a/include/nighthawk/client/BUILD
+++ b/include/nighthawk/client/BUILD
@@ -23,6 +23,7 @@ envoy_basic_cc_library(
         ":output_formatter_lib",
         "//api/client:base_cc_proto",
         "//include/nighthawk/common:base_includes",
+        "//include/nighthawk/common:request_source_lib",
         "@envoy//include/envoy/common:base_includes",
         "@envoy//include/envoy/http:conn_pool_interface_with_external_headers",
         "@envoy//source/common/api:api_lib_with_external_headers",

--- a/include/nighthawk/common/BUILD
+++ b/include/nighthawk/common/BUILD
@@ -24,11 +24,35 @@ envoy_basic_cc_library(
     ],
     include_prefix = "nighthawk/common",
     deps = [
+        ":request_lib",
         "@envoy//include/envoy/common:base_includes",
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/common/common:non_copyable",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/network:dns_lib",
         "@envoy//source/common/protobuf",
+    ],
+)
+
+envoy_basic_cc_library(
+    name = "request_lib",
+    hdrs = [
+        "request.h",
+    ],
+    include_prefix = "nighthawk/common",
+    deps = [
+        "@envoy//source/common/http:headers_lib",
+    ],
+)
+
+envoy_basic_cc_library(
+    name = "request_source_lib",
+    hdrs = [
+        "request_source.h",
+    ],
+    include_prefix = "nighthawk/common",
+    deps = [
+        ":request_lib",
+        "@envoy//source/common/http:headers_lib",
     ],
 )

--- a/include/nighthawk/common/request.h
+++ b/include/nighthawk/common/request.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <functional>
+
+#include "envoy/http/header_map.h"
+
+namespace Nighthawk {
+
+using HeaderMapPtr = std::shared_ptr<const Envoy::Http::HeaderMap>;
+
+/**
+ * Defines the specifics of requests to be send by the load generator, as well as
+ * may hold request-level expectations.
+ */
+class Request {
+public:
+  virtual ~Request() = default;
+  virtual HeaderMapPtr header() const PURE;
+  // TODO(oschaaf): expectations
+};
+
+using RequestPtr = std::unique_ptr<Request>;
+
+} // namespace Nighthawk

--- a/include/nighthawk/common/request_source.h
+++ b/include/nighthawk/common/request_source.h
@@ -4,10 +4,11 @@
 
 #include "envoy/http/header_map.h"
 
+#include "nighthawk/common/request.h"
+
 namespace Nighthawk {
 
-using HeaderMapPtr = std::shared_ptr<const Envoy::Http::HeaderMap>;
-using RequestGenerator = std::function<HeaderMapPtr()>;
+using RequestGenerator = std::function<RequestPtr()>;
 
 class RequestSource {
 public:

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -40,6 +40,7 @@ envoy_cc_library(
         "//api/client:base_cc_proto",
         "//include/nighthawk/client:client_includes",
         "//include/nighthawk/common:base_includes",
+        "//source/common:request_source_impl_lib",
         "//source/common:nighthawk_common_lib",
         "@envoy//source/common/access_log:access_log_manager_lib_with_external_headers",
         "@envoy//source/common/api:api_lib_with_external_headers",

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -82,11 +82,11 @@ bool BenchmarkClientHttpImpl::tryStartRequest(CompletionCallback caller_completi
       return false;
     }
   }
-  auto header = request_generator_();
-  auto* content_length_header = header->ContentLength();
+  auto request = request_generator_();
+  auto* content_length_header = request->header()->ContentLength();
   uint64_t content_length = 0;
   if (content_length_header != nullptr) {
-    auto s_content_length = header->ContentLength()->value().getStringView();
+    auto s_content_length = content_length_header->value().getStringView();
     if (!absl::SimpleAtoi(s_content_length, &content_length)) {
       ENVOY_LOG(error, "Ignoring bad content length of {}", s_content_length);
       content_length = 0;
@@ -96,7 +96,7 @@ bool BenchmarkClientHttpImpl::tryStartRequest(CompletionCallback caller_completi
   std::string x_request_id = generator_.uuid();
   auto stream_decoder = new StreamDecoder(
       dispatcher_, api_.timeSource(), *this, std::move(caller_completion_callback),
-      *connect_statistic_, *response_statistic_, std::move(header), measureLatencies(),
+      *connect_statistic_, *response_statistic_, request->header(), measureLatencies(),
       content_length, x_request_id, http_tracer_);
   requests_initiated_++;
   pool_ptr->newStream(*stream_decoder, *stream_decoder);

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -69,7 +69,6 @@ public:
                           Envoy::Tracing::HttpTracerPtr& http_tracer,
                           absl::string_view cluster_name, RequestGenerator request_generator,
                           const bool provide_resource_backpressure);
-
   void setConnectionLimit(uint32_t connection_limit) { connection_limit_ = connection_limit; }
   void setMaxPendingRequests(uint32_t max_pending_requests) {
     max_pending_requests_ = max_pending_requests;

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -121,8 +121,9 @@ RequestSourcePtr RequestSourceFactoryImpl::create() const {
   header->insertScheme().value(uri.scheme() == "https"
                                    ? Envoy::Http::Headers::get().SchemeValues.Https
                                    : Envoy::Http::Headers::get().SchemeValues.Http);
-  if (options_.requestBodySize()) {
-    header->insertContentLength().value(options_.requestBodySize());
+  const uint32_t content_length = options_.requestBodySize();
+  if (content_length > 0) {
+    header->insertContentLength().value(content_length);
   }
 
   auto request_options = options_.toCommandLineOptions()->request_options();

--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -9,10 +9,39 @@ load(
 envoy_package()
 
 envoy_cc_library(
+    name = "request_impl_lib",
+    hdrs = [
+        "request_impl.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":nighthawk_common_lib",
+        "//include/nighthawk/common:request_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "request_source_impl_lib",
+    srcs = [
+        "request_source_impl.cc",
+    ],
+    hdrs = [
+        "request_source_impl.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":nighthawk_common_lib",
+        ":request_impl_lib",
+        "//include/nighthawk/common:request_source_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "nighthawk_common_lib",
     srcs = [
         "rate_limiter_impl.cc",
-        "request_source_impl.cc",
         "sequencer_impl.cc",
         "statistic_impl.cc",
         "termination_predicate_impl.cc",
@@ -24,7 +53,6 @@ envoy_cc_library(
         "frequency.h",
         "platform_util_impl.h",
         "rate_limiter_impl.h",
-        "request_source_impl.h",
         "sequencer_impl.h",
         "statistic_impl.h",
         "termination_predicate_impl.h",

--- a/source/common/request_impl.h
+++ b/source/common/request_impl.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "envoy/http/header_map.h"
+
+#include "nighthawk/common/request.h"
+
+namespace Nighthawk {
+
+class RequestImpl : public Request {
+public:
+  RequestImpl(HeaderMapPtr header) : header_(std::move(header)) {}
+  HeaderMapPtr header() const override { return header_; }
+
+private:
+  HeaderMapPtr header_;
+};
+
+} // namespace Nighthawk

--- a/source/common/request_source_impl.cc
+++ b/source/common/request_source_impl.cc
@@ -2,8 +2,9 @@
 
 #include "external/envoy/source/common/common/assert.h"
 
+#include "common/request_impl.h"
+
 namespace Nighthawk {
-namespace Client {
 
 StaticRequestSourceImpl::StaticRequestSourceImpl(Envoy::Http::HeaderMapPtr&& header,
                                                  const uint64_t max_yields)
@@ -12,13 +13,12 @@ StaticRequestSourceImpl::StaticRequestSourceImpl(Envoy::Http::HeaderMapPtr&& hea
 }
 
 RequestGenerator StaticRequestSourceImpl::get() {
-  return [this]() -> HeaderMapPtr {
+  return [this]() -> RequestPtr {
     while (yields_left_--) {
-      return header_;
+      return std::make_unique<RequestImpl>(header_);
     }
     return nullptr;
   };
 }
 
-} // namespace Client
 } // namespace Nighthawk

--- a/source/common/request_source_impl.h
+++ b/source/common/request_source_impl.h
@@ -2,12 +2,19 @@
 
 #include "envoy/http/header_map.h"
 
+#include "nighthawk/common/request.h"
 #include "nighthawk/common/request_source.h"
 
-namespace Nighthawk {
-namespace Client {
+#include "external/envoy/source/common/common/logger.h"
 
-class StaticRequestSourceImpl : public RequestSource {
+
+namespace Nighthawk {
+
+class BaseRequestSourceImpl : public RequestSource,
+                              public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
+};
+
+class StaticRequestSourceImpl : public BaseRequestSourceImpl {
 public:
   StaticRequestSourceImpl(Envoy::Http::HeaderMapPtr&&, const uint64_t max_yields = UINT64_MAX);
   RequestGenerator get() override;
@@ -17,5 +24,4 @@ private:
   uint64_t yields_left_;
 };
 
-} // namespace Client
 } // namespace Nighthawk

--- a/source/common/request_source_impl.h
+++ b/source/common/request_source_impl.h
@@ -7,12 +7,10 @@
 
 #include "external/envoy/source/common/common/logger.h"
 
-
 namespace Nighthawk {
 
 class BaseRequestSourceImpl : public RequestSource,
-                              public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
-};
+                              public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {};
 
 class StaticRequestSourceImpl : public BaseRequestSourceImpl {
 public:

--- a/test/BUILD
+++ b/test/BUILD
@@ -26,6 +26,7 @@ envoy_cc_test(
     srcs = ["benchmark_http_client_test.cc"],
     repository = "@envoy",
     deps = [
+        "//source/common:request_impl_lib",
         "//test:nighthawk_mocks",
         "//test/test_common:environment_lib",
         "@envoy//source/common/http:header_map_lib_with_external_headers",
@@ -265,6 +266,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/client:nighthawk_client_lib",
+        "//source/client:nighthawk_service_lib",
         "//source/common:nighthawk_common_lib",
         "//source/server:http_test_server_filter_lib",
         "//test/test_common:environment_lib",

--- a/test/request_generator_test.cc
+++ b/test/request_generator_test.cc
@@ -18,7 +18,7 @@ TEST_F(RequestSourceTest, StaticRequestSourceImpl) {
   StaticRequestSourceImpl impl(std::move(header), yields);
   auto generator = impl.get();
   while (yields--) {
-    ASSERT_EQ(generator().get(), unsafe_header_ptr);
+    ASSERT_EQ(generator()->header().get(), unsafe_header_ptr);
   }
   ASSERT_EQ(generator(), nullptr);
 }


### PR DESCRIPTION
This adds infrastructure in preparation of
sending dynamic requests / validating request-level expectations.

No functional changes.

Prelude to #137, where add a feature which
streams  to-be replayed requests from a gRPC remote service method.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>