### PR TITLE
Move MockOptions into its own compilation unit.

### DIFF
--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -9,6 +9,8 @@
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 
+#include "nighthawk/common/termination_predicate.h"
+
 #include "api/client/options.pb.h"
 
 #include "absl/types/optional.h"

--- a/test/BUILD
+++ b/test/BUILD
@@ -59,6 +59,7 @@ envoy_cc_test(
     deps = [
         "//source/client:nighthawk_client_lib",
         "//test:nighthawk_mocks",
+        "//test/mocks/client:mock_options",
         "@envoy//source/common/api:api_lib",
         "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
         "@envoy//test/mocks/init:init_mocks",
@@ -75,6 +76,7 @@ envoy_cc_test(
     deps = [
         "//source/client:nighthawk_client_lib",
         "//test:nighthawk_mocks",
+        "//test/mocks/client:mock_options",
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/mocks/tracing:tracing_mocks",
         "@envoy//test/test_common:simulated_time_system_lib",
@@ -114,7 +116,7 @@ envoy_cc_test(
     deps = [
         "//source/client:output_formatter_impl_lib",
         "//source/common:nighthawk_common_lib",
-        "//test:nighthawk_mocks",
+        "//test/mocks/client:mock_options",
         "//test/test_common:environment_lib",
         "@envoy//test/test_common:simulated_time_system_lib",
     ],

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -16,6 +16,7 @@
 #include "client/client_worker_impl.h"
 
 #include "test/mocks.h"
+#include "test/mocks/client/mock_options.h"
 
 #include "gtest/gtest.h"
 

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -12,6 +12,7 @@
 #include "client/factories_impl.h"
 
 #include "test/mocks.h"
+#include "test/mocks/client/mock_options.h"
 
 #include "gtest/gtest.h"
 

--- a/test/mocks.cc
+++ b/test/mocks.cc
@@ -14,8 +14,6 @@ MockSequencerTarget::MockSequencerTarget() = default;
 
 MockSequencer::MockSequencer() = default;
 
-MockOptions::MockOptions() = default;
-
 MockBenchmarkClientFactory::MockBenchmarkClientFactory() = default;
 
 MockSequencerFactory::MockSequencerFactory() = default;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -11,7 +11,6 @@
 
 #include "nighthawk/client/benchmark_client.h"
 #include "nighthawk/client/factories.h"
-#include "nighthawk/client/options.h"
 #include "nighthawk/common/platform_util.h"
 #include "nighthawk/common/rate_limiter.h"
 #include "nighthawk/common/request_source.h"
@@ -28,8 +27,6 @@
 #include "gmock/gmock.h"
 
 using namespace std::chrono_literals;
-
-constexpr std::chrono::milliseconds TimeResolution = 1ms;
 
 namespace Nighthawk {
 
@@ -63,52 +60,6 @@ public:
   MOCK_CONST_METHOD0(executionDuration, std::chrono::nanoseconds());
   MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
   MOCK_METHOD0(cancel, void());
-};
-
-class MockOptions : public Client::Options {
-public:
-  MockOptions();
-
-  MOCK_CONST_METHOD0(requestsPerSecond, uint32_t());
-  MOCK_CONST_METHOD0(connections, uint32_t());
-  MOCK_CONST_METHOD0(duration, std::chrono::seconds());
-  MOCK_CONST_METHOD0(timeout, std::chrono::seconds());
-  MOCK_CONST_METHOD0(uri, absl::optional<std::string>());
-  MOCK_CONST_METHOD0(h2, bool());
-  MOCK_CONST_METHOD0(concurrency, std::string());
-  MOCK_CONST_METHOD0(verbosity, nighthawk::client::Verbosity::VerbosityOptions());
-  MOCK_CONST_METHOD0(outputFormat, nighthawk::client::OutputFormat::OutputFormatOptions());
-  MOCK_CONST_METHOD0(prefetchConnections, bool());
-  MOCK_CONST_METHOD0(burstSize, uint32_t());
-  MOCK_CONST_METHOD0(addressFamily, nighthawk::client::AddressFamily::AddressFamilyOptions());
-  MOCK_CONST_METHOD0(requestMethod, envoy::config::core::v3::RequestMethod());
-  MOCK_CONST_METHOD0(requestHeaders, std::vector<std::string>());
-  MOCK_CONST_METHOD0(requestBodySize, uint32_t());
-  MOCK_CONST_METHOD0(tlsContext,
-                     envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&());
-  MOCK_CONST_METHOD0(transportSocket, absl::optional<envoy::config::core::v3::TransportSocket>&());
-  MOCK_CONST_METHOD0(maxPendingRequests, uint32_t());
-  MOCK_CONST_METHOD0(maxActiveRequests, uint32_t());
-  MOCK_CONST_METHOD0(maxRequestsPerConnection, uint32_t());
-  MOCK_CONST_METHOD0(toCommandLineOptions, Client::CommandLineOptionsPtr());
-  MOCK_CONST_METHOD0(sequencerIdleStrategy,
-                     nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions());
-  MOCK_CONST_METHOD0(requestSource, std::string());
-  MOCK_CONST_METHOD0(trace, std::string());
-  MOCK_CONST_METHOD0(
-      h1ConnectionReuseStrategy,
-      nighthawk::client::H1ConnectionReuseStrategy::H1ConnectionReuseStrategyOptions());
-  MOCK_CONST_METHOD0(terminationPredicates, Client::TerminationPredicateMap());
-  MOCK_CONST_METHOD0(failurePredicates, Client::TerminationPredicateMap());
-  MOCK_CONST_METHOD0(openLoop, bool());
-  MOCK_CONST_METHOD0(jitterUniform, std::chrono::nanoseconds());
-  MOCK_CONST_METHOD0(nighthawkService, std::string());
-  MOCK_CONST_METHOD0(h2UseMultipleConnections, bool());
-  MOCK_CONST_METHOD0(multiTargetEndpoints, std::vector<nighthawk::client::MultiTarget::Endpoint>());
-  MOCK_CONST_METHOD0(multiTargetPath, std::string());
-  MOCK_CONST_METHOD0(multiTargetUseHttps, bool());
-  MOCK_CONST_METHOD0(labels, std::vector<std::string>());
-  MOCK_CONST_METHOD0(simpleWarmup, bool());
 };
 
 class MockBenchmarkClientFactory : public Client::BenchmarkClientFactory {

--- a/test/mocks/client/BUILD
+++ b/test/mocks/client/BUILD
@@ -1,0 +1,20 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_mock",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_mock(
+    name = "mock_options",
+    srcs = ["mock_options.cc"],
+    hdrs = ["mock_options.h"],
+    repository = "@envoy",
+    deps = [
+        "//source/client:nighthawk_client_lib",
+    ],
+)

--- a/test/mocks/client/BUILD
+++ b/test/mocks/client/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])  # Apache 2
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",
-    "envoy_cc_test",
     "envoy_package",
 )
 

--- a/test/mocks/client/mock_options.cc
+++ b/test/mocks/client/mock_options.cc
@@ -1,7 +1,5 @@
 #include "test/mocks/client/mock_options.h"
 
-#include <memory>
-
 #include "gmock/gmock.h"
 
 namespace Nighthawk {

--- a/test/mocks/client/mock_options.cc
+++ b/test/mocks/client/mock_options.cc
@@ -1,0 +1,13 @@
+#include "test/mocks/client/mock_options.h"
+
+#include <memory>
+
+#include "gmock/gmock.h"
+
+namespace Nighthawk {
+namespace Client {
+
+MockOptions::MockOptions() = default;
+
+}
+} // namespace Nighthawk

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "nighthawk/client/options.h"
+
+#include "absl/types/optional.h"
+#include "gmock/gmock.h"
+
+namespace Nighthawk {
+namespace Client {
+
+class MockOptions : public Options {
+public:
+  MockOptions();
+  MOCK_CONST_METHOD0(requestsPerSecond, uint32_t());
+  MOCK_CONST_METHOD0(connections, uint32_t());
+  MOCK_CONST_METHOD0(duration, std::chrono::seconds());
+  MOCK_CONST_METHOD0(timeout, std::chrono::seconds());
+  MOCK_CONST_METHOD0(uri, absl::optional<std::string>());
+  MOCK_CONST_METHOD0(h2, bool());
+  MOCK_CONST_METHOD0(concurrency, std::string());
+  MOCK_CONST_METHOD0(verbosity, nighthawk::client::Verbosity::VerbosityOptions());
+  MOCK_CONST_METHOD0(outputFormat, nighthawk::client::OutputFormat::OutputFormatOptions());
+  MOCK_CONST_METHOD0(prefetchConnections, bool());
+  MOCK_CONST_METHOD0(burstSize, uint32_t());
+  MOCK_CONST_METHOD0(addressFamily, nighthawk::client::AddressFamily::AddressFamilyOptions());
+  MOCK_CONST_METHOD0(requestMethod, envoy::config::core::v3::RequestMethod());
+  MOCK_CONST_METHOD0(requestHeaders, std::vector<std::string>());
+  MOCK_CONST_METHOD0(requestBodySize, uint32_t());
+  MOCK_CONST_METHOD0(tlsContext,
+                     envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&());
+  MOCK_CONST_METHOD0(transportSocket, absl::optional<envoy::config::core::v3::TransportSocket>&());
+  MOCK_CONST_METHOD0(maxPendingRequests, uint32_t());
+  MOCK_CONST_METHOD0(maxActiveRequests, uint32_t());
+  MOCK_CONST_METHOD0(maxRequestsPerConnection, uint32_t());
+  MOCK_CONST_METHOD0(toCommandLineOptions, CommandLineOptionsPtr());
+  MOCK_CONST_METHOD0(sequencerIdleStrategy,
+                     nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions());
+  MOCK_CONST_METHOD0(requestSource, std::string());
+  MOCK_CONST_METHOD0(trace, std::string());
+  MOCK_CONST_METHOD0(
+      h1ConnectionReuseStrategy,
+      nighthawk::client::H1ConnectionReuseStrategy::H1ConnectionReuseStrategyOptions());
+  MOCK_CONST_METHOD0(terminationPredicates, TerminationPredicateMap());
+  MOCK_CONST_METHOD0(failurePredicates, TerminationPredicateMap());
+  MOCK_CONST_METHOD0(openLoop, bool());
+  MOCK_CONST_METHOD0(jitterUniform, std::chrono::nanoseconds());
+  MOCK_CONST_METHOD0(nighthawkService, std::string());
+  MOCK_CONST_METHOD0(h2UseMultipleConnections, bool());
+  MOCK_CONST_METHOD0(multiTargetEndpoints, std::vector<nighthawk::client::MultiTarget::Endpoint>());
+  MOCK_CONST_METHOD0(multiTargetPath, std::string());
+  MOCK_CONST_METHOD0(multiTargetUseHttps, bool());
+  MOCK_CONST_METHOD0(labels, std::vector<std::string>());
+  MOCK_CONST_METHOD0(simpleWarmup, bool());
+};
+
+} // namespace Client
+} // namespace Nighthawk

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -3,6 +3,7 @@
 #include "nighthawk/common/exception.h"
 
 #include "external/envoy/source/common/protobuf/message_validator_impl.h"
+#include "external/envoy/source/common/protobuf/utility.h"
 #include "external/envoy/test/test_common/file_system_for_test.h"
 #include "external/envoy/test/test_common/simulated_time_system.h"
 
@@ -17,7 +18,7 @@
 
 #include "test_common/environment.h"
 
-#include "test/mocks.h"
+#include "test/mocks/client/mock_options.h"
 
 #include "absl/strings/str_replace.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
Part of an effort to attempt to reduce memory usage during
the build, to address ASAN flakes in CI.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>