### PR TITLE
add missing do_ci.sh commands into the help message

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -197,7 +197,7 @@ case "$1" in
         exit 0
     ;;
     *)
-        echo "must be one of [build,test,clang_tidy,test_with_valgrind,coverage,asan,tsan,docker]"
+        echo "must be one of [build,test,clang_tidy,test_with_valgrind,coverage,asan,tsan,docker,check_format,fix_format]"
         exit 1
     ;;
 esac


### PR DESCRIPTION
Adds missing commands into the help message produced by do_ci.sh.

Signed-off-by: eric846 <56563761+eric846@users.noreply.github.com>