### PR TITLE
Move MockPlatformUtil and MockRequestSource

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -17,7 +17,6 @@ envoy_cc_mock(
     deps = [
         "//include/nighthawk/common:base_includes",
         "//source/client:nighthawk_client_lib",
-        "@envoy//test/test_common:simulated_time_system_lib",
     ],
 )
 
@@ -61,6 +60,7 @@ envoy_cc_test(
         "//test:nighthawk_mocks",
         "//test/mocks/client:mock_benchmark_client",
         "//test/mocks/client:mock_options",
+        "//test/mocks/common:mock_request_source",
         "//test/mocks/common:mock_sequencer",
         "//test/mocks/common:mock_termination_predicate",
         "@envoy//source/common/api:api_lib",
@@ -171,7 +171,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/common:nighthawk_common_lib",
-        "//test:nighthawk_mocks",
+        "//test/mocks/common:mock_platform_util",
         "//test/mocks/common:mock_rate_limiter",
         "//test/mocks/common:mock_termination_predicate",
         "@envoy//source/common/event:dispatcher_includes_with_external_headers",

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -18,6 +18,7 @@
 #include "test/mocks.h"
 #include "test/mocks/client/mock_benchmark_client.h"
 #include "test/mocks/client/mock_options.h"
+#include "test/mocks/common/mock_request_source.h"
 #include "test/mocks/common/mock_sequencer.h"
 #include "test/mocks/common/mock_termination_predicate.h"
 
@@ -25,6 +26,7 @@
 
 using namespace testing;
 using namespace std::chrono_literals;
+
 namespace Nighthawk {
 namespace Client {
 

--- a/test/mocks.cc
+++ b/test/mocks.cc
@@ -4,20 +4,14 @@
 
 namespace Nighthawk {
 
-MockPlatformUtil::MockPlatformUtil() = default;
-
 MockBenchmarkClientFactory::MockBenchmarkClientFactory() = default;
 
 MockSequencerFactory::MockSequencerFactory() = default;
-
-MockStoreFactory::MockStoreFactory() = default;
 
 MockStatisticFactory::MockStatisticFactory() = default;
 
 MockRequestSourceFactory::MockRequestSourceFactory() = default;
 
 MockTerminationPredicateFactory::MockTerminationPredicateFactory() = default;
-
-MockRequestSource::MockRequestSource() = default;
 
 } // namespace Nighthawk

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -1,40 +1,18 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-
 #include "envoy/api/api.h"
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
-#include "envoy/stats/store.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "nighthawk/client/factories.h"
-#include "nighthawk/common/platform_util.h"
-#include "nighthawk/common/request_source.h"
 #include "nighthawk/common/statistic.h"
-#include "nighthawk/common/uri.h"
 
-#include "external/envoy/test/test_common/simulated_time_system.h"
-
-#include "common/utility.h"
-
-#include "absl/types/optional.h"
 #include "gmock/gmock.h"
-
-using namespace std::chrono_literals;
 
 namespace Nighthawk {
 
 // TODO(oschaaf): split this out in files for common/ and client/ mocks
-
-class MockPlatformUtil : public PlatformUtil {
-public:
-  MockPlatformUtil();
-
-  MOCK_CONST_METHOD0(yieldCurrentThread, void());
-  MOCK_CONST_METHOD1(sleep, void(std::chrono::microseconds));
-};
 
 class MockBenchmarkClientFactory : public Client::BenchmarkClientFactory {
 public:
@@ -56,12 +34,6 @@ public:
                                           TerminationPredicatePtr&& termination_predicate,
                                           Envoy::Stats::Scope& scope,
                                           const Envoy::MonotonicTime scheduled_starting_time));
-};
-
-class MockStoreFactory : public Client::StoreFactory {
-public:
-  MockStoreFactory();
-  MOCK_CONST_METHOD0(create, Envoy::Stats::StorePtr());
 };
 
 class MockStatisticFactory : public Client::StatisticFactory {
@@ -87,13 +59,6 @@ public:
                      TerminationPredicatePtr(Envoy::TimeSource& time_source,
                                              Envoy::Stats::Scope& scope,
                                              const Envoy::MonotonicTime scheduled_starting_time));
-};
-
-class MockRequestSource : public RequestSource {
-public:
-  MockRequestSource();
-  MOCK_METHOD0(get, RequestGenerator());
-  MOCK_METHOD0(initOnThread, void());
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/BUILD
+++ b/test/mocks/common/BUILD
@@ -37,3 +37,23 @@ envoy_cc_mock(
         "//include/nighthawk/common:base_includes",
     ],
 )
+
+envoy_cc_mock(
+    name = "mock_platform_util",
+    srcs = ["mock_platform_util.cc"],
+    hdrs = ["mock_platform_util.h"],
+    repository = "@envoy",
+    deps = [
+        "//include/nighthawk/common:base_includes",
+    ],
+)
+
+envoy_cc_mock(
+    name = "mock_request_source",
+    srcs = ["mock_request_source.cc"],
+    hdrs = ["mock_request_source.h"],
+    repository = "@envoy",
+    deps = [
+        "//include/nighthawk/common:base_includes",
+    ],
+)

--- a/test/mocks/common/mock_platform_util.cc
+++ b/test/mocks/common/mock_platform_util.cc
@@ -1,0 +1,7 @@
+#include "test/mocks/common/mock_platform_util.h"
+
+namespace Nighthawk {
+
+MockPlatformUtil::MockPlatformUtil() = default;
+
+}

--- a/test/mocks/common/mock_platform_util.h
+++ b/test/mocks/common/mock_platform_util.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "nighthawk/common/platform_util.h"
+
+#include "gmock/gmock.h"
+
+namespace Nighthawk {
+
+class MockPlatformUtil : public PlatformUtil {
+public:
+  MockPlatformUtil();
+
+  MOCK_CONST_METHOD0(yieldCurrentThread, void());
+  MOCK_CONST_METHOD1(sleep, void(std::chrono::microseconds));
+};
+
+} // namespace Nighthawk

--- a/test/mocks/common/mock_request_source.cc
+++ b/test/mocks/common/mock_request_source.cc
@@ -1,0 +1,7 @@
+#include "test/mocks/common/mock_request_source.h"
+
+namespace Nighthawk {
+
+MockRequestSource::MockRequestSource() = default;
+
+} // namespace Nighthawk

--- a/test/mocks/common/mock_request_source.h
+++ b/test/mocks/common/mock_request_source.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "nighthawk/common/request_source.h"
+
+#include "gmock/gmock.h"
+
+namespace Nighthawk {
+
+class MockRequestSource : public RequestSource {
+public:
+  MockRequestSource();
+  MOCK_METHOD0(get, RequestGenerator());
+  MOCK_METHOD0(initOnThread, void());
+};
+
+} // namespace Nighthawk

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -13,7 +13,7 @@
 #include "common/sequencer_impl.h"
 #include "common/statistic_impl.h"
 
-#include "test/mocks.h"
+#include "test/mocks/common/mock_platform_util.h"
 #include "test/mocks/common/mock_rate_limiter.h"
 #include "test/mocks/common/mock_termination_predicate.h"
 


### PR DESCRIPTION
Part of an effort to attempt to reduce memory usage during
the build, to address ASAN flakes in CI.

- This is a mechanical change, no functional changes.
- Does have some additional cleanup.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>