### PR TITLE
Update Envoy dep

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "5be15b31aa46e3c3776a15fd3d399c67ac432598"  # Feb 21st, 2020
-ENVOY_SHA = "cb8169e869c205edb410f4384771efe81a23e7ce1388f28ad39af9f26d00cad6"
+ENVOY_COMMIT = "3a2512d923e2eee1fce9f4f6a23cf93f2e7ed93f"  # March 1st, 2020
+ENVOY_SHA = "6a643ae3141762c403aa031cc19e65c441759785fd7dda51dcf5ad5f149283d0"
 
 RULES_PYTHON_COMMIT = "dd7f9c5f01bafbfea08c44092b6b0c8fc8fcb77f"  # Feb 22nd, 2020
 RULES_PYTHON_SHA = "0aa9ec790a58053e3ab5af397879b267a625955f8297c239b2d8559c6773397b"

--- a/source/common/uri_impl.cc
+++ b/source/common/uri_impl.cc
@@ -69,9 +69,10 @@ bool UriImpl::performDnsLookup(Envoy::Event::Dispatcher& dispatcher,
   Envoy::Network::ActiveDnsQuery* active_dns_query_ = dns_resolver->resolve(
       hostname, dns_lookup_family,
       [this, &dispatcher,
-       &active_dns_query_](std::list<Envoy::Network::DnsResponse>&& response) -> void {
+       &active_dns_query_](Envoy::Network::DnsResolver::ResolutionStatus status,
+                           std::list<Envoy::Network::DnsResponse>&& response) -> void {
         active_dns_query_ = nullptr;
-        if (!response.empty()) {
+        if (!response.empty() && status == Envoy::Network::DnsResolver::ResolutionStatus::Success) {
           address_ =
               Envoy::Network::Utility::getAddressWithPort(*response.front().address_, port());
           ENVOY_LOG(debug, "DNS resolution complete for {} ({} entries, using {}).",


### PR DESCRIPTION
One change on the NH side: Envoy's Dns resolution api changed.
Updates Envoy to 3a2512d923e2eee1fce9f4f6a23cf93f2e7ed93f

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>