### PR TITLE
Add missing dependencies to run tools/gen_compilation_database.py 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pytest
 pytest-dependency
 pytest-xdist
 pyyaml
+zipp
+importlib_metadata


### PR DESCRIPTION
Add missing dependencies to run tools/gen_compilation_database.py successfully. This command will create the files needed for CLang intellisense to work.