### PR TITLE
Dead code: eliminate StoreFactory

### DIFF
--- a/include/nighthawk/client/factories.h
+++ b/include/nighthawk/client/factories.h
@@ -6,7 +6,6 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
-#include "envoy/stats/store.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "nighthawk/client/benchmark_client.h"
@@ -41,12 +40,6 @@ public:
                               TerminationPredicatePtr&& termination_predicate,
                               Envoy::Stats::Scope& scope,
                               const Envoy::MonotonicTime scheduled_starting_time) const PURE;
-};
-
-class StoreFactory {
-public:
-  virtual ~StoreFactory() = default;
-  virtual Envoy::Stats::StorePtr create() const PURE;
 };
 
 class StatisticFactory {

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -69,7 +69,6 @@ envoy_cc_library(
         "@envoy//source/common/secret:secret_manager_impl_lib_with_external_headers",
         "@envoy//source/common/singleton:manager_impl_lib_with_external_headers",
         "@envoy//source/common/stats:allocator_lib_with_external_headers",
-        "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
         "@envoy//source/common/stats:symbol_table_lib_with_external_headers",
         "@envoy//source/common/stats:thread_local_store_lib_with_external_headers",
         "@envoy//source/common/stream_info:stream_info_lib_with_external_headers",

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -1,7 +1,6 @@
 #include "client/factories_impl.h"
 
 #include "external/envoy/source/common/http/header_map_impl.h"
-#include "external/envoy/source/common/stats/isolated_store_impl.h"
 
 #include "api/client/options.pb.h"
 
@@ -80,12 +79,6 @@ SequencerPtr SequencerFactoryImpl::create(
       platform_util_, dispatcher, time_source, std::move(rate_limiter), sequencer_target,
       statistic_factory.create(), statistic_factory.create(), options_.sequencerIdleStrategy(),
       std::move(termination_predicate), scope, scheduled_starting_time);
-}
-
-StoreFactoryImpl::StoreFactoryImpl(const Options& options) : OptionBasedFactoryImpl(options) {}
-
-Envoy::Stats::StorePtr StoreFactoryImpl::create() const {
-  return std::make_unique<Envoy::Stats::IsolatedStoreImpl>();
 }
 
 StatisticFactoryImpl::StatisticFactoryImpl(const Options& options)

--- a/source/client/factories_impl.h
+++ b/source/client/factories_impl.h
@@ -2,7 +2,6 @@
 
 #include "envoy/api/api.h"
 #include "envoy/event/dispatcher.h"
-#include "envoy/stats/store.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "nighthawk/client/factories.h"
@@ -42,12 +41,6 @@ public:
                       BenchmarkClient& benchmark_client,
                       TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope,
                       const Envoy::MonotonicTime scheduled_starting_time) const override;
-};
-
-class StoreFactoryImpl : public OptionBasedFactoryImpl, public StoreFactory {
-public:
-  StoreFactoryImpl(const Options& options);
-  Envoy::Stats::StorePtr create() const override;
 };
 
 class StatisticFactoryImpl : public OptionBasedFactoryImpl, public StatisticFactory {

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -98,8 +98,7 @@ private:
 };
 
 ProcessImpl::ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_system)
-    : time_system_(time_system), store_factory_(options), stats_allocator_(symbol_table_),
-      store_root_(stats_allocator_),
+    : time_system_(time_system), stats_allocator_(symbol_table_), store_root_(stats_allocator_),
       api_(std::make_unique<Envoy::Api::Impl>(platform_impl_.threadFactory(), store_root_,
                                               time_system_, platform_impl_.fileSystem())),
       dispatcher_(api_->allocateDispatcher()), benchmark_client_factory_(options),

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -95,7 +95,6 @@ private:
   Envoy::ProcessWide process_wide_;
   Envoy::PlatformImpl platform_impl_;
   Envoy::Event::TimeSystem& time_system_;
-  StoreFactoryImpl store_factory_;
   Envoy::Stats::SymbolTableImpl symbol_table_;
   Envoy::Stats::AllocatorImpl stats_allocator_;
   Envoy::ThreadLocal::InstanceImpl tls_;

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -104,11 +104,6 @@ INSTANTIATE_TEST_SUITE_P(SequencerIdleStrategies, SequencerFactoryTest,
                                    nighthawk::client::SequencerIdleStrategy::SLEEP,
                                    nighthawk::client::SequencerIdleStrategy::SPIN}));
 
-TEST_F(FactoriesTest, CreateStore) {
-  StoreFactoryImpl factory(options_);
-  EXPECT_NE(nullptr, factory.create().get());
-}
-
 TEST_F(FactoriesTest, CreateStatistic) {
   StatisticFactoryImpl factory(options_);
   EXPECT_NE(nullptr, factory.create().get());


### PR DESCRIPTION
Just noticed some code that no longer is actually used.

Context:

StoreFactory became obsolete when it became apparent that
the isolated stats store implementation didn't have enough
production mileage to be a suitable candidate. We switched
to use the thread local backing store.

Today NH is basically hard-coupled to that store, as it builds
on top of some of its shared semantics, so this abstraction
probably will not be useful in the foreseeable future.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>