### PR TITLE
integration-tests: tweaks to stabilize sanitizer runs

### DIFF
--- a/test/integration/nighthawk_grpc_service.py
+++ b/test/integration/nighthawk_grpc_service.py
@@ -60,7 +60,7 @@ class NighthawkGrpcService(object):
       self._address_file = None
 
   def _waitUntilServerListening(self):
-    tries = 30
+    tries = 90
     while tries > 0:
       contents = ""
       if not self._address_file is None:

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -53,7 +53,7 @@ class TestServerBase(object):
   def serverThreadRunner(self):
     args = [
         self.server_binary_path, self.server_binary_config_path_arg, self.parameterized_config_path,
-        "-l", "error", "--base-id", self.instance_id, "--admin-address-path",
+        "-l", "error", "--concurrency", "1", "--base-id", self.instance_id, "--admin-address-path",
         self.admin_address_path
     ]
     logging.info("Test server popen() args: [%s]" % args)
@@ -101,7 +101,7 @@ class TestServerBase(object):
   def waitUntilServerListening(self):
     # we allow 30 seconds for the server to have its listeners up.
     # (It seems that in sanitizer-enabled runs this can take a little while)
-    timeout = time.time() + 30
+    timeout = time.time() + 60
     while time.time() < timeout:
       if self.tryUpdateFromAdminInterface():
         return True

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -53,7 +53,7 @@ class TestServerBase(object):
   def serverThreadRunner(self):
     args = [
         self.server_binary_path, self.server_binary_config_path_arg, self.parameterized_config_path,
-        "-l", "error", "--concurrency", "1", "--base-id", self.instance_id, "--admin-address-path",
+        "-l", "error", "--base-id", self.instance_id, "--admin-address-path",
         self.admin_address_path
     ]
     logging.info("Test server popen() args: [%s]" % args)

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -127,5 +127,4 @@ def test_h1_pool_strategy(http_test_server_fixture):
   for i in range(1, connections):
     line_count = countLogLinesWithSubstring(logs, "[C%d] message complete" % i)
     strict_count = (requests / connections) * 2
-    # We need to mind a single warmup call
     assertBetweenInclusive(line_count, strict_count, strict_count)

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -107,26 +107,25 @@ def test_h1_pool_strategy(http_test_server_fixture):
     return len([line for line in logs.split(os.linesep) if substring in line])
 
   _, logs = http_test_server_fixture.runNighthawkClient([
-      "--rps 20", "-v", "trace", "--connections", "2", "--prefetch-connections",
+      "--rps 5", "-v", "trace", "--connections", "2", "--prefetch-connections",
       "--experimental-h1-connection-reuse-strategy", "mru", "--termination-predicate",
-      "benchmark.http_2xx:10", "--simple-warmup",
-      http_test_server_fixture.getTestServerRootUri()
+      "benchmark.http_2xx:4", http_test_server_fixture.getTestServerRootUri()
   ])
 
-  requests = 60
-  connections = 3
   assertNotIn("[C1] message complete", logs)
-  assertEqual(countLogLinesWithSubstring(logs, "[C0] message complete"), 22)
+  assertEqual(countLogLinesWithSubstring(logs, "[C0] message complete"), 10)
 
+  requests = 12
+  connections = 3
   _, logs = http_test_server_fixture.runNighthawkClient([
-      "--rps", "20", "-v trace", "--connections",
+      "--rps", "5", "-v trace", "--connections",
       str(connections), "--prefetch-connections", "--experimental-h1-connection-reuse-strategy",
       "lru", "--termination-predicate",
-      "benchmark.http_2xx:%d" % requests,
+      "benchmark.http_2xx:%d" % (requests-1),
       http_test_server_fixture.getTestServerRootUri()
   ])
   for i in range(1, connections):
     line_count = countLogLinesWithSubstring(logs, "[C%d] message complete" % i)
     strict_count = (requests / connections) * 2
     # We need to mind a single warmup call
-    assertBetweenInclusive(line_count, strict_count, strict_count + 2)
+    assertBetweenInclusive(line_count, strict_count, strict_count)

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -109,7 +109,8 @@ def test_h1_pool_strategy(http_test_server_fixture):
   _, logs = http_test_server_fixture.runNighthawkClient([
       "--rps 5", "-v", "trace", "--connections", "2", "--prefetch-connections",
       "--experimental-h1-connection-reuse-strategy", "mru", "--termination-predicate",
-      "benchmark.http_2xx:4", http_test_server_fixture.getTestServerRootUri()
+      "benchmark.http_2xx:4",
+      http_test_server_fixture.getTestServerRootUri()
   ])
 
   assertNotIn("[C1] message complete", logs)
@@ -121,7 +122,7 @@ def test_h1_pool_strategy(http_test_server_fixture):
       "--rps", "5", "-v trace", "--connections",
       str(connections), "--prefetch-connections", "--experimental-h1-connection-reuse-strategy",
       "lru", "--termination-predicate",
-      "benchmark.http_2xx:%d" % (requests-1),
+      "benchmark.http_2xx:%d" % (requests - 1),
       http_test_server_fixture.getTestServerRootUri()
   ])
   for i in range(1, connections):

--- a/test/integration/test_grpc_service.py
+++ b/test/integration/test_grpc_service.py
@@ -8,13 +8,13 @@ from utility import *
 def test_grpc_service_happy_flow(http_test_server_fixture):
   http_test_server_fixture.startNighthawkGrpcService("dummy-request-source")
   parsed_json, _ = http_test_server_fixture.runNighthawkClient([
-      "--termination-predicate", "benchmark.http_2xx:10", "--rps 100",
+      "--termination-predicate", "benchmark.http_2xx:5", "--rps 10",
       "--request-source %s:%s" % (http_test_server_fixture.grpc_service.server_ip,
                                   http_test_server_fixture.grpc_service.server_port),
       http_test_server_fixture.getTestServerRootUri()
   ])
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  assertGreaterEqual(counters["benchmark.http_2xx"], 10)
+  assertGreaterEqual(counters["benchmark.http_2xx"], 5)
   assertEqual(counters["requestsource.internal.upstream_rq_200"], 1)
 
 

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -310,7 +310,7 @@ def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2)
         https_test_server_fixture.getTestServerRootUri()
     ])
     counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-    assertCounterEqual(counters, "ssl.ciphers.%s" % cipher, 1)
+    assertCounterGreaterEqual(counters, "ssl.ciphers.%s" % cipher, 1)
 
 
 def test_https_h1_tls_context_configuration(https_test_server_fixture):

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -87,8 +87,8 @@ def test_http_h1_mini_stress_test_with_client_side_queueing(http_test_server_fix
       "10", "--connections", "1", "--duration", "100", "--termination-predicate",
       "benchmark.http_2xx:99", "--simple-warmup"
   ])
-  assertCounterEqual(counters, "upstream_rq_pending_total", 11)
-  assertCounterEqual(counters, "upstream_cx_overflow", 10)
+  assertCounterGreaterEqual(counters, "upstream_rq_pending_total", 11)
+  assertCounterGreaterEqual(counters, "upstream_cx_overflow", 10)
 
 
 def test_http_h1_mini_stress_test_without_client_side_queueing(http_test_server_fixture):
@@ -115,7 +115,7 @@ def test_http_h2_mini_stress_test_with_client_side_queueing(http_test_server_fix
       "--termination-predicate", "benchmark.http_2xx:99", "--simple-warmup"
   ])
   assertCounterEqual(counters, "upstream_rq_pending_total", 1)
-  assertCounterEqual(counters, "upstream_rq_pending_overflow", 10)
+  assertCounterGreaterEqual(counters, "upstream_rq_pending_overflow", 10)
 
 
 def test_http_h2_mini_stress_test_without_client_side_queueing(http_test_server_fixture):
@@ -124,7 +124,7 @@ def test_http_h2_mini_stress_test_without_client_side_queueing(http_test_server_
   queueing. 
   """
   counters = mini_stress_test(http_test_server_fixture, [
-      http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--h2",
+      http_test_server_fixture.getTestServerRootUri(), "--rps", "1000", "--h2",
       "--max-active-requests", "1", "--connections", "1", "--duration", "100",
       "--termination-predicate", "benchmark.http_2xx:99"
   ])
@@ -276,7 +276,7 @@ def test_https_h2_multiple_connections(https_test_server_fixture):
       "10"
   ])
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  assertCounterEqual(counters, "benchmark.http_2xx", 100)
+  assertCounterGreaterEqual(counters, "benchmark.http_2xx", 100)
   # Empirical observation shows we may end up creating more then 10 connections.
   # This is stock Envoy h/2 pool behavior.
   assertCounterGreaterEqual(counters, "upstream_cx_http2_total", 10)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -138,7 +138,7 @@ def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   H1 open loop stress test. We expect higher pending and overflow counts 
   """
   counters = mini_stress_test(http_test_server_fixture, [
-      http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--max-pending-requests",
+      http_test_server_fixture.getTestServerRootUri(), "--rps", "10000", "--max-pending-requests",
       "1", "--open-loop", "--max-active-requests", "1", "--connections", "1", "--duration", "100",
       "--termination-predicate", "benchmark.http_2xx:99", "--simple-warmup"
   ])

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -124,7 +124,7 @@ def test_http_h2_mini_stress_test_without_client_side_queueing(http_test_server_
   queueing. 
   """
   counters = mini_stress_test(http_test_server_fixture, [
-      http_test_server_fixture.getTestServerRootUri(), "--rps", "1000", "--h2",
+      http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--h2",
       "--max-active-requests", "1", "--connections", "1", "--duration", "100",
       "--termination-predicate", "benchmark.http_2xx:99"
   ])
@@ -138,7 +138,7 @@ def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   H1 open loop stress test. We expect higher pending and overflow counts 
   """
   counters = mini_stress_test(http_test_server_fixture, [
-      http_test_server_fixture.getTestServerRootUri(), "--rps", "10000", "--max-pending-requests",
+      http_test_server_fixture.getTestServerRootUri(), "--rps", "999999", "--max-pending-requests",
       "1", "--open-loop", "--max-active-requests", "1", "--connections", "1", "--duration", "100",
       "--termination-predicate", "benchmark.http_2xx:99", "--simple-warmup"
   ])

--- a/test/integration/test_remote_execution.py
+++ b/test/integration/test_remote_execution.py
@@ -20,7 +20,7 @@ def test_remote_execution_basics(http_test_server_fixture):
   ]
   parsed_json, _ = http_test_server_fixture.runNighthawkClient(args)
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  assertCounterEqual(counters, "benchmark.http_2xx", 25)
+  assertCounterGreaterEqual(counters, "benchmark.http_2xx", 25)
 
   # As a control step, prove we are actually performing remote execution: re-run the command without an
   # operational gRPC service. That ought to fail.


### PR DESCRIPTION
This PR has changes to deflake integration tests for sanitizer runs.

- Allow servers more time to start up
- Slow down some tests to make them less sensitive to timing issues 
- It is possible for some counter values to slightly exceed a configured termination threshold
  for them in edge cases. Update expectations to match that. 

Fixes #332 