### PR TITLE
Removing unused loader envoy_cc_mock

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -2,7 +2,6 @@ licenses(["notice"])  # Apache 2
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_cc_mock",
     "envoy_cc_test",
     "envoy_package",
 )


### PR DESCRIPTION
Cleaning up an unused loader `envoy_cc_mock`

Risk: Low

Signed-off-by: Adi Suissa-Peleg <adip@google.com>