### PR TITLE
Update CommandLineOptions proto documentation for grpc users

### DIFF
--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -97,77 +97,95 @@ message H1ConnectionReuseStrategy {
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
 message CommandLineOptions {
-  // See :option:`--rps` for details.
+  // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
       [(validate.rules).uint32 = {gte: 1, lte: 1000000}];
-  // See :option:`--connections` for details.
+  // The maximum allowed number of concurrent connections per event loop. HTTP/1 only. Default: 100.
   google.protobuf.UInt32Value connections = 2 [(validate.rules).uint32 = {gte: 1, lte: 1000000}];
-  // See :option:`--duration` for details.
+  // The number of seconds that the test should run. Default: 5.
   google.protobuf.Duration duration = 3 [(validate.rules).duration.gte.nanos = 1];
-  // See :option:`--timeout` for details.
+  // Connection connect timeout period in seconds. Default: 30.
   google.protobuf.Duration timeout = 4 [(validate.rules).duration.gte.seconds = 0];
-  // See :option:`--h2` for details.
+  // Use HTTP/2
   google.protobuf.BoolValue h2 = 5;
-  // See :option:`--concurrency` for details.
+  // The number of concurrent event loops that should be used. Specify 'auto' to let
+  // Nighthawk leverage all vCPUs that have affinity to the Nighthawk process. Note that
+  // increasing this results in an effective load multiplier combined with the configured
+  // --rps and --connections values. Default: 1.
   google.protobuf.StringValue concurrency =
       6; // [(validate.rules).string = {pattern: "^([0-9]*|auto)$"}];
-  // See :option:`--verbosity` for details.
+  // Verbosity of the output. Possible values: [trace, debug, info, warn,
+  // error, critical]. The default level is 'info'.
   Verbosity verbosity = 7;
-  // See :option:`--output-format` for details.
+  // Output format. Possible values: {"json", "human", "yaml", "dotted",
+  // "fortio"}. The default output format is 'human'.
+  // NOTE: not relevant to gRPC service
   OutputFormat output_format = 8;
-  // See :option:`--prefetch-connections` for details.
+  // Use proactive connection prefetching (HTTP/1 only).
   google.protobuf.BoolValue prefetch_connections = 9;
-  // See :option:`--burst-size` for details.
+  // Release requests in bursts of the specified size (default: 0).
   google.protobuf.UInt32Value burst_size = 10 [(validate.rules).uint32 = {lte: 1000000}];
 
-  // See :option:`--address-family` for details.
+  // Network address family preference. Possible values: [auto, v4, v6]. The default output format
+  // is 'AUTO'.
   AddressFamily address_family = 11;
   // Either requests will be statically configured, or delivered through a remote gRPC service.
   oneof oneof_request_options {
-    // See :option:`--request_options` for details.
+    // Static configuration to use on every outgoing request
     RequestOptions request_options = 12;
-    // See :option:`--request_source` for details.
+    // Remote gRPC source that will deliver to-be-replayed traffic. Each worker will separately
+    // connect to this source.
     RequestSource request_source = 26;
   }
-  // See :option:`--tls_context` for details.
-  envoy.extensions.transport_sockets.tls.v3alpha.UpstreamTlsContext tls_context = 13;
-  // See :option:`--max-pending_requests` for details.
+  // DEPRECATED, use --transport-socket instead. Tls context configuration in json or compact yaml.
+  // Mutually exclusive with --transport-socket.
+  envoy.extensions.transport_sockets.tls.v3alpha.UpstreamTlsContext tls_context = 13
+      [deprecated = true];
+  // Max pending requests (default: 0, no client side queuing. Specifying any other value will allow
+  // client-side queuing of requests).
   google.protobuf.UInt32Value max_pending_requests = 14;
-  // See :option:`--max-active_requests` for details.
+  // The maximum allowed number of concurrently active requests. HTTP/2 only. (default: 100).
   google.protobuf.UInt32Value max_active_requests = 15 [(validate.rules).uint32 = {gte: 1}];
-  // See :option:`--max-requests-per-connection` for details.
+  // Max requests per connection (default: 4294937295).
   google.protobuf.UInt32Value max_requests_per_connection = 16 [(validate.rules).uint32 = {gte: 1}];
-  // See :option:`--sequencer-idle-strategy` for details.
+  // Choose between using a busy spin/yield loop or have the thread poll or sleep while waiting for
+  // the next scheduled request (default: SPIN).
   SequencerIdleStrategy sequencer_idle_strategy = 17;
   // Either a single URI is configured, or the same traffic can be spread across a static
   // set of backends.
   oneof oneof_uri {
-    // See :option:`--uri` for details.
+    // URI to benchmark. http:// and https:// are supported, but in case of https no certificates
+    // are validated. For benchmarking a single endpoint.
     google.protobuf.StringValue uri = 18; // [(validate.rules).string.uri = true];
-    // For details see:
-    // - :option:`--multi-target-endpoint`
-    // - :option:`--multi-target-path`
-    // - :option:`--multi-target-use-https`
+    // Defines multiple URIs to benchmark
     MultiTarget multi_target = 29;
   }
-  // See :option:`--trace` for details.
+  // Trace uri. Example: zipkin://localhost:9411/api/v1/spans. Default is empty.
   google.protobuf.StringValue trace = 19; // [(validate.rules).string.uri = true];
-  // See :option:`--experimental-h1-connection-reuse-strategy` for details.
+  // Choose picking the most recently used, or least-recently-used connections for re-use.(default:
+  // mru). WARNING: this option is experimental and may be removed or changed in the future!
   H1ConnectionReuseStrategy experimental_h1_connection_reuse_strategy = 23;
-  // See :option:`--termination-predicates` for details.
+  // Termination predicate. Allows specifying a counter name plus threshold value for terminating
+  // execution.
   map<string, uint64> termination_predicates = 20;
-  // See :option:`--failure-predicates` for details.
+  // Allows specifying a counter name plus threshold value for failing execution. Defaults to not
+  // tolerating error status codes and connection errors.
   map<string, uint64> failure_predicates = 24;
-  // See :option:`--open-loop` for details.
+  // Enable open loop mode. When enabled, the benchmark client will not provide backpressure when
+  // resource limits are hit.
   google.protobuf.BoolValue open_loop = 21;
-  // See :option:`--jitter-uniform`
+  // Add uniformly distributed absolute request-release timing jitter. For example, to add 10 us of
+  // jitter, specify .00001s. Default is empty / no uniform jitter.
   google.protobuf.Duration jitter_uniform = 25 [(validate.rules).duration.gte.nanos = 1];
-  // See :option --nighthawk-service
+  // Nighthawk service uri for running CLI in remote host mode. Example: grpc://localhost:8843/.
+  // Default is empty.
+  // NOTE: not relevant to gRPC service
   google.protobuf.StringValue nighthawk_service = 31; // [(validate.rules).string.uri = true];
-  // See :option:`--experimental-h2-use-multiple-connections` for details.
+  // Use experimental HTTP/2 pool which will use multiple connections.
+  // WARNING: feature may be removed or changed in the future!
   google.protobuf.BoolValue experimental_h2_use_multiple_connections = 30;
-  // See :option:`--labels`
+  // Label. Allows specifying multiple labels which will be persisted in structured output formats.
   repeated string labels = 28;
-  // See :option:`--transport-socket` for details.
+  // TransportSocket configuration to use in every request
   envoy.config.core.v3alpha.TransportSocket transport_socket = 27;
 }


### PR DESCRIPTION
Applies the documentation that is available in the README from TCLAP into the proto file directly, for consumption there by gRPC consumers.  Adds in some notes for fields that are not relevant to the gRPC service.

Signed-off-by: Nathan Perry <nbperry@google.com>