### PR TITLE
Dns resolution: use UDP instead of TCP

### DIFF
--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -427,7 +427,7 @@ bool ProcessImpl::run(OutputCollector& collector) {
       std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(time_system_);
   cluster_manager_factory_ = std::make_unique<ClusterManagerFactory>(
       admin_, Envoy::Runtime::LoaderSingleton::get(), store_root_, tls_, generator_,
-      dispatcher_->createDnsResolver({}, true), *ssl_context_manager_, *dispatcher_, *local_info_,
+      dispatcher_->createDnsResolver({}, false), *ssl_context_manager_, *dispatcher_, *local_info_,
       secret_manager_, validation_context_, *api_, http_context_, access_log_manager_,
       *singleton_manager_);
   cluster_manager_factory_->setConnectionReuseStrategy(

--- a/source/common/uri_impl.cc
+++ b/source/common/uri_impl.cc
@@ -59,7 +59,7 @@ UriImpl::UriImpl(absl::string_view uri, absl::string_view default_scheme)
 
 bool UriImpl::performDnsLookup(Envoy::Event::Dispatcher& dispatcher,
                                const Envoy::Network::DnsLookupFamily dns_lookup_family) {
-  auto dns_resolver = dispatcher.createDnsResolver({}, true);
+  auto dns_resolver = dispatcher.createDnsResolver({}, false);
   std::string hostname = std::string(hostWithoutPort());
 
   if (!hostname.empty() && hostname[0] == '[' && hostname[hostname.size() - 1] == ']') {


### PR DESCRIPTION
Today, we use TCP for resolving DNS. This makes us use UDP
instead. I think the choice here was never actively discussed,
and possibly the current default crept in via an Envoy dep
update.

Fixes https://github.com/envoyproxy/nighthawk/issues/300

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>