### PR TITLE
Fix benchmark_http_client_test.cc and add test cases.

### DIFF
--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -99,14 +99,15 @@ public:
       }
     }
 
-    // If max_pending is set to 0, and we queued up work, we shouldn't be able to add more.
-    if (max_pending == 0 && amount > 0) {
+    const uint64_t max_in_flight_allowed = max_pending + connection_limit;
+    // If amount_of_request >= max_in_flight_allowed, we are not able to add more request.
+    if (amount >= max_in_flight_allowed) {
       EXPECT_FALSE(client_->tryStartRequest(f));
     }
 
     dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
-    // If max pending is set > 0, we expect in_flight to be equal to max_pending.
-    EXPECT_EQ(max_pending == 0 ? 1 : max_pending, inflight_response_count);
+    // Expect inflight_response_count to be equal to min(amount, max_in_flight_allowed).
+    EXPECT_EQ(amount < max_in_flight_allowed ? amount : max_in_flight_allowed, inflight_response_count);
 
     for (Envoy::Http::ResponseDecoder* decoder : decoders_) {
       Envoy::Http::ResponseHeaderMapPtr response_headers{
@@ -160,6 +161,18 @@ public:
   RequestGenerator request_generator_;
 };
 
+TEST_F(BenchmarkClientHttpTest, BasicTestH1200) {
+  response_code_ = "200";
+  testBasicFunctionality(2, 3, 10);
+  EXPECT_EQ(5, getCounter("http_2xx"));
+}
+  
+TEST_F(BenchmarkClientHttpTest, BasicTestH1300) {
+  response_code_ = "300";
+  testBasicFunctionality(0, 11, 10);
+  EXPECT_EQ(10, getCounter("http_2xx"));
+}
+  
 TEST_F(BenchmarkClientHttpTest, BasicTestH1404) {
   response_code_ = "404";
   testBasicFunctionality(0, 1, 10);
@@ -261,6 +274,7 @@ TEST_F(BenchmarkClientHttpTest, BadContentLength) {
   };
 
   // Note we we explicitly do not expect encodeData to be called.
+  EXPECT_CALL(stream_encoder_, encodeData(_, _)).Times(0);
   testBasicFunctionality(1, 1, 1);
   EXPECT_EQ(1, getCounter("http_2xx"));
 }

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -107,7 +107,8 @@ public:
 
     dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
     // Expect inflight_response_count to be equal to min(amount, max_in_flight_allowed).
-    EXPECT_EQ(amount < max_in_flight_allowed ? amount : max_in_flight_allowed, inflight_response_count);
+    EXPECT_EQ(amount < max_in_flight_allowed ? amount : max_in_flight_allowed,
+              inflight_response_count);
 
     for (Envoy::Http::ResponseDecoder* decoder : decoders_) {
       Envoy::Http::ResponseHeaderMapPtr response_headers{
@@ -166,13 +167,13 @@ TEST_F(BenchmarkClientHttpTest, BasicTestH1200) {
   testBasicFunctionality(2, 3, 10);
   EXPECT_EQ(5, getCounter("http_2xx"));
 }
-  
+
 TEST_F(BenchmarkClientHttpTest, BasicTestH1300) {
   response_code_ = "300";
   testBasicFunctionality(0, 11, 10);
   EXPECT_EQ(10, getCounter("http_3xx"));
 }
-  
+
 TEST_F(BenchmarkClientHttpTest, BasicTestH1404) {
   response_code_ = "404";
   testBasicFunctionality(0, 1, 10);

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -170,7 +170,7 @@ TEST_F(BenchmarkClientHttpTest, BasicTestH1200) {
 TEST_F(BenchmarkClientHttpTest, BasicTestH1300) {
   response_code_ = "300";
   testBasicFunctionality(0, 11, 10);
-  EXPECT_EQ(10, getCounter("http_2xx"));
+  EXPECT_EQ(10, getCounter("http_3xx"));
 }
   
 TEST_F(BenchmarkClientHttpTest, BasicTestH1404) {

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -274,7 +274,6 @@ TEST_F(BenchmarkClientHttpTest, BadContentLength) {
     return std::make_unique<RequestImpl>(header);
   };
 
-  // Note we we explicitly do not expect encodeData to be called.
   EXPECT_CALL(stream_encoder_, encodeData(_, _)).Times(0);
   testBasicFunctionality(1, 1, 1);
   EXPECT_EQ(1, getCounter("http_2xx"));


### PR DESCRIPTION
Fix benchmark_http_client_test.cc which has a bug in function testBasicFunctionality().

For example, if we have a test fixture with testBasicFunctionality(max_pending=0,connection_limit=15,amount_of_request=10),
then EXPECT_FALSE(client_->tryStartRequest(f)) and
EXPECT_EQ(max_pending == 0 ? 1 : max_pending, inflight_response_count) will fail.

For test fixture with
testBasicFunctionality(max_pending=2,connection_limit=3,amount_of_request=10),
EXPECT_EQ(max_pending == 0 ? 1 : max_pending, inflight_response_count) will fail.

Added 2 test cases to verify the expected behavior fixed by this change.

Tested:
Unit test.