### PR TITLE
CI: lower test_gcc parallellism.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -190,6 +190,8 @@ if [ -n "$CIRCLECI" ]; then
         NUM_CPUS=4
     elif [[ "$1" == "asan" ]]; then
         NUM_CPUS=3
+    elif [[ "$1" == "test_gcc" ]]; then
+        NUM_CPUS=4
     else
         NUM_CPUS=8
     fi

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -191,7 +191,7 @@ if [ -n "$CIRCLECI" ]; then
     elif [[ "$1" == "asan" ]]; then
         NUM_CPUS=3
     elif [[ "$1" == "test_gcc" ]]; then
-        NUM_CPUS=4
+        NUM_CPUS=6
     else
         NUM_CPUS=8
     fi


### PR DESCRIPTION
Compared to clang, gcc uses more memory. Lower parallelism to
avoid the build running out of memory.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>