### PR TITLE
Fix opt build of nighthawk_service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,13 @@ jobs:
     steps:
       - checkout
       - run: ci/do_ci.sh build
+  opt_build:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh opt_build
   test:
     docker:
       - image: *envoy-build-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ workflows:
   all:
     jobs:
       - build
+      - opt_build
       - test
       - clang_tidy
 #      - test_with_valgrind

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -6,9 +6,12 @@ export BUILDIFIER_BIN="/usr/local/bin/buildifier"
 export BUILDOZER_BIN="/usr/local/bin/buildozer"
 
 function do_build () {
-    bazel build $BAZEL_BUILD_OPTIONS --verbose_failures=true //:nighthawk_client //:nighthawk_test_server \
-        //:nighthawk_service
+    bazel build $BAZEL_BUILD_OPTIONS --verbose_failures=true //:nighthawk
     tools/update_cli_readme_documentation.sh --mode check
+}
+
+function do_opt_build () {
+    bazel build $BAZEL_BUILD_OPTIONS -c opt --verbose_failures=true //:nighthawk
 }
 
 function do_test() {
@@ -142,6 +145,9 @@ export CLANG_FORMAT=clang-format
 case "$1" in
     build)
         do_build
+        exit 0
+    opt_build)
+        do_opt_build
         exit 0
     ;;
     test)

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -146,6 +146,7 @@ case "$1" in
     build)
         do_build
         exit 0
+    ;;
     opt_build)
         do_opt_build
         exit 0

--- a/source/client/service_main.cc
+++ b/source/client/service_main.cc
@@ -102,7 +102,7 @@ void ServiceMain::onSignal() { initiateShutdown(); }
 void ServiceMain::initiateShutdown() {
   if (pipe_fds_.size() == 2) {
     const int tmp = 0;
-    write(pipe_fds_[1], &tmp, sizeof(int));
+    RELEASE_ASSERT(write(pipe_fds_[1], &tmp, sizeof(int)) == sizeof(int), "write failed");
   }
 }
 


### PR DESCRIPTION
- Don't  ignore return value of `write()`
- Add opt build to CI to avoid regression
- While at it, I noticed CI didn't target the output transform utility.
  Amend that, and just target the `nighthawk` target, which will build
  all binaries.

Fixes https://github.com/envoyproxy/nighthawk/issues/233

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>