### PR TITLE
CircleCI: reduce ASAN parallelism

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -73,7 +73,6 @@ function do_asan() {
     echo "bazel ASAN/UBSAN debug build with tests"
     echo "Building and testing envoy tests..."
     cd "${SRCDIR}"
-    [ -z "$CIRCLECI" ] || export BAZEL_BUILD_OPTIONS="${BAZEL_TEST_OPTIONS} --jobs=4 --local_ram_resources=12288"
 
     # We build this in steps to avoid running out of memory in CI
     run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan -- //source/exe/... && \
@@ -123,6 +122,9 @@ if [ -n "$CIRCLECI" ]; then
     fi
     # We constrain parallelism in CI to avoid running out of memory.	
     NUM_CPUS=8
+    if [ "$1" == "asan" ]; then
+        NUM_CPUS=5
+    fi
 fi
 
 if grep 'docker\|lxc' /proc/1/cgroup; then


### PR DESCRIPTION
Another stab at https://github.com/envoyproxy/nighthawk/issues/272
Since the last Envoy update the ASAN build runs out of memory more often then not.

I noticed that the earlier attempt at reducing `NUM_CPUS`/`--jobs` didn't yield expected
results in CI, as bazel would still be running 8 jobs in parallel.

Upon investigation, I noticed that my earlier attempt had issues:
- it set the wrong variable
- upon fixing that, the script would end up handing two `--jobs=x` arguments to bazel

The approach here sets `NUM_CPUS` early on in the script, and doesn't attempt to mess
with the build flags later on.

Hopefully fixes https://github.com/envoyproxy/nighthawk/issues/272

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>