### PR TITLE
Fortio output: add bytes sent / received

### DIFF
--- a/api/client/transform/fortio.proto
+++ b/api/client/transform/fortio.proto
@@ -90,8 +90,8 @@ message FortioResult {
   // equivalent).
   uint64 BytesSent = 18;
 
-  // Bytes sent should reflect the bytes sent after protocol serialization, compression, and
-  // encryption are applied (i.e., the size of the buffers passed to the send() system call or its
+  // Bytes received should reflect the bytes read before decryption, de-compression, and protocol
+  // de-serialization are applied (i.e., the size of bytes read from the recv() system call or its
   // equivalent).
   uint64 BytesReceived = 19;
 }

--- a/api/client/transform/fortio.proto
+++ b/api/client/transform/fortio.proto
@@ -84,6 +84,16 @@ message FortioResult {
 
   // We don't populate AbortOn (a status code that may abort termination) for reasons
   // similar to Exactly.
+
+  // Bytes sent should reflect the bytes sent after protocol serialization, compression, and
+  // encryption are applied (i.e., the size of the buffers passed to the send() system call or its
+  // equivalent).
+  uint64 BytesSent = 18;
+
+  // Bytes sent should reflect the bytes sent after protocol serialization, compression, and
+  // encryption are applied (i.e., the size of the buffers passed to the send() system call or its
+  // equivalent).
+  uint64 BytesReceived = 19;
 }
 
 message DurationHistogram {

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -213,17 +213,16 @@ FortioOutputFormatterImpl::getGlobalResult(const nighthawk::client::Output& outp
   throw NighthawkException("Nighthawk output was malformed, contains no 'global' results.");
 }
 
-const nighthawk::client::Counter&
-FortioOutputFormatterImpl::getCounterByName(const nighthawk::client::Result& result,
-                                            absl::string_view counter_name) const {
+bool FortioOutputFormatterImpl::visitCounter(
+    const nighthawk::client::Result& result, absl::string_view counter_name,
+    std::function<void(const nighthawk::client::Counter&)> callback) const {
   for (const auto& nh_counter : result.counters()) {
     if (nh_counter.name() == counter_name) {
-      return nh_counter;
+      callback(nh_counter);
+      return true;
     }
   }
-
-  throw NighthawkException(absl::StrCat(
-      "Nighthawk result was malformed, contains no counter with name: ", counter_name));
+  return false;
 }
 
 const nighthawk::client::Statistic*
@@ -288,45 +287,58 @@ std::string FortioOutputFormatterImpl::formatProto(const nighthawk::client::Outp
   fortio_output.set_numthreads(number_of_connections);
 
   // Get the result that represents all workers (global)
-  const auto& nh_global_result = this->getGlobalResult(output);
+  const auto& nh_global_result = getGlobalResult(output);
 
   // Fill in the actual QPS based on the counters
-  const auto& nh_rq_counter = this->getCounterByName(nh_global_result, "upstream_rq_total");
-  const double actual_qps = static_cast<double>(
-      nh_rq_counter.value() / std::chrono::duration<double>(actual_duration).count());
-  fortio_output.set_actualqps(actual_qps);
+  if (!visitCounter(
+          nh_global_result, "upstream_rq_total",
+          [&fortio_output, actual_duration](const nighthawk::client::Counter& nh_counter) {
+            const double actual_qps = static_cast<double>(
+                nh_counter.value() / std::chrono::duration<double>(actual_duration).count());
+            fortio_output.set_actualqps(actual_qps);
+          })) {
+    throw NighthawkException(
+        "Nighthawk result was malformed, contains no counter with name: upstream_rq_total");
+  };
+  visitCounter(nh_global_result, "upstream_cx_rx_bytes_total",
+               [&fortio_output](const nighthawk::client::Counter& nh_counter) {
+                 fortio_output.set_bytesreceived(nh_counter.value());
+               });
+  visitCounter(nh_global_result, "upstream_cx_tx_bytes_total",
+               [&fortio_output](const nighthawk::client::Counter& nh_counter) {
+                 fortio_output.set_bytessent(nh_counter.value());
+               });
 
   // Fill in the number of successful responses.
   // Fortio-ui only reads the 200 OK field, other fields are never displayed.
+  // If this field doesn't exist, then there were no 2xx responses
   fortio_output.mutable_retcodes()->insert({"200", 0});
-  try {
-    const auto& nh_2xx_counter = this->getCounterByName(nh_global_result, "benchmark.http_2xx");
-    // So Fortio computes the error percentage based on:
-    // - the sample count in the histogram
-    // - the number of 200 responses
-    // Nighthawk workers perform a single-request as a warmup, and doesn't measure latency for that.
-    // So we do an approximation here: we substract number_of_workers from the observed 2xx
-    // responses.
-    // TODO(oschaaf): It would be better to compute the actual ratio of error codes vs success
-    // codes.. and possibly also factor in connection failures, etc.
-    fortio_output.mutable_retcodes()->at("200") = nh_2xx_counter.value() - number_of_workers;
-  } catch (const NighthawkException& e) {
-    // If this field doesn't exist, then there were no 2xx responses
-    fortio_output.mutable_retcodes()->at("200") = 0;
-  }
+  visitCounter(nh_global_result, "benchmark.http_2xx",
+               [&fortio_output, number_of_workers](const nighthawk::client::Counter& nh_counter) {
+                 // So Fortio computes the error percentage based on:
+                 // - the sample count in the histogram
+                 // - the number of 200 responses
+                 // Nighthawk workers perform a single-request as a warmup, and
+                 // doesn't measure latency for that. So we do an approximation here:
+                 // we substract number_of_workers from the observed 2xx responses.
+                 // TODO(oschaaf): It would be better to compute the actual ratio of
+                 // error codes vs success codes.. and possibly also factor in
+                 // connection failures, etc.
+                 fortio_output.mutable_retcodes()->at("200") =
+                     nh_counter.value() - number_of_workers;
+               });
 
-  auto* statistic =
-      this->findStatistic(nh_global_result, "benchmark_http_client.request_to_response");
+  auto* statistic = findStatistic(nh_global_result, "benchmark_http_client.request_to_response");
   if (statistic == nullptr) {
     throw NighthawkException("Nighthawk result was malformed, contains no "
                              "'benchmark_http_client.request_to_response' statistic.");
   }
   fortio_output.mutable_durationhistogram()->CopyFrom(renderFortioDurationHistogram(*statistic));
-  statistic = this->findStatistic(nh_global_result, "benchmark_http_client.response_body_size");
+  statistic = findStatistic(nh_global_result, "benchmark_http_client.response_body_size");
   if (statistic != nullptr) {
     fortio_output.mutable_sizes()->CopyFrom(renderFortioDurationHistogram(*statistic));
   }
-  statistic = this->findStatistic(nh_global_result, "benchmark_http_client.response_header_size");
+  statistic = findStatistic(nh_global_result, "benchmark_http_client.response_header_size");
   if (statistic != nullptr) {
     fortio_output.mutable_headersizes()->CopyFrom(renderFortioDurationHistogram(*statistic));
   }

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -314,18 +314,14 @@ std::string FortioOutputFormatterImpl::formatProto(const nighthawk::client::Outp
   // If this field doesn't exist, then there were no 2xx responses
   fortio_output.mutable_retcodes()->insert({"200", 0});
   visitCounter(nh_global_result, "benchmark.http_2xx",
-               [&fortio_output, number_of_workers](const nighthawk::client::Counter& nh_counter) {
+               [&fortio_output](const nighthawk::client::Counter& nh_counter) {
                  // So Fortio computes the error percentage based on:
                  // - the sample count in the histogram
                  // - the number of 200 responses
-                 // Nighthawk workers perform a single-request as a warmup, and
-                 // doesn't measure latency for that. So we do an approximation here:
-                 // we substract number_of_workers from the observed 2xx responses.
                  // TODO(oschaaf): It would be better to compute the actual ratio of
                  // error codes vs success codes.. and possibly also factor in
                  // connection failures, etc.
-                 fortio_output.mutable_retcodes()->at("200") =
-                     nh_counter.value() - number_of_workers;
+                 fortio_output.mutable_retcodes()->at("200") = nh_counter.value();
                });
 
   auto* statistic = findStatistic(nh_global_result, "benchmark_http_client.request_to_response");

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -215,7 +215,7 @@ FortioOutputFormatterImpl::getGlobalResult(const nighthawk::client::Output& outp
 
 bool FortioOutputFormatterImpl::visitCounter(
     const nighthawk::client::Result& result, absl::string_view counter_name,
-    std::function<void(const nighthawk::client::Counter&)> callback) const {
+    const std::function<void(const nighthawk::client::Counter&)> callback) const {
   for (const auto& nh_counter : result.counters()) {
     if (nh_counter.name() == counter_name) {
       callback(nh_counter);

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -213,16 +213,15 @@ FortioOutputFormatterImpl::getGlobalResult(const nighthawk::client::Output& outp
   throw NighthawkException("Nighthawk output was malformed, contains no 'global' results.");
 }
 
-bool FortioOutputFormatterImpl::visitCounter(
-    const nighthawk::client::Result& result, absl::string_view counter_name,
-    const std::function<void(const nighthawk::client::Counter&)>& callback) const {
+uint64_t FortioOutputFormatterImpl::getCounterValue(const nighthawk::client::Result& result,
+                                                    absl::string_view counter_name,
+                                                    const uint64_t value_if_not_found) const {
   for (const auto& nh_counter : result.counters()) {
     if (nh_counter.name() == counter_name) {
-      callback(nh_counter);
-      return true;
+      return nh_counter.value();
     }
   }
-  return false;
+  return value_if_not_found;
 }
 
 const nighthawk::client::Statistic*
@@ -290,46 +289,23 @@ std::string FortioOutputFormatterImpl::formatProto(const nighthawk::client::Outp
   const auto& nh_global_result = getGlobalResult(output);
 
   // Fill in the actual QPS based on the counters
-  if (!visitCounter(
-          nh_global_result, "upstream_rq_total",
-          [&fortio_output, actual_duration](const nighthawk::client::Counter& nh_counter) {
-            const double actual_qps = static_cast<double>(
-                nh_counter.value() / std::chrono::duration<double>(actual_duration).count());
-            fortio_output.set_actualqps(actual_qps);
-          })) {
-    throw NighthawkException(
-        "Nighthawk result was malformed, contains no counter with name: upstream_rq_total");
-  };
-  visitCounter(nh_global_result, "upstream_cx_rx_bytes_total",
-               [&fortio_output](const nighthawk::client::Counter& nh_counter) {
-                 fortio_output.set_bytesreceived(nh_counter.value());
-               });
-  visitCounter(nh_global_result, "upstream_cx_tx_bytes_total",
-               [&fortio_output](const nighthawk::client::Counter& nh_counter) {
-                 fortio_output.set_bytessent(nh_counter.value());
-               });
-
-  // Fill in the number of successful responses.
+  const double actual_qps =
+      static_cast<double>(getCounterValue(nh_global_result, "upstream_rq_total", 0) /
+                          std::chrono::duration<double>(actual_duration).count());
+  fortio_output.set_actualqps(actual_qps);
+  fortio_output.set_bytesreceived(
+      getCounterValue(nh_global_result, "upstream_cx_rx_bytes_total", 0));
+  fortio_output.set_bytessent(getCounterValue(nh_global_result, "upstream_cx_tx_bytes_total", 0));
   // Fortio-ui only reads the 200 OK field, other fields are never displayed.
-  // If this field doesn't exist, then there were no 2xx responses
-  fortio_output.mutable_retcodes()->insert({"200", 0});
-  visitCounter(nh_global_result, "benchmark.http_2xx",
-               [&fortio_output](const nighthawk::client::Counter& nh_counter) {
-                 // So Fortio computes the error percentage based on:
-                 // - the sample count in the histogram
-                 // - the number of 200 responses
-                 // TODO(oschaaf): It would be better to compute the actual ratio of
-                 // error codes vs success codes.. and possibly also factor in
-                 // connection failures, etc.
-                 fortio_output.mutable_retcodes()->at("200") = nh_counter.value();
-               });
-
+  // Fortio computes the error percentage based on:
+  // - the sample count in the histogram
+  // - the number of 200 responses
+  fortio_output.mutable_retcodes()->insert(
+      {"200", getCounterValue(nh_global_result, "benchmark.http_2xx", 0)});
   auto* statistic = findStatistic(nh_global_result, "benchmark_http_client.request_to_response");
-  if (statistic == nullptr) {
-    throw NighthawkException("Nighthawk result was malformed, contains no "
-                             "'benchmark_http_client.request_to_response' statistic.");
+  if (statistic != nullptr) {
+    fortio_output.mutable_durationhistogram()->CopyFrom(renderFortioDurationHistogram(*statistic));
   }
-  fortio_output.mutable_durationhistogram()->CopyFrom(renderFortioDurationHistogram(*statistic));
   statistic = findStatistic(nh_global_result, "benchmark_http_client.response_body_size");
   if (statistic != nullptr) {
     fortio_output.mutable_sizes()->CopyFrom(renderFortioDurationHistogram(*statistic));

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -215,7 +215,7 @@ FortioOutputFormatterImpl::getGlobalResult(const nighthawk::client::Output& outp
 
 bool FortioOutputFormatterImpl::visitCounter(
     const nighthawk::client::Result& result, absl::string_view counter_name,
-    const std::function<void(const nighthawk::client::Counter&)> callback) const {
+    const std::function<void(const nighthawk::client::Counter&)>& callback) const {
   for (const auto& nh_counter : result.counters()) {
     if (nh_counter.name() == counter_name) {
       callback(nh_counter);

--- a/source/client/output_formatter_impl.h
+++ b/source/client/output_formatter_impl.h
@@ -69,11 +69,11 @@ protected:
    *
    * @param result a single Nighthawk result, preferably the global result
    * @param counter_name the name of the counter to return
-   * @return the corresponding counter
-   * @throws NighthawkException if counter with given name is not found
+   * @param callback The callback to run iff a counter is found, passing the counter as an argument.
+   * @return True iff a counter was found.
    */
-  const nighthawk::client::Counter& getCounterByName(const nighthawk::client::Result& result,
-                                                     absl::string_view counter_name) const;
+  bool visitCounter(const nighthawk::client::Result& result, absl::string_view counter_name,
+                    std::function<void(const nighthawk::client::Counter&)> callback) const;
 
   /**
    * Return the statistic that represents the request/response round-trip times.

--- a/source/client/output_formatter_impl.h
+++ b/source/client/output_formatter_impl.h
@@ -73,7 +73,7 @@ protected:
    * @return True iff a counter was found.
    */
   bool visitCounter(const nighthawk::client::Result& result, absl::string_view counter_name,
-                    const std::function<void(const nighthawk::client::Counter&)> callback) const;
+                    const std::function<void(const nighthawk::client::Counter&)>& callback) const;
 
   /**
    * Return the statistic that represents the request/response round-trip times.

--- a/source/client/output_formatter_impl.h
+++ b/source/client/output_formatter_impl.h
@@ -73,7 +73,7 @@ protected:
    * @return True iff a counter was found.
    */
   bool visitCounter(const nighthawk::client::Result& result, absl::string_view counter_name,
-                    std::function<void(const nighthawk::client::Counter&)> callback) const;
+                    const std::function<void(const nighthawk::client::Counter&)> callback) const;
 
   /**
    * Return the statistic that represents the request/response round-trip times.

--- a/source/client/output_formatter_impl.h
+++ b/source/client/output_formatter_impl.h
@@ -69,11 +69,12 @@ protected:
    *
    * @param result a single Nighthawk result, preferably the global result
    * @param counter_name the name of the counter to return
-   * @param callback The callback to run iff a counter is found, passing the counter as an argument.
+   * @param value_if_not_found value that will be returned when the counter does not exist in the
+   * output.
    * @return True iff a counter was found.
    */
-  bool visitCounter(const nighthawk::client::Result& result, absl::string_view counter_name,
-                    const std::function<void(const nighthawk::client::Counter&)>& callback) const;
+  uint64_t getCounterValue(const nighthawk::client::Result& result, absl::string_view counter_name,
+                           const uint64_t value_if_not_found = 0) const;
 
   /**
    * Return the statistic that represents the request/response round-trip times.

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -155,22 +155,19 @@ TEST_F(FortioOutputCollectorTest, MissingGlobalResult) {
 TEST_F(FortioOutputCollectorTest, MissingCounter) {
   nighthawk::client::Output output_proto = collector_->toProto();
   output_proto.mutable_results(2)->clear_counters();
-
   FortioOutputFormatterImpl formatter;
-  ASSERT_THROW(formatter.formatProto(output_proto), NighthawkException);
+  ASSERT_NO_THROW(formatter.formatProto(output_proto));
 }
 
 TEST_F(FortioOutputCollectorTest, MissingStatistic) {
   nighthawk::client::Output output_proto = collector_->toProto();
   output_proto.mutable_results(2)->clear_statistics();
-
   FortioOutputFormatterImpl formatter;
-  ASSERT_THROW(formatter.formatProto(output_proto), NighthawkException);
+  ASSERT_NO_THROW(formatter.formatProto(output_proto);
 }
 
 TEST_F(FortioOutputCollectorTest, NoExceptions) {
   nighthawk::client::Output output_proto = collector_->toProto();
-
   FortioOutputFormatterImpl formatter;
   ASSERT_NO_THROW(formatter.formatProto(output_proto));
 }

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -163,7 +163,7 @@ TEST_F(FortioOutputCollectorTest, MissingStatistic) {
   nighthawk::client::Output output_proto = collector_->toProto();
   output_proto.mutable_results(2)->clear_statistics();
   FortioOutputFormatterImpl formatter;
-  ASSERT_NO_THROW(formatter.formatProto(output_proto);
+  ASSERT_NO_THROW(formatter.formatProto(output_proto));
 }
 
 TEST_F(FortioOutputCollectorTest, NoExceptions) {

--- a/test/test_data/output_formatter.medium.fortio.gold
+++ b/test/test_data/output_formatter.medium.fortio.gold
@@ -223,7 +223,7 @@
   ]
  },
  "RetCodes": {
-  "200": "53"
+  "200": "56"
  },
  "URL": "https://www.google.com/",
  "Version": "0.0.0",

--- a/test/test_data/output_formatter.medium.fortio.gold
+++ b/test/test_data/output_formatter.medium.fortio.gold
@@ -476,6 +476,8 @@
    }
   ]
  },
+ "BytesSent": "3528",
+ "BytesReceived": "2702142",
  "StartTime": "2020-01-11T12:47:57.259885200Z",
  "RequestedDuration": "2s"
 }


### PR DESCRIPTION
This adds two new fields to the fortio output:

```proto
  // Bytes sent should reflect the bytes sent after protocol serialization, compression, and
  // encryption are applied (i.e., the size of the buffers passed to the send() system call or its
  // equivalent).
  uint64 BytesSent = 18;

  // Bytes received should reflect the bytes read before decryption, de-compression, and protocol
  // de-serialization are applied (i.e., the size of bytes read from the recv() system call or its
  // equivalent).
  uint64 BytesReceived = 19;
```

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>
