### PR TITLE
Move a couple of mocks into their own compilation units

### DIFF
--- a/include/nighthawk/common/BUILD
+++ b/include/nighthawk/common/BUILD
@@ -27,8 +27,9 @@ envoy_basic_cc_library(
     include_prefix = "nighthawk/common",
     deps = [
         ":request_lib",
-        "@envoy//source/common/common:minimal_logger_lib_with_external_headers",
-        "@envoy//source/common/common:non_copyable_with_external_headers",
+        "@envoy//source/common/common:minimal_logger_lib",
+        "@envoy//source/common/common:non_copyable",
+        "@envoy//source/common/event:dispatcher_lib",
         "@envoy//source/common/network:utility_lib_with_external_headers",
     ],
 )

--- a/include/nighthawk/common/BUILD
+++ b/include/nighthawk/common/BUILD
@@ -27,9 +27,10 @@ envoy_basic_cc_library(
     include_prefix = "nighthawk/common",
     deps = [
         ":request_lib",
+        "//api/client:base_cc_proto",
         "@envoy//source/common/common:minimal_logger_lib",
-        "@envoy//source/common/common:non_copyable",
-        "@envoy//source/common/event:dispatcher_lib",
+        "@envoy//source/common/common:non_copyable_with_external_headers",
+        "@envoy//source/common/event:dispatcher_lib_with_external_headers",
         "@envoy//source/common/network:utility_lib_with_external_headers",
     ],
 )

--- a/include/nighthawk/common/BUILD
+++ b/include/nighthawk/common/BUILD
@@ -27,12 +27,9 @@ envoy_basic_cc_library(
     include_prefix = "nighthawk/common",
     deps = [
         ":request_lib",
-        "@envoy//include/envoy/common:base_includes",
-        "@envoy//source/common/common:minimal_logger_lib",
-        "@envoy//source/common/common:non_copyable",
-        "@envoy//source/common/http:headers_lib",
-        "@envoy//source/common/network:dns_lib",
-        "@envoy//source/common/protobuf",
+        "@envoy//source/common/common:minimal_logger_lib_with_external_headers",
+        "@envoy//source/common/common:non_copyable_with_external_headers",
+        "@envoy//source/common/network:utility_lib_with_external_headers",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -61,6 +61,8 @@ envoy_cc_test(
         "//test:nighthawk_mocks",
         "//test/mocks/client:mock_benchmark_client",
         "//test/mocks/client:mock_options",
+        "//test/mocks/common:mock_sequencer",
+        "//test/mocks/common:mock_termination_predicate",
         "@envoy//source/common/api:api_lib",
         "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
         "@envoy//test/mocks/init:init_mocks",
@@ -79,6 +81,7 @@ envoy_cc_test(
         "//test:nighthawk_mocks",
         "//test/mocks/client:mock_benchmark_client",
         "//test/mocks/client:mock_options",
+        "//test/mocks/common:mock_termination_predicate",
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/mocks/tracing:tracing_mocks",
         "@envoy//test/test_common:simulated_time_system_lib",
@@ -151,7 +154,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/common:nighthawk_common_lib",
-        "//test:nighthawk_mocks",
+        "//test/mocks/common:mock_rate_limiter",
         "@envoy//test/test_common:simulated_time_system_lib",
     ],
 )
@@ -169,7 +172,10 @@ envoy_cc_test(
     deps = [
         "//source/common:nighthawk_common_lib",
         "//test:nighthawk_mocks",
+        "//test/mocks/common:mock_rate_limiter",
+        "//test/mocks/common:mock_termination_predicate",
         "@envoy//source/common/event:dispatcher_includes_with_external_headers",
+        "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/test_common:simulated_time_system_lib",
     ],

--- a/test/BUILD
+++ b/test/BUILD
@@ -26,13 +26,13 @@ envoy_cc_test(
     srcs = ["benchmark_http_client_test.cc"],
     repository = "@envoy",
     deps = [
+        "//source/client:nighthawk_client_lib",
         "//source/common:request_impl_lib",
-        "//test:nighthawk_mocks",
         "//test/test_common:environment_lib",
         "@envoy//source/common/http:header_map_lib_with_external_headers",
         "@envoy//source/common/network:utility_lib_with_external_headers",
         "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
-        "@envoy//source/exe:process_wide_lib",
+        "@envoy//source/exe:process_wide_lib_with_external_headers",
         "@envoy//test/mocks/runtime:runtime_mocks",
         "@envoy//test/mocks/stream_info:stream_info_mocks",
         "@envoy//test/mocks/thread_local:thread_local_mocks",
@@ -59,6 +59,7 @@ envoy_cc_test(
     deps = [
         "//source/client:nighthawk_client_lib",
         "//test:nighthawk_mocks",
+        "//test/mocks/client:mock_benchmark_client",
         "//test/mocks/client:mock_options",
         "@envoy//source/common/api:api_lib",
         "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
@@ -76,6 +77,7 @@ envoy_cc_test(
     deps = [
         "//source/client:nighthawk_client_lib",
         "//test:nighthawk_mocks",
+        "//test/mocks/client:mock_benchmark_client",
         "//test/mocks/client:mock_options",
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/mocks/tracing:tracing_mocks",
@@ -114,6 +116,7 @@ envoy_cc_test(
     ],
     repository = "@envoy",
     deps = [
+        "//source/client:output_collector_impl_lib",
         "//source/client:output_formatter_impl_lib",
         "//source/common:nighthawk_common_lib",
         "//test/mocks/client:mock_options",

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -19,8 +19,6 @@
 
 #include "client/benchmark_client_impl.h"
 
-#include "test/mocks.h"
-
 #include "gtest/gtest.h"
 
 using namespace testing;

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -18,6 +18,8 @@
 #include "test/mocks.h"
 #include "test/mocks/client/mock_benchmark_client.h"
 #include "test/mocks/client/mock_options.h"
+#include "test/mocks/common/mock_sequencer.h"
+#include "test/mocks/common/mock_termination_predicate.h"
 
 #include "gtest/gtest.h"
 

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -16,6 +16,7 @@
 #include "client/client_worker_impl.h"
 
 #include "test/mocks.h"
+#include "test/mocks/client/mock_benchmark_client.h"
 #include "test/mocks/client/mock_options.h"
 
 #include "gtest/gtest.h"

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -14,6 +14,7 @@
 #include "test/mocks.h"
 #include "test/mocks/client/mock_benchmark_client.h"
 #include "test/mocks/client/mock_options.h"
+#include "test/mocks/common/mock_termination_predicate.h"
 
 #include "gtest/gtest.h"
 

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -12,6 +12,7 @@
 #include "client/factories_impl.h"
 
 #include "test/mocks.h"
+#include "test/mocks/client/mock_benchmark_client.h"
 #include "test/mocks/client/mock_options.h"
 
 #include "gtest/gtest.h"

--- a/test/mocks.cc
+++ b/test/mocks.cc
@@ -1,18 +1,10 @@
 #include "test/mocks.h"
 
-#include <memory>
-
 #include "gmock/gmock.h"
 
 namespace Nighthawk {
 
 MockPlatformUtil::MockPlatformUtil() = default;
-
-MockRateLimiter::MockRateLimiter() = default;
-
-MockSequencerTarget::MockSequencerTarget() = default;
-
-MockSequencer::MockSequencer() = default;
 
 MockBenchmarkClientFactory::MockBenchmarkClientFactory() = default;
 
@@ -27,9 +19,5 @@ MockRequestSourceFactory::MockRequestSourceFactory() = default;
 MockTerminationPredicateFactory::MockTerminationPredicateFactory() = default;
 
 MockRequestSource::MockRequestSource() = default;
-
-MockTerminationPredicate::MockTerminationPredicate() = default;
-
-MockDiscreteNumericDistributionSampler::MockDiscreteNumericDistributionSampler() = default;
 
 } // namespace Nighthawk

--- a/test/mocks.cc
+++ b/test/mocks.cc
@@ -26,8 +26,6 @@ MockRequestSourceFactory::MockRequestSourceFactory() = default;
 
 MockTerminationPredicateFactory::MockTerminationPredicateFactory() = default;
 
-MockBenchmarkClient::MockBenchmarkClient() = default;
-
 MockRequestSource::MockRequestSource() = default;
 
 MockTerminationPredicate::MockTerminationPredicate() = default;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -11,11 +11,8 @@
 
 #include "nighthawk/client/factories.h"
 #include "nighthawk/common/platform_util.h"
-#include "nighthawk/common/rate_limiter.h"
 #include "nighthawk/common/request_source.h"
-#include "nighthawk/common/sequencer.h"
 #include "nighthawk/common/statistic.h"
-#include "nighthawk/common/termination_predicate.h"
 #include "nighthawk/common/uri.h"
 
 #include "external/envoy/test/test_common/simulated_time_system.h"
@@ -37,28 +34,6 @@ public:
 
   MOCK_CONST_METHOD0(yieldCurrentThread, void());
   MOCK_CONST_METHOD1(sleep, void(std::chrono::microseconds));
-};
-
-class MockRateLimiter : public RateLimiter {
-public:
-  MockRateLimiter();
-
-  MOCK_METHOD0(tryAcquireOne, bool());
-  MOCK_METHOD0(releaseOne, void());
-  MOCK_METHOD0(timeSource, Envoy::TimeSource&());
-  MOCK_METHOD0(elapsed, std::chrono::nanoseconds());
-};
-
-class MockSequencer : public Sequencer {
-public:
-  MockSequencer();
-
-  MOCK_METHOD0(start, void());
-  MOCK_METHOD0(waitForCompletion, void());
-  MOCK_CONST_METHOD0(completionsPerSecond, double());
-  MOCK_CONST_METHOD0(executionDuration, std::chrono::nanoseconds());
-  MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
-  MOCK_METHOD0(cancel, void());
 };
 
 class MockBenchmarkClientFactory : public Client::BenchmarkClientFactory {
@@ -114,41 +89,11 @@ public:
                                              const Envoy::MonotonicTime scheduled_starting_time));
 };
 
-class FakeSequencerTarget {
-public:
-  virtual ~FakeSequencerTarget() = default;
-  // A fake method that matches the sequencer target signature.
-  virtual bool callback(OperationCallback) PURE;
-};
-
-class MockSequencerTarget : public FakeSequencerTarget {
-public:
-  MockSequencerTarget();
-  MOCK_METHOD1(callback, bool(OperationCallback));
-};
-
 class MockRequestSource : public RequestSource {
 public:
   MockRequestSource();
   MOCK_METHOD0(get, RequestGenerator());
   MOCK_METHOD0(initOnThread, void());
-};
-
-class MockTerminationPredicate : public TerminationPredicate {
-public:
-  MockTerminationPredicate();
-  MOCK_METHOD1(link, TerminationPredicate&(TerminationPredicatePtr&&));
-  MOCK_METHOD1(appendToChain, TerminationPredicate&(TerminationPredicatePtr&&));
-  MOCK_METHOD0(evaluateChain, TerminationPredicate::Status());
-  MOCK_METHOD0(evaluate, TerminationPredicate::Status());
-};
-
-class MockDiscreteNumericDistributionSampler : public DiscreteNumericDistributionSampler {
-public:
-  MockDiscreteNumericDistributionSampler();
-  MOCK_METHOD0(getValue, uint64_t());
-  MOCK_CONST_METHOD0(min, uint64_t());
-  MOCK_CONST_METHOD0(max, uint64_t());
 };
 
 } // namespace Nighthawk

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -9,7 +9,6 @@
 #include "envoy/stats/store.h"
 #include "envoy/upstream/cluster_manager.h"
 
-#include "nighthawk/client/benchmark_client.h"
 #include "nighthawk/client/factories.h"
 #include "nighthawk/common/platform_util.h"
 #include "nighthawk/common/rate_limiter.h"
@@ -126,19 +125,6 @@ class MockSequencerTarget : public FakeSequencerTarget {
 public:
   MockSequencerTarget();
   MOCK_METHOD1(callback, bool(OperationCallback));
-};
-
-class MockBenchmarkClient : public Client::BenchmarkClient {
-public:
-  MockBenchmarkClient();
-
-  MOCK_METHOD0(terminate, void());
-  MOCK_METHOD1(setShouldMeasureLatencies, void(bool));
-  MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
-  MOCK_METHOD1(tryStartRequest, bool(Client::CompletionCallback));
-  MOCK_CONST_METHOD0(scope, Envoy::Stats::Scope&());
-  MOCK_CONST_METHOD0(shouldMeasureLatencies, bool());
-  MOCK_CONST_METHOD0(requestHeaders, const Envoy::Http::HeaderMap&());
 };
 
 class MockRequestSource : public RequestSource {

--- a/test/mocks/client/BUILD
+++ b/test/mocks/client/BUILD
@@ -14,6 +14,17 @@ envoy_cc_mock(
     hdrs = ["mock_options.h"],
     repository = "@envoy",
     deps = [
-        "//source/client:nighthawk_client_lib",
+        "//include/nighthawk/client:client_includes",
+        "@envoy//source/common/protobuf:message_validator_lib_with_external_headers",
+    ],
+)
+
+envoy_cc_mock(
+    name = "mock_benchmark_client",
+    srcs = ["mock_benchmark_client.cc"],
+    hdrs = ["mock_benchmark_client.h"],
+    repository = "@envoy",
+    deps = [
+        "//include/nighthawk/client:client_includes",
     ],
 )

--- a/test/mocks/client/mock_benchmark_client.cc
+++ b/test/mocks/client/mock_benchmark_client.cc
@@ -1,0 +1,9 @@
+#include "test/mocks/client/mock_benchmark_client.h"
+
+namespace Nighthawk {
+namespace Client {
+
+MockBenchmarkClient::MockBenchmarkClient() = default;
+
+}
+} // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client.h
+++ b/test/mocks/client/mock_benchmark_client.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "nighthawk/client/benchmark_client.h"
+
+#include "gmock/gmock.h"
+
+namespace Nighthawk {
+namespace Client {
+
+class MockBenchmarkClient : public BenchmarkClient {
+public:
+  MockBenchmarkClient();
+
+  MOCK_METHOD0(terminate, void());
+  MOCK_METHOD1(setShouldMeasureLatencies, void(bool));
+  MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
+  MOCK_METHOD1(tryStartRequest, bool(Client::CompletionCallback));
+  MOCK_CONST_METHOD0(scope, Envoy::Stats::Scope&());
+  MOCK_CONST_METHOD0(shouldMeasureLatencies, bool());
+  MOCK_CONST_METHOD0(requestHeaders, const Envoy::Http::HeaderMap&());
+};
+
+} // namespace Client
+} // namespace Nighthawk

--- a/test/mocks/client/mock_options.cc
+++ b/test/mocks/client/mock_options.cc
@@ -1,7 +1,5 @@
 #include "test/mocks/client/mock_options.h"
 
-#include "gmock/gmock.h"
-
 namespace Nighthawk {
 namespace Client {
 

--- a/test/mocks/common/BUILD
+++ b/test/mocks/common/BUILD
@@ -1,0 +1,39 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_mock",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_mock(
+    name = "mock_rate_limiter",
+    srcs = ["mock_rate_limiter.cc"],
+    hdrs = ["mock_rate_limiter.h"],
+    repository = "@envoy",
+    deps = [
+        "//include/nighthawk/common:base_includes",
+    ],
+)
+
+envoy_cc_mock(
+    name = "mock_sequencer",
+    srcs = ["mock_sequencer.cc"],
+    hdrs = ["mock_sequencer.h"],
+    repository = "@envoy",
+    deps = [
+        "//include/nighthawk/common:base_includes",
+    ],
+)
+
+envoy_cc_mock(
+    name = "mock_termination_predicate",
+    srcs = ["mock_termination_predicate.cc"],
+    hdrs = ["mock_termination_predicate.h"],
+    repository = "@envoy",
+    deps = [
+        "//include/nighthawk/common:base_includes",
+    ],
+)

--- a/test/mocks/common/mock_rate_limiter.cc
+++ b/test/mocks/common/mock_rate_limiter.cc
@@ -1,0 +1,9 @@
+#include "test/mocks/common/mock_rate_limiter.h"
+
+namespace Nighthawk {
+
+MockRateLimiter::MockRateLimiter() = default;
+
+MockDiscreteNumericDistributionSampler::MockDiscreteNumericDistributionSampler() = default;
+
+} // namespace Nighthawk

--- a/test/mocks/common/mock_rate_limiter.h
+++ b/test/mocks/common/mock_rate_limiter.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "nighthawk/common/rate_limiter.h"
+
+#include "gmock/gmock.h"
+
+namespace Nighthawk {
+
+class MockRateLimiter : public RateLimiter {
+public:
+  MockRateLimiter();
+
+  MOCK_METHOD0(tryAcquireOne, bool());
+  MOCK_METHOD0(releaseOne, void());
+  MOCK_METHOD0(timeSource, Envoy::TimeSource&());
+  MOCK_METHOD0(elapsed, std::chrono::nanoseconds());
+};
+
+class MockDiscreteNumericDistributionSampler : public DiscreteNumericDistributionSampler {
+public:
+  MockDiscreteNumericDistributionSampler();
+  MOCK_METHOD0(getValue, uint64_t());
+  MOCK_CONST_METHOD0(min, uint64_t());
+  MOCK_CONST_METHOD0(max, uint64_t());
+};
+
+} // namespace Nighthawk

--- a/test/mocks/common/mock_sequencer.cc
+++ b/test/mocks/common/mock_sequencer.cc
@@ -1,0 +1,7 @@
+#include "test/mocks/common/mock_sequencer.h"
+
+namespace Nighthawk {
+
+MockSequencer::MockSequencer() = default;
+
+}

--- a/test/mocks/common/mock_sequencer.h
+++ b/test/mocks/common/mock_sequencer.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "nighthawk/common/sequencer.h"
+
+#include "gmock/gmock.h"
+
+namespace Nighthawk {
+
+class MockSequencer : public Sequencer {
+public:
+  MockSequencer();
+
+  MOCK_METHOD0(start, void());
+  MOCK_METHOD0(waitForCompletion, void());
+  MOCK_CONST_METHOD0(completionsPerSecond, double());
+  MOCK_CONST_METHOD0(executionDuration, std::chrono::nanoseconds());
+  MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
+  MOCK_METHOD0(cancel, void());
+};
+
+} // namespace Nighthawk

--- a/test/mocks/common/mock_termination_predicate.cc
+++ b/test/mocks/common/mock_termination_predicate.cc
@@ -1,0 +1,7 @@
+#include "test/mocks/common/mock_termination_predicate.h"
+
+namespace Nighthawk {
+
+MockTerminationPredicate::MockTerminationPredicate() = default;
+
+}

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "nighthawk/common/termination_predicate.h"
+
+#include "gmock/gmock.h"
+
+namespace Nighthawk {
+
+class MockTerminationPredicate : public TerminationPredicate {
+public:
+  MockTerminationPredicate();
+  MOCK_METHOD1(link, TerminationPredicate&(TerminationPredicatePtr&&));
+  MOCK_METHOD1(appendToChain, TerminationPredicate&(TerminationPredicatePtr&&));
+  MOCK_METHOD0(evaluateChain, TerminationPredicate::Status());
+  MOCK_METHOD0(evaluate, TerminationPredicate::Status());
+};
+
+} // namespace Nighthawk

--- a/test/rate_limiter_test.cc
+++ b/test/rate_limiter_test.cc
@@ -7,7 +7,7 @@
 #include "common/frequency.h"
 #include "common/rate_limiter_impl.h"
 
-#include "test/mocks.h"
+#include "test/mocks/common/mock_rate_limiter.h"
 
 #include "gtest/gtest.h"
 

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -14,8 +14,9 @@
 #include "common/statistic_impl.h"
 
 #include "test/mocks.h"
+#include "test/mocks/common/mock_rate_limiter.h"
+#include "test/mocks/common/mock_termination_predicate.h"
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using namespace std::chrono_literals;
@@ -23,6 +24,18 @@ using namespace nighthawk::client;
 using namespace testing;
 
 namespace Nighthawk {
+
+class FakeSequencerTarget {
+public:
+  virtual ~FakeSequencerTarget() = default;
+  // A fake method that matches the sequencer target signature.
+  virtual bool callback(OperationCallback) PURE;
+};
+
+class MockSequencerTarget : public FakeSequencerTarget {
+public:
+  MOCK_METHOD1(callback, bool(OperationCallback));
+};
 
 class SequencerTestBase : public testing::Test {
 public:


### PR DESCRIPTION
Part of an effort to attempt to reduce memory usage during
the build, to address ASAN flakes in CI.

- This is a mechanical change, no functional changes
- Moves the mocks for:
  - BenchmarkClient
  - RateLimiter
  - TerminationPredicate
  - Sequencer
- Contains some additional cleanup.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>