### PR TITLE
CI/ASAN: Break ASAN build in multiple steps to reduce memory usage

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -73,6 +73,11 @@ function do_asan() {
     echo "bazel ASAN/UBSAN debug build with tests"
     echo "Building and testing envoy tests..."
     cd "${SRCDIR}"
+    # We build this in steps to avoid running out of memory in CI
+    run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan -- //source/exe/...
+    run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan -- //source/server/...
+    run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan -- //test/mocks/...
+    run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan -- //test/...
     run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan //test/...
 }
 
@@ -177,10 +182,6 @@ case "$1" in
         exit 0
     ;;
     asan)
-        if [ -n "$CIRCLECI" ]; then
-            # Decrease parallelism to avoid running out of memory
-            NUM_CPUS=7
-        fi
         do_asan
         exit 0
     ;;


### PR DESCRIPTION
- Perform the build in incremental steps, to reduce memory footprint of the build.
- Additionally, separate test and build, to ensure they won't run concurrently. This helps stabilize the python integration test.

These two things combined seem to help stabilize ASAN in CI. I could confirm a couple of
consecutive succeeding CI runs:
https://app.circleci.com/pipelines/github/envoyproxy/nighthawk?branch=pull%2F315

Associated issue: https://github.com/envoyproxy/nighthawk/issues/272
Leaving that open for now, let's close it later if we're confident the problem is resolved.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>
