### PR TITLE
Update MAINTAINERS.md: mention pre-merge commit message cleanup

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,10 @@ Envoy internals.
 - Does the PR have breaking changes? Then that should be explicitly mentioned in the [version history](docs/root/version_history.md).
 - New features should be added to the [version history](docs/root/version_history.md).
 - Breaking changes to the [protobuf APIs](api/) are not allowed.
+- When merging, clean up the commit message so we get a nice history. By default,
+  github will compile a messages from all the commits that are squashed.
+  The PR title and description should be a good starting point for the final commit message. 
+  (If it is not, it may be worth asking the PR author to update the description).
 
 ## Updates to the Envoy dependency
 


### PR DESCRIPTION
Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>