### PR TITLE
Update Envoy to 5c553261d14730af5a2c290c4b3687ae667a65db

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "7f251daa2e488587bc7335f91faceed420f162c4"  # June 19th, 2020
-ENVOY_SHA = "bc14914c9639eca9c5b2b09117b812796067c17c7f1d0d3f7ad622d554323d94"
+ENVOY_COMMIT = "5c553261d14730af5a2c290c4b3687ae667a65db"  # June 26th, 2020
+ENVOY_SHA = "ebfd3ead4347d27542aa7603ba2ce650d4ada7bdc21441073b85cf2e26f257d8"
 
 HDR_HISTOGRAM_C_VERSION = "0.9.13"  # Feb 22nd, 2020
 HDR_HISTOGRAM_C_SHA = "2bd4a4631b64f2f8cf968ef49dd03ff3c51b487c3c98a01217ae4cf4a35b8310"

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -28,7 +28,7 @@ Http1PoolImpl::newStream(Envoy::Http::ResponseDecoder& response_decoder,
     while (host_->cluster().resourceManager(priority_).connections().canCreate()) {
       // We cannot rely on ::tryCreateConnection here, because that might decline without
       // updating connections().canCreate() above. We would risk an infinite loop.
-      ActiveClientPtr client = instantiateActiveClient();
+      Envoy::ConnectionPool::ActiveClientPtr client = instantiateActiveClient();
       connecting_request_capacity_ += client->effectiveConcurrentRequestLimit();
       client->moveIntoList(std::move(client), owningList(client->state_));
     }
@@ -38,7 +38,8 @@ Http1PoolImpl::newStream(Envoy::Http::ResponseDecoder& response_decoder,
   // of ready_clients_, which will pick the oldest one instead. This makes us cycle through
   // all the available connections.
   if (!ready_clients_.empty() && connection_reuse_strategy_ == ConnectionReuseStrategy::LRU) {
-    attachRequestToClient(*ready_clients_.back(), response_decoder, callbacks);
+    auto context = std::make_pair(&response_decoder, &callbacks);
+    attachRequestToClientImpl(*ready_clients_.back(), &context);
     return nullptr;
   }
 


### PR DESCRIPTION
Notable changes:

- Fixes our Http1PoolImpl to work with the updated Envoy
  code.
- Tweaks the cluster setup: we specify at least an empty
  http2_protocol_options proto config. Without doing this
  passing --h2 to the nighthawk client would fail as caught
  by tests.
- Moves away from using hidden_envoy_deprecated_hosts.
  Side effect of looking into the bevavioral change listed
  above. This resolves #377. (strictly not needed for this
  update).

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>