### PR TITLE
Address CLI incidental argument error suppression

### DIFF
--- a/source/exe/client_main_entry.cc
+++ b/source/exe/client_main_entry.cc
@@ -19,8 +19,10 @@ int main(int argc, char** argv) {
   } catch (const Nighthawk::Client::NoServingException& e) {
     return EXIT_SUCCESS;
   } catch (const Nighthawk::Client::MalformedArgvException& e) {
+    std::cerr << "Bad argument: " << e.what() << std::endl;
     return EXIT_FAILURE;
   } catch (const Nighthawk::NighthawkException& e) {
+    std::cerr << "An unknown error occurred: " << e.what() << std::endl;
     return EXIT_FAILURE;
   }
   return client->run() ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -412,3 +412,15 @@ def test_http_h1_failure_predicate(http_test_server_fixture):
                                                                expect_failure=True)
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   assertCounterEqual(counters, "benchmark.http_2xx", 1)
+
+
+def test_bad_arg_error_messages(http_test_server_fixture):
+  """
+  Test arguments that pass proto validation, but are found to be no good nonetheless, result in reasonable error
+  messages.
+  """
+  _, err = http_test_server_fixture.runNighthawkClient(
+      [http_test_server_fixture.getTestServerRootUri(), "--termination-predicate ", "a:a"],
+      expect_failure=True,
+      as_json=False)
+  assert "Bad argument: Termination predicate 'a:a' has an out of range threshold." in err


### PR DESCRIPTION
The CLI doesn't output a helpful error message when an argument
is supplied that passes proto validation but is found to be no good
nonetheless later on.

Fixes https://github.com/envoyproxy/nighthawk/issues/236

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>