### PR TITLE
Add new NH statistic class CircllhistStatistic and SinkableCircllhist…

### DIFF
--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -109,7 +109,7 @@ envoy_cc_library(
         "@envoy//source/common/http:utility_lib_with_external_headers",
         "@envoy//source/common/network:utility_lib_with_external_headers",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
-        "@envoy//source/common/stats:stats_lib_with_external_headers",
+        "@envoy//source/common/stats:histogram_lib_with_external_headers",
         "@envoy//source/exe:envoy_common_lib_with_external_headers",
         "@envoy//source/server/config_validation:server_lib_with_external_headers",
     ],

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -253,7 +253,7 @@ nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain do
   if (count() == 0)
     return proto;
 
-  std::vector<double> quantiles{0, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 0.995, 0.999, 1};
+  std::vector<double> quantiles{0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.775, 0.8, 0.825, 0.85, 0.875, 0.90, 0.925, 0.95, 0.975, 0.99, 0.995, 0.999, 1};
   std::vector<double> computed_quantiles(quantiles.size(), 0.0);
   hist_approx_quantile(histogram_, quantiles.data(), quantiles.size(), computed_quantiles.data());
   for (size_t i = 0; i < quantiles.size(); i++) {

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -256,8 +256,8 @@ double CircllhistStatistic::pstdev() const {
 StatisticPtr CircllhistStatistic::combine(const Statistic& statistic) const {
   auto combined = std::make_unique<CircllhistStatistic>();
   const auto& stat = dynamic_cast<const CircllhistStatistic&>(statistic);
-  hist_accumulate(combined->histogram_, &this->histogram_, /*histogram_count=*/1);
-  hist_accumulate(combined->histogram_, &stat.histogram_, /*histogram_count=*/1);
+  hist_accumulate(combined->histogram_, &this->histogram_, /*cnt=*/1);
+  hist_accumulate(combined->histogram_, &stat.histogram_, /*cnt=*/1);
 
   combined->min_ = std::min(this->min(), stat.min());
   combined->max_ = std::max(this->max(), stat.max());

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -253,7 +253,9 @@ nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain do
   if (count() == 0)
     return proto;
 
-  std::vector<double> quantiles{0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.775, 0.8, 0.825, 0.85, 0.875, 0.90, 0.925, 0.95, 0.975, 0.99, 0.995, 0.999, 1};
+  std::vector<double> quantiles{0,    0.1,   0.2,  0.3,   0.4,  0.5,   0.55,  0.6,
+                                0.65, 0.7,   0.75, 0.775, 0.8,  0.825, 0.85,  0.875,
+                                0.90, 0.925, 0.95, 0.975, 0.99, 0.995, 0.999, 1};
   std::vector<double> computed_quantiles(quantiles.size(), 0.0);
   hist_approx_quantile(histogram_, quantiles.data(), quantiles.size(), computed_quantiles.data());
   for (size_t i = 0; i < quantiles.size(); i++) {

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -236,4 +236,39 @@ nighthawk::client::Statistic HdrStatistic::toProto(SerializationDomain domain) c
   return proto;
 }
 
+StatisticPtr CircllhistStatistic::combine(const Statistic& statistic) const {
+  auto combined = std::make_unique<CircllhistStatistic>();
+  const auto& b = dynamic_cast<const CircllhistStatistic&>(statistic);
+  hist_accumulate(combined->histogram_, &this->histogram_, 1);
+  hist_accumulate(combined->histogram_, &b.histogram_, 1);
+
+  combined->min_ = std::min(this->min(), b.min());
+  combined->max_ = std::max(this->max(), b.max());
+  combined->count_ = this->count() + b.count();
+  return combined;
+}
+
+nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain domain) const {
+  nighthawk::client::Statistic proto = StatisticImpl::toProto(domain);
+  if (count() == 0)
+    return proto;
+
+  std::vector<double> quantiles{0, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 0.995, 0.999, 1};
+  std::vector<double> computed_quantiles(quantiles.size(), 0.0);
+  hist_approx_quantile(histogram_, quantiles.data(), quantiles.size(), computed_quantiles.data());
+  for (size_t i = 0; i < quantiles.size(); i++) {
+    nighthawk::client::Percentile* percentile = proto.add_percentiles();
+    if (domain == Statistic::SerializationDomain::DURATION) {
+      setDurationFromNanos(*percentile->mutable_duration(),
+                           static_cast<int64_t>(computed_quantiles[i]));
+    } else {
+      percentile->set_raw_value(computed_quantiles[i]);
+    }
+    percentile->set_percentile(quantiles[i]);
+    percentile->set_count(hist_approx_count_below(histogram_, computed_quantiles[i]));
+  }
+
+  return proto;
+}
+
 } // namespace Nighthawk

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -250,8 +250,9 @@ StatisticPtr CircllhistStatistic::combine(const Statistic& statistic) const {
 
 nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain domain) const {
   nighthawk::client::Statistic proto = StatisticImpl::toProto(domain);
-  if (count() == 0)
+  if (count() == 0) {
     return proto;
+  }
 
   std::vector<double> quantiles{0,    0.1,   0.2,  0.3,   0.4,  0.5,   0.55,  0.6,
                                 0.65, 0.7,   0.75, 0.775, 0.8,  0.825, 0.85,  0.875,

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -236,16 +236,37 @@ nighthawk::client::Statistic HdrStatistic::toProto(SerializationDomain domain) c
   return proto;
 }
 
+CircllhistStatistic::CircllhistStatistic() {
+  histogram_ = hist_alloc();
+  ASSERT(histogram_ != nullptr);
+}
+
+CircllhistStatistic::~CircllhistStatistic() { hist_free(histogram_); }
+
+void CircllhistStatistic::addValue(uint64_t value) {
+  hist_insert_intscale(histogram_, value, 0, 1);
+  StatisticImpl::addValue(value);
+}
+double CircllhistStatistic::mean() const { return hist_approx_mean(histogram_); }
+double CircllhistStatistic::pvariance() const { return pstdev() * pstdev(); }
+double CircllhistStatistic::pstdev() const {
+  return count() == 0 ? std::nan("") : hist_approx_stddev(histogram_);
+}
+
 StatisticPtr CircllhistStatistic::combine(const Statistic& statistic) const {
   auto combined = std::make_unique<CircllhistStatistic>();
-  const auto& b = dynamic_cast<const CircllhistStatistic&>(statistic);
-  hist_accumulate(combined->histogram_, &this->histogram_, 1);
-  hist_accumulate(combined->histogram_, &b.histogram_, 1);
+  const auto& stat = dynamic_cast<const CircllhistStatistic&>(statistic);
+  hist_accumulate(combined->histogram_, &this->histogram_, /*histogram_count=*/1);
+  hist_accumulate(combined->histogram_, &stat.histogram_, /*histogram_count=*/1);
 
-  combined->min_ = std::min(this->min(), b.min());
-  combined->max_ = std::max(this->max(), b.max());
-  combined->count_ = this->count() + b.count();
+  combined->min_ = std::min(this->min(), stat.min());
+  combined->max_ = std::max(this->max(), stat.max());
+  combined->count_ = this->count() + stat.count();
   return combined;
+}
+
+StatisticPtr CircllhistStatistic::createNewInstanceOfSameType() const {
+  return std::make_unique<CircllhistStatistic>();
 }
 
 nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain domain) const {
@@ -254,9 +275,11 @@ nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain do
     return proto;
   }
 
-  std::vector<double> quantiles{0,    0.1,   0.2,  0.3,   0.4,  0.5,   0.55,  0.6,
-                                0.65, 0.7,   0.75, 0.775, 0.8,  0.825, 0.85,  0.875,
-                                0.90, 0.925, 0.95, 0.975, 0.99, 0.995, 0.999, 1};
+  // List of quantiles is based on hdr_proto_json.gold which lists the quantiles provided by
+  // HdrHistogram.
+  const std::vector<double> quantiles{0,    0.1,   0.2,  0.3,   0.4,  0.5,   0.55,  0.6,
+                                      0.65, 0.7,   0.75, 0.775, 0.8,  0.825, 0.85,  0.875,
+                                      0.90, 0.925, 0.95, 0.975, 0.99, 0.995, 0.999, 1};
   std::vector<double> computed_quantiles(quantiles.size(), 0.0);
   hist_approx_quantile(histogram_, quantiles.data(), quantiles.size(), computed_quantiles.data());
   for (size_t i = 0; i < quantiles.size(); i++) {
@@ -272,6 +295,44 @@ nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain do
   }
 
   return proto;
+}
+
+SinkableStatistic::SinkableStatistic(Envoy::Stats::Scope& scope, absl::optional<int> worker_id)
+    : Envoy::Stats::HistogramImplHelper(scope.symbolTable()), scope_(scope), worker_id_(worker_id) {
+}
+
+SinkableStatistic::~SinkableStatistic() {
+  // We must explicitly free the StatName here in order to supply the
+  // SymbolTable reference.
+  MetricImpl::clear(scope_.symbolTable());
+}
+
+Envoy::Stats::Histogram::Unit SinkableStatistic::unit() const {
+  return Envoy::Stats::Histogram::Unit::Unspecified;
+}
+
+Envoy::Stats::SymbolTable& SinkableStatistic::symbolTable() { return scope_.symbolTable(); }
+
+SinkableHdrStatistic::SinkableHdrStatistic(Envoy::Stats::Scope& scope,
+                                           absl::optional<int> worker_id)
+    : SinkableStatistic(scope, worker_id) {}
+
+void SinkableHdrStatistic::recordValue(uint64_t value) {
+  addValue(value);
+  // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
+  // value directly to stats Sinks.
+  scope_.deliverHistogramToSinks(*this, value);
+}
+
+SinkableCircllhistStatistic::SinkableCircllhistStatistic(Envoy::Stats::Scope& scope,
+                                                         absl::optional<int> worker_id)
+    : SinkableStatistic(scope, worker_id) {}
+
+void SinkableCircllhistStatistic::recordValue(uint64_t value) {
+  addValue(value);
+  // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
+  // value directly to stats Sinks.
+  scope_.deliverHistogramToSinks(*this, value);
 }
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -275,8 +275,7 @@ nighthawk::client::Statistic CircllhistStatistic::toProto(SerializationDomain do
     return proto;
   }
 
-  // List of quantiles is based on hdr_proto_json.gold which lists the quantiles provided by
-  // HdrHistogram.
+  // List of quantiles is based on hdr_proto_json.gold.
   const std::vector<double> quantiles{0,    0.1,   0.2,  0.3,   0.4,  0.5,   0.55,  0.6,
                                       0.65, 0.7,   0.75, 0.775, 0.8,  0.825, 0.85,  0.875,
                                       0.90, 0.925, 0.95, 0.975, 0.99, 0.995, 0.999, 1};
@@ -321,7 +320,7 @@ void SinkableHdrStatistic::recordValue(uint64_t value) {
   addValue(value);
   // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
   // value directly to stats Sinks.
-  scope_.deliverHistogramToSinks(*this, value);
+  scope().deliverHistogramToSinks(*this, value);
 }
 
 SinkableCircllhistStatistic::SinkableCircllhistStatistic(Envoy::Stats::Scope& scope,
@@ -332,7 +331,7 @@ void SinkableCircllhistStatistic::recordValue(uint64_t value) {
   addValue(value);
   // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
   // value directly to stats Sinks.
-  scope_.deliverHistogramToSinks(*this, value);
+  scope().deliverHistogramToSinks(*this, value);
 }
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -320,7 +320,7 @@ void SinkableHdrStatistic::recordValue(uint64_t value) {
   addValue(value);
   // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
   // value directly to stats Sinks.
-  scope().deliverHistogramToSinks(*this, value);
+  scope_.deliverHistogramToSinks(*this, value);
 }
 
 SinkableCircllhistStatistic::SinkableCircllhistStatistic(Envoy::Stats::Scope& scope,
@@ -331,7 +331,7 @@ void SinkableCircllhistStatistic::recordValue(uint64_t value) {
   addValue(value);
   // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
   // value directly to stats Sinks.
-  scope().deliverHistogramToSinks(*this, value);
+  scope_.deliverHistogramToSinks(*this, value);
 }
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -167,6 +167,8 @@ public:
   double pvariance() const override;
   double pstdev() const override;
   StatisticPtr combine(const Statistic& statistic) const override;
+  // circllhist has low significant digit precision as a result of base 10
+  // algorithm.
   uint64_t significantDigits() const override { return 1; }
   StatisticPtr createNewInstanceOfSameType() const override;
   nighthawk::client::Statistic toProto(SerializationDomain domain) const override;
@@ -198,11 +200,13 @@ public:
   // statistic should always set worker_id. Return absl::nullopt when the
   // statistic is not defined per worker.
   const absl::optional<int> worker_id() { return worker_id_; }
+  // Return the Scope reference.
+  Envoy::Stats::Scope& scope() { return scope_; }
 
+private:
   // This is used for delivering the histogram data to sinks.
   Envoy::Stats::Scope& scope_;
 
-private:
   // worker_id can be used in downstream stats Sinks as the stats tag.
   absl::optional<int> worker_id_;
 };

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -186,18 +186,18 @@ private:
 };
 
 /**
- * In order to be able to flush a histogram value to downstream Envoy stats Sinks, abstract class SinkableStatistic takes the Scope reference in the constructor and wraps the
- * Envoy::Stats::HistogramHelper interface. Implementation of sinkable Nighthawk Statistic class will inherit from this class.
+ * In order to be able to flush a histogram value to downstream Envoy stats Sinks, abstract class
+ * SinkableStatistic takes the Scope reference in the constructor and wraps the
+ * Envoy::Stats::HistogramHelper interface. Implementation of sinkable Nighthawk Statistic class
+ * will inherit from this class.
  */
 class SinkableStatistic : public Envoy::Stats::HistogramImplHelper {
- public:
+public:
   // Calling HistogramImplHelper(SymbolTable& symbol_table) constructor to construct an empty
   // MetricImpl. This is to bypass the complicated logic of setting up SymbolTable/StatName in
   // Envoy.
-  SinkableStatistic(Envoy::Stats::Scope& scope,
-                      const absl::optional<int> worker_id)
-      : Envoy::Stats::HistogramImplHelper(scope.symbolTable()),
-        scope_(scope),
+  SinkableStatistic(Envoy::Stats::Scope& scope, const absl::optional<int> worker_id)
+      : Envoy::Stats::HistogramImplHelper(scope.symbolTable()), scope_(scope),
         worker_id_(worker_id) {}
 
   ~SinkableStatistic() override {
@@ -206,30 +206,30 @@ class SinkableStatistic : public Envoy::Stats::HistogramImplHelper {
     MetricImpl::clear(scope_.symbolTable());
   }
 
-  // Currently Envoy Histogram Unit supports {Unspecified, Bytes, Microseconds, Milliseconds}. By default, Nighthawk::Statistic uses nanosecond as the unit of latency histograms, so Unspecified is returned here to isolate Nighthawk Statistic from Envoy Histogram Unit.
+  // Currently Envoy Histogram Unit supports {Unspecified, Bytes, Microseconds, Milliseconds}. By
+  // default, Nighthawk::Statistic uses nanosecond as the unit of latency histograms, so Unspecified
+  // is returned here to isolate Nighthawk Statistic from Envoy Histogram Unit.
   Envoy::Stats::Histogram::Unit unit() const override {
     return Envoy::Stats::Histogram::Unit::Unspecified;
   };
-  Envoy::Stats::SymbolTable& symbolTable() override {
-    return scope_.symbolTable();
-  }
+  Envoy::Stats::SymbolTable& symbolTable() override { return scope_.symbolTable(); }
 
   const absl::optional<int> worker_id() { return worker_id_; }
 
- protected:
+protected:
   // This is used for delivering the histogram data to sinks.
   Envoy::Stats::Scope& scope_;
 
- private:
+private:
   // worker_id can be used in downstream stats Sinks as the stats tag.
   absl::optional<int> worker_id_;
 };
 
 // Implementation of sinkable Nighthawk Statistic with HdrHistogram.
 class SinkableHdrStatistic : public SinkableStatistic, public HdrStatistic {
- public:
+public:
   SinkableHdrStatistic(Envoy::Stats::Scope& scope,
-                      const absl::optional<int> worker_id = absl::nullopt)
+                       const absl::optional<int> worker_id = absl::nullopt)
       : SinkableStatistic(scope, worker_id) {}
 
   // Envoy::Stats::Histogram
@@ -242,14 +242,16 @@ class SinkableHdrStatistic : public SinkableStatistic, public HdrStatistic {
   bool used() const override { return count() > 0; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
-  std::string tagExtractedName() const override { ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic"); }
+  std::string tagExtractedName() const override {
+    ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
+  }
 };
 
 // Implementation of sinkable Nighthawk Statistic with Circllhist Histogram.
 class SinkableCircllhistStatistic : public SinkableStatistic, public CircllhistStatistic {
- public:
+public:
   SinkableCircllhistStatistic(Envoy::Stats::Scope& scope,
-                      const absl::optional<int> worker_id = absl::nullopt)
+                              const absl::optional<int> worker_id = absl::nullopt)
       : SinkableStatistic(scope, worker_id) {}
 
   // Envoy::Stats::Histogram
@@ -262,7 +264,9 @@ class SinkableCircllhistStatistic : public SinkableStatistic, public CircllhistS
   bool used() const override { return count() > 0; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
-  std::string tagExtractedName() const override { ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic"); }
+  std::string tagExtractedName() const override {
+    ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
+  }
 };
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -240,9 +240,9 @@ class SinkableHdrStatistic : public SinkableStatistic, public HdrStatistic {
     scope_.deliverHistogramToSinks(*this, value);
   }
   bool used() const override { return count() > 0; }
-  // Overriding name() and tagExtractedName() method to return Nighthawk::Statistic::id().
+  // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
-  std::string tagExtractedName() const override { return id(); }
+  std::string tagExtractedName() const override { ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic"); }
 };
 
 // Implementation of sinkable Nighthawk Statistic with Circllhist Histogram.
@@ -260,9 +260,9 @@ class SinkableCircllhistStatistic : public SinkableStatistic, public CircllhistS
     scope_.deliverHistogramToSinks(*this, value);
   }
   bool used() const override { return count() > 0; }
-  // Overriding name() and tagExtractedName() method to return Nighthawk::Statistic::id().
+  // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
-  std::string tagExtractedName() const override { return id(); }
+  std::string tagExtractedName() const override { ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic"); }
 };
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -243,8 +243,7 @@ public:
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override {
-    RELEASE_ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
-    return id();
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 };
 
@@ -266,8 +265,7 @@ public:
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override {
-    RELEASE_ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
-    return id();
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 };
 

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -159,26 +159,16 @@ private:
  */
 class CircllhistStatistic : public StatisticImpl {
 public:
-  CircllhistStatistic() {
-    histogram_ = hist_alloc();
-    ASSERT(histogram_ != nullptr);
-  }
-  ~CircllhistStatistic() override { hist_free(histogram_); }
+  CircllhistStatistic();
+  ~CircllhistStatistic() override;
 
-  void addValue(uint64_t value) override {
-    hist_insert_intscale(histogram_, value, 0, 1);
-    StatisticImpl::addValue(value);
-  }
-  double mean() const override { return hist_approx_mean(histogram_); }
-  double pvariance() const override { return pstdev() * pstdev(); }
-  double pstdev() const override {
-    return count() == 0 ? std::nan("") : hist_approx_stddev(histogram_);
-  }
+  void addValue(uint64_t value) override;
+  double mean() const override;
+  double pvariance() const override;
+  double pstdev() const override;
   StatisticPtr combine(const Statistic& statistic) const override;
   uint64_t significantDigits() const override { return 1; }
-  StatisticPtr createNewInstanceOfSameType() const override {
-    return std::make_unique<CircllhistStatistic>();
-  }
+  StatisticPtr createNewInstanceOfSameType() const override;
   nighthawk::client::Statistic toProto(SerializationDomain domain) const override;
 
 private:
@@ -196,27 +186,19 @@ public:
   // Calling HistogramImplHelper(SymbolTable& symbol_table) constructor to construct an empty
   // MetricImpl. This is to bypass the complicated logic of setting up SymbolTable/StatName in
   // Envoy.
-  SinkableStatistic(Envoy::Stats::Scope& scope, const absl::optional<int> worker_id)
-      : Envoy::Stats::HistogramImplHelper(scope.symbolTable()), scope_(scope),
-        worker_id_(worker_id) {}
-
-  ~SinkableStatistic() override {
-    // We must explicitly free the StatName here in order to supply the
-    // SymbolTable reference.
-    MetricImpl::clear(scope_.symbolTable());
-  }
+  SinkableStatistic(Envoy::Stats::Scope& scope, absl::optional<int> worker_id);
+  ~SinkableStatistic() override;
 
   // Currently Envoy Histogram Unit supports {Unspecified, Bytes, Microseconds, Milliseconds}. By
   // default, Nighthawk::Statistic uses nanosecond as the unit of latency histograms, so Unspecified
   // is returned here to isolate Nighthawk Statistic from Envoy Histogram Unit.
-  Envoy::Stats::Histogram::Unit unit() const override {
-    return Envoy::Stats::Histogram::Unit::Unspecified;
-  };
-  Envoy::Stats::SymbolTable& symbolTable() override { return scope_.symbolTable(); }
-
+  Envoy::Stats::Histogram::Unit unit() const override;
+  Envoy::Stats::SymbolTable& symbolTable() override;
+  // Return the id of the worker where this statistic is defined. Per worker
+  // statistic should always set worker_id. Return absl::nullopt when the
+  // statistic is not defined per worker.
   const absl::optional<int> worker_id() { return worker_id_; }
 
-protected:
   // This is used for delivering the histogram data to sinks.
   Envoy::Stats::Scope& scope_;
 
@@ -228,17 +210,12 @@ private:
 // Implementation of sinkable Nighthawk Statistic with HdrHistogram.
 class SinkableHdrStatistic : public SinkableStatistic, public HdrStatistic {
 public:
-  SinkableHdrStatistic(Envoy::Stats::Scope& scope,
-                       const absl::optional<int> worker_id = absl::nullopt)
-      : SinkableStatistic(scope, worker_id) {}
+  // The constructor takes the Scope reference which is used to flush a histogram value to
+  // downstream stats Sinks through deliverHistogramToSinks().
+  SinkableHdrStatistic(Envoy::Stats::Scope& scope, absl::optional<int> worker_id = absl::nullopt);
 
   // Envoy::Stats::Histogram
-  void recordValue(uint64_t value) override {
-    addValue(value);
-    // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
-    // value directly to stats Sinks.
-    scope_.deliverHistogramToSinks(*this, value);
-  }
+  void recordValue(uint64_t value) override;
   bool used() const override { return count() > 0; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
@@ -248,17 +225,13 @@ public:
 // Implementation of sinkable Nighthawk Statistic with Circllhist Histogram.
 class SinkableCircllhistStatistic : public SinkableStatistic, public CircllhistStatistic {
 public:
+  // The constructor takes the Scope reference which is used to flush a histogram value to
+  // downstream stats Sinks through deliverHistogramToSinks().
   SinkableCircllhistStatistic(Envoy::Stats::Scope& scope,
-                              const absl::optional<int> worker_id = absl::nullopt)
-      : SinkableStatistic(scope, worker_id) {}
+                              absl::optional<int> worker_id = absl::nullopt);
 
   // Envoy::Stats::Histogram
-  void recordValue(uint64_t value) override {
-    addValue(value);
-    // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
-    // value directly to stats Sinks.
-    scope_.deliverHistogramToSinks(*this, value);
-  }
+  void recordValue(uint64_t value) override;
   bool used() const override { return count() > 0; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -242,9 +242,7 @@ public:
   bool used() const override { return count() > 0; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
-  std::string tagExtractedName() const override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  std::string tagExtractedName() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 };
 
 // Implementation of sinkable Nighthawk Statistic with Circllhist Histogram.
@@ -264,9 +262,7 @@ public:
   bool used() const override { return count() > 0; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
-  std::string tagExtractedName() const override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  std::string tagExtractedName() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 };
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -244,6 +244,7 @@ public:
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override {
     ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
+    return id();
   }
 };
 
@@ -266,6 +267,7 @@ public:
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override {
     ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
+    return id();
   }
 };
 

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -200,7 +200,7 @@ public:
   // statistic should always set worker_id. Return absl::nullopt when the
   // statistic is not defined per worker.
   const absl::optional<int> worker_id() { return worker_id_; }
-  // Return the Scope reference.
+  // Return the Scope reference used for delivering the histogram data to sinks.
   Envoy::Stats::Scope& scope() { return scope_; }
 
 private:

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -200,13 +200,12 @@ public:
   // statistic should always set worker_id. Return absl::nullopt when the
   // statistic is not defined per worker.
   const absl::optional<int> worker_id() { return worker_id_; }
-  // Return the Scope reference used for delivering the histogram data to sinks.
-  Envoy::Stats::Scope& scope() { return scope_; }
 
-private:
-  // This is used for delivering the histogram data to sinks.
+protected:
+  // This is used in child class for delivering the histogram data to sinks.
   Envoy::Stats::Scope& scope_;
 
+private:
   // worker_id can be used in downstream stats Sinks as the stats tag.
   absl::optional<int> worker_id_;
 };

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -243,7 +243,7 @@ public:
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override {
-    ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
+    RELEASE_ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
     return id();
   }
 };
@@ -266,7 +266,7 @@ public:
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override {
-    ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
+    RELEASE_ASSERT(false, "tagExtractedName() should not be called in Nighthawk Statistic");
     return id();
   }
 };

--- a/test/BUILD
+++ b/test/BUILD
@@ -195,13 +195,17 @@ envoy_cc_test(
 envoy_cc_test(
     name = "statistic_test",
     srcs = ["statistic_test.cc"],
-    data = ["test_data/hdr_proto_json.gold"],
+    data = [
+        "test_data/circllhist_proto_json.gold",
+        "test_data/hdr_proto_json.gold",
+    ],
     repository = "@envoy",
     deps = [
         "//source/common:nighthawk_common_lib",
         "//test/test_common:environment_lib",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
+        "@envoy//test/mocks/stats:stats_mocks",
     ],
 )
 

--- a/test/run_nighthawk_bazel_coverage.sh
+++ b/test/run_nighthawk_bazel_coverage.sh
@@ -43,7 +43,7 @@ COVERAGE_VALUE=${COVERAGE_VALUE%?}
 
 if [ "$VALIDATE_COVERAGE" == "true" ]
 then
-  COVERAGE_THRESHOLD=98.6
+  COVERAGE_THRESHOLD=98.4
   COVERAGE_FAILED=$(echo "${COVERAGE_VALUE}<${COVERAGE_THRESHOLD}" | bc)
   if test ${COVERAGE_FAILED} -eq 1; then
       echo Code coverage ${COVERAGE_VALUE} is lower than limit of ${COVERAGE_THRESHOLD}

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -380,6 +380,7 @@ TYPED_TEST(SinkableStatisticTest, EmptySinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_FALSE(stat.used());
   EXPECT_EQ("", stat.name());
+  EXPECT_DEATH(stat.tagExtractedName(), ".*should not be called in Nighthawk Statistic");
   EXPECT_EQ(absl::nullopt, stat.worker_id());
 }
 
@@ -398,6 +399,7 @@ TYPED_TEST(SinkableStatisticTest, SimpleSinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_TRUE(stat.used());
   EXPECT_EQ(stat_name, stat.name());
+  EXPECT_DEATH(stat.tagExtractedName(), ".*should not be called in Nighthawk Statistic");
   EXPECT_TRUE(stat.worker_id().has_value());
   EXPECT_EQ(worker_id, stat.worker_id().value());
 }

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -380,7 +380,7 @@ TYPED_TEST(SinkableStatisticTest, EmptySinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_FALSE(stat.used());
   EXPECT_EQ("", stat.name());
-  EXPECT_DEATH(stat.tagExtractedName(), ".*should not be called in Nighthawk Statistic");
+  EXPECT_DEATH(stat.tagExtractedName(), ".*");
   EXPECT_EQ(absl::nullopt, stat.worker_id());
 }
 
@@ -399,7 +399,7 @@ TYPED_TEST(SinkableStatisticTest, SimpleSinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_TRUE(stat.used());
   EXPECT_EQ(stat_name, stat.name());
-  EXPECT_DEATH(stat.tagExtractedName(), ".*should not be called in Nighthawk Statistic");
+  EXPECT_DEATH(stat.tagExtractedName(), ".*");
   EXPECT_TRUE(stat.worker_id().has_value());
   EXPECT_EQ(worker_id, stat.worker_id().value());
 }

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -277,10 +277,12 @@ TEST(StatisticTest, CircllhistStatisticProtoOutputLargeValues) {
   uint64_t value = 100ul + 0xFFFFFFFF;
   statistic.addValue(value);
   statistic.addValue(value);
-  const nighthawk::client::Statistic proto = statistic.toProto(Statistic::SerializationDomain::DURATION);
+  const nighthawk::client::Statistic proto =
+      statistic.toProto(Statistic::SerializationDomain::DURATION);
 
   EXPECT_EQ(proto.count(), 2);
-  Helper::expectNear(Envoy::Protobuf::util::TimeUtil::DurationToNanoseconds(proto.mean()), value, statistic.significantDigits());
+  Helper::expectNear(Envoy::Protobuf::util::TimeUtil::DurationToNanoseconds(proto.mean()), value,
+                     statistic.significantDigits());
   EXPECT_EQ(Envoy::Protobuf::util::TimeUtil::DurationToNanoseconds(proto.pstdev()), 0);
 }
 

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -378,7 +378,7 @@ TYPED_TEST(SinkableStatisticTest, EmptySinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_FALSE(stat.used());
   EXPECT_EQ("", stat.name());
-  EXPECT_EQ("", stat.tagExtractedName());
+  ASSERT_DEATH(stat.tagExtractedName(), ".*should not be called in Nighthawk Statistic");
   EXPECT_EQ(absl::nullopt, stat.worker_id());
 }
 
@@ -397,7 +397,7 @@ TYPED_TEST(SinkableStatisticTest, SimpleSinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_TRUE(stat.used());
   EXPECT_EQ(stat_name, stat.name());
-  EXPECT_EQ(stat_name, stat.tagExtractedName());
+  ASSERT_DEATH(stat.tagExtractedName(), ".*should not be called in Nighthawk Statistic");
   EXPECT_TRUE(stat.worker_id().has_value());
   EXPECT_EQ(worker_id, stat.worker_id().value());
 }

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -380,7 +380,6 @@ TYPED_TEST(SinkableStatisticTest, EmptySinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_FALSE(stat.used());
   EXPECT_EQ("", stat.name());
-  ASSERT_DEATH(stat.tagExtractedName(), ".*should not be called in Nighthawk Statistic");
   EXPECT_EQ(absl::nullopt, stat.worker_id());
 }
 
@@ -399,7 +398,6 @@ TYPED_TEST(SinkableStatisticTest, SimpleSinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_TRUE(stat.used());
   EXPECT_EQ(stat_name, stat.name());
-  ASSERT_DEATH(stat.tagExtractedName(), ".*should not be called in Nighthawk Statistic");
   EXPECT_TRUE(stat.worker_id().has_value());
   EXPECT_EQ(worker_id, stat.worker_id().value());
 }

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -307,12 +307,14 @@ TEST(StatisticTest, HdrStatisticPercentilesProto) {
   util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
                         TestEnvironment::runfilesPath("test/test_data/hdr_proto_json.gold")),
                     parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
-  // Instead of comparing proto's, we perform a string-based comparison, because that emits a
-  // helpful diff when this fails.
   const std::string json = util.getJsonStringFromMessage(
       statistic.toProto(Statistic::SerializationDomain::DURATION), true, true);
   const std::string golden_json = util.getJsonStringFromMessage(parsed_json_proto, true, true);
-  EXPECT_EQ(json, golden_json);
+  EXPECT_THAT(statistic.toProto(Statistic::SerializationDomain::DURATION),
+              Envoy::ProtoEq(parsed_json_proto))
+      << json << "\n"
+      << "is not equal to golden file:\n"
+      << golden_json;
 }
 
 TEST(StatisticTest, CircllhistStatisticPercentilesProto) {
@@ -327,12 +329,14 @@ TEST(StatisticTest, CircllhistStatisticPercentilesProto) {
   util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
                         TestEnvironment::runfilesPath("test/test_data/circllhist_proto_json.gold")),
                     parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
-  // Instead of comparing proto's, we perform a string-based comparison, because that emits a
-  // helpful diff when this fails.
   const std::string json = util.getJsonStringFromMessage(
       statistic.toProto(Statistic::SerializationDomain::DURATION), true, true);
   const std::string golden_json = util.getJsonStringFromMessage(parsed_json_proto, true, true);
-  EXPECT_EQ(json, golden_json);
+  EXPECT_THAT(statistic.toProto(Statistic::SerializationDomain::DURATION),
+              Envoy::ProtoEq(parsed_json_proto))
+      << json << "\n"
+      << "is not equal to golden file:\n"
+      << golden_json;
 }
 
 TEST(StatisticTest, CombineAcrossTypesFails) {

--- a/test/test_data/circllhist_proto_json.gold
+++ b/test/test_data/circllhist_proto_json.gold
@@ -1,0 +1,60 @@
+{
+ "count": "10",
+ "id": "",
+ "percentiles": [
+  {
+   "percentile": 0,
+   "count": "0",
+   "duration": "0.000000001s"
+  },
+  {
+   "percentile": 0.25,
+   "count": "2",
+   "duration": "0.000000003s"
+  },
+  {
+   "percentile": 0.5,
+   "count": "5",
+   "duration": "0.000000005s"
+  },
+  {
+   "percentile": 0.75,
+   "count": "7",
+   "duration": "0.000000008s"
+  },
+  {
+   "percentile": 0.9,
+   "count": "9",
+   "duration": "0.000000009s"
+  },
+  {
+   "percentile": 0.95,
+   "count": "9",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 0.99,
+   "count": "9",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 0.995,
+   "count": "9",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 0.999,
+   "count": "9",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 1,
+   "count": "10",
+   "duration": "0.000000011s"
+  }
+ ],
+ "mean": "0.000000006s",
+ "pstdev": "0.000000003s",
+ "min": "0.000000001s",
+ "max": "0.000000010s"
+}

--- a/test/test_data/circllhist_proto_json.gold
+++ b/test/test_data/circllhist_proto_json.gold
@@ -8,9 +8,24 @@
    "duration": "0.000000001s"
   },
   {
-   "percentile": 0.25,
+   "percentile": 0.1,
+   "count": "1",
+   "duration": "0.000000001s"
+  },
+  {
+   "percentile": 0.2,
    "count": "2",
+   "duration": "0.000000002s"
+  },
+  {
+   "percentile": 0.3,
+   "count": "3",
    "duration": "0.000000003s"
+  },
+  {
+   "percentile": 0.4,
+   "count": "4",
+   "duration": "0.000000004s"
   },
   {
    "percentile": 0.5,
@@ -18,9 +33,54 @@
    "duration": "0.000000005s"
   },
   {
+   "percentile": 0.55,
+   "count": "5",
+   "duration": "0.000000006s"
+  },
+  {
+   "percentile": 0.6,
+   "count": "6",
+   "duration": "0.000000006s"
+  },
+  {
+   "percentile": 0.65,
+   "count": "6",
+   "duration": "0.000000007s"
+  },
+  {
+   "percentile": 0.7,
+   "count": "7",
+   "duration": "0.000000007s"
+  },
+  {
    "percentile": 0.75,
    "count": "7",
    "duration": "0.000000008s"
+  },
+  {
+   "percentile": 0.775,
+   "count": "7",
+   "duration": "0.000000008s"
+  },
+  {
+   "percentile": 0.8,
+   "count": "8",
+   "duration": "0.000000008s"
+  },
+  {
+   "percentile": 0.825,
+   "count": "8",
+   "duration": "0.000000009s"
+  },
+  {
+   "percentile": 0.85,
+   "count": "8",
+   "duration": "0.000000009s"
+  },
+  {
+   "percentile": 0.875,
+   "count": "8",
+   "duration": "0.000000009s"
   },
   {
    "percentile": 0.9,
@@ -28,7 +88,17 @@
    "duration": "0.000000009s"
   },
   {
+   "percentile": 0.925,
+   "count": "9",
+   "duration": "0.000000010s"
+  },
+  {
    "percentile": 0.95,
+   "count": "9",
+   "duration": "0.000000010s"
+  },
+  {
+   "percentile": 0.975,
    "count": "9",
    "duration": "0.000000010s"
   },


### PR DESCRIPTION
Add new NH statistic class CircllhistStatistic and SinkableCircllhistStatistic.

CircllhistStatistic uses Circllhist under the hood to compute statistics where Circllhist is used in the implementation of Envoy Histograms. Compared to HdrHistogram Circllhist trades precision for fast performance in merge and insertion according to #115.

SinkableCircllhistStatistic wraps the Envoy::Stats::Histogram interface and is used to flush histogram value to downstream Envoy stats Sinks.

Linked Issues: #344

Testing: unit tests