### PR TITLE
Labels option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ bazel build -c opt //:nighthawk
 ```
 USAGE:
 
-bazel-bin/nighthawk_client  [--jitter-uniform <duration>] [--open-loop]
+bazel-bin/nighthawk_client  [--label <<string>>] ... [--jitter-uniform
+<duration>] [--open-loop]
 [--experimental-h1-connection-reuse-strategy
 <mru|lru>] [--failure-predicate <<string,
 uint64_t>>] ... [--termination-predicate
@@ -69,6 +70,10 @@ format>
 
 
 Where:
+
+--label <<string>>  (accepted multiple times)
+Label. Allows specifying multiple labels which will be persisted in
+structured output formats.
 
 --jitter-uniform <duration>
 Add uniformly distributed absolute request-release timing jitter. For

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ bazel build -c opt //:nighthawk
 ```
 USAGE:
 
-bazel-bin/nighthawk_client  [--label <<string>>] ... [--jitter-uniform
+bazel-bin/nighthawk_client  [--label <string>] ... [--jitter-uniform
 <duration>] [--open-loop]
 [--experimental-h1-connection-reuse-strategy
 <mru|lru>] [--failure-predicate <<string,
@@ -71,7 +71,7 @@ format>
 
 Where:
 
---label <<string>>  (accepted multiple times)
+--label <string>  (accepted multiple times)
 Label. Allows specifying multiple labels which will be persisted in
 structured output formats.
 

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -139,4 +139,6 @@ message CommandLineOptions {
   google.protobuf.BoolValue open_loop = 21;
   // See :option:`--jitter-uniform`
   google.protobuf.Duration jitter_uniform = 25 [(validate.rules).duration.gte.nanos = 1];
+  // See :option:`--labels`
+  repeated string labels = 28;
 }

--- a/api/client/transform/fortio.proto
+++ b/api/client/transform/fortio.proto
@@ -15,6 +15,13 @@ message FortioResult {
   // The field cases must match the final output JSON that fortio-ui expects.
   option (validate.disabled) = true;
 
+  // From https://github.com/fortio/fortio/wiki/FAQ:
+  // If using the command line, don't forget to use -a to auto save the json results in the current
+  // data directory. And to use labels -labels "x y z" so the file name and the json include some
+  // description of your run. You can later run fortio report to browse
+  // graphically your results.
+  // The Nighthawk equivalent of this field is structured as a repeated string, which will be
+  // concatenated into this field, using ' ' as a separator.
   string Labels = 1;
 
   google.protobuf.Timestamp StartTime = 2;

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -50,6 +50,7 @@ public:
   virtual TerminationPredicateMap failurePredicates() const PURE;
   virtual bool openLoop() const PURE;
   virtual std::chrono::nanoseconds jitterUniform() const PURE;
+  virtual std::vector<std::string> labels() const PURE;
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option
    * values.

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -205,7 +205,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::MultiArg<std::string> labels("", "label",
                                       "Label. Allows specifying multiple labels which will be "
                                       "persisted in structured output formats.",
-                                      false, "<string>", cmd);
+                                      false, "string", cmd);
   TCLAP::UnlabeledValueArg<std::string> uri("uri",
                                             "uri to benchmark. http:// and https:// are supported, "
                                             "but in case of https no certificates are validated.",

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -62,6 +62,7 @@ public:
   bool openLoop() const override { return open_loop_; }
 
   std::chrono::nanoseconds jitterUniform() const override { return jitter_uniform_; }
+  std::vector<std::string> labels() const override { return labels_; };
 
 private:
   void parsePredicates(const TCLAP::MultiArg<std::string>& arg,
@@ -101,6 +102,7 @@ private:
   TerminationPredicateMap failure_predicates_;
   bool open_loop_{false};
   std::chrono::nanoseconds jitter_uniform_;
+  std::vector<std::string> labels_;
 };
 
 } // namespace Client

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -12,6 +12,7 @@
 #include "api/client/transform/fortio.pb.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/strip.h"
 
 namespace Nighthawk {
 namespace Client {
@@ -184,8 +185,11 @@ const nighthawk::client::Statistic& FortioOutputFormatterImpl::getRequestRespons
 
 std::string FortioOutputFormatterImpl::formatProto(const nighthawk::client::Output& output) const {
   nighthawk::client::FortioResult fortio_output;
-
-  fortio_output.set_labels("Nighthawk");
+  std::string labels;
+  for (const auto& label : output.options().labels()) {
+    labels += label + " ";
+  }
+  fortio_output.set_labels(std::string(absl::StripSuffix(labels, " ")));
   fortio_output.mutable_starttime()->set_seconds(output.timestamp().seconds());
   fortio_output.set_requestedqps(output.options().requests_per_second().value());
   fortio_output.set_url(output.options().uri().value());

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -98,6 +98,7 @@ public:
   MOCK_CONST_METHOD0(failurePredicates, Client::TerminationPredicateMap());
   MOCK_CONST_METHOD0(openLoop, bool());
   MOCK_CONST_METHOD0(jitterUniform, std::chrono::nanoseconds());
+  MOCK_CONST_METHOD0(labels, std::vector<std::string>());
 };
 
 class MockBenchmarkClientFactory : public Client::BenchmarkClientFactory {

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -47,7 +47,7 @@ TEST_F(OptionsImplTest, All) {
       "--max-active-requests 11 --max-requests-per-connection 12 --sequencer-idle-strategy sleep "
       "--termination-predicate t1:1 --termination-predicate t2:2 --failure-predicate f1:1 "
       "--failure-predicate f2:2 --jitter-uniform .00001s "
-      "--experimental-h1-connection-reuse-strategy lru ",
+      "--experimental-h1-connection-reuse-strategy lru --label label1 --label label2 ",
       client_name_,
       "{common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}",
       good_test_uri_));

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -84,6 +84,8 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(10us, options->jitterUniform());
   EXPECT_EQ(nighthawk::client::H1ConnectionReuseStrategy::LRU,
             options->h1ConnectionReuseStrategy());
+  const std::vector<std::string> expected_labels{"label1", "label2"};
+  EXPECT_EQ(expected_labels, options->labels());
 
   // Check that our conversion to CommandLineOptionsPtr makes sense.
   CommandLineOptionsPtr cmd = options->toCommandLineOptions();
@@ -133,6 +135,11 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(cmd->jitter_uniform().nanos(), options->jitterUniform().count());
   EXPECT_EQ(cmd->experimental_h1_connection_reuse_strategy().value(),
             options->h1ConnectionReuseStrategy());
+  i = 0;
+  for (const auto& label : cmd->labels()) {
+    EXPECT_EQ(expected_labels[i++], label);
+  }
+  EXPECT_EQ(expected_labels.size(), i);
 
   OptionsImpl options_from_proto(*cmd);
   std::string s1 = Envoy::MessageUtil::getYamlStringFromMessage(

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -135,11 +135,7 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(cmd->jitter_uniform().nanos(), options->jitterUniform().count());
   EXPECT_EQ(cmd->experimental_h1_connection_reuse_strategy().value(),
             options->h1ConnectionReuseStrategy());
-  i = 0;
-  for (const auto& label : cmd->labels()) {
-    EXPECT_EQ(expected_labels[i++], label);
-  }
-  EXPECT_EQ(expected_labels.size(), i);
+  EXPECT_THAT(cmd->labels(), ElementsAreArray(expected_labels));
 
   OptionsImpl options_from_proto(*cmd);
   std::string s1 = Envoy::MessageUtil::getYamlStringFromMessage(

--- a/test/test_data/output_formatter.json.gold
+++ b/test/test_data/output_formatter.json.gold
@@ -2,6 +2,7 @@
  "options": {
   "termination_predicates": {},
   "failure_predicates": {},
+  "labels": [],
   "connections": 0,
   "duration": "1s"
  },

--- a/test/test_data/output_formatter.medium.proto.gold
+++ b/test/test_data/output_formatter.medium.proto.gold
@@ -33,7 +33,8 @@
   "max_active_requests": 4294937295,
   "max_requests_per_connection": 4294937295,
   "uri": "http://127.0.0.1:10000/",
-  "trace": ""
+  "trace": "",
+  "labels": "Nighthawk",
  },
  "results": [
   {

--- a/test/test_data/output_formatter.yaml.gold
+++ b/test/test_data/output_formatter.yaml.gold
@@ -3,6 +3,8 @@ options:
     {}
   failure_predicates:
     {}
+  labels:
+    []
   connections: 0
   duration: 1s
 results:


### PR DESCRIPTION
Adds a new `--label` option. Allows tagging executions with multiple
labels. These labels will be persisted in our structured output formats.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>