### PR TITLE
Add the functionality to flush stats to sinks periodically in NH

### DIFF
--- a/include/nighthawk/common/factories.h
+++ b/include/nighthawk/common/factories.h
@@ -6,6 +6,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/stats/symbol_table.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "nighthawk/common/platform_util.h"
@@ -46,6 +47,28 @@ public:
   virtual TerminationPredicatePtr
   create(Envoy::TimeSource& time_source, Envoy::Stats::Scope& scope,
          const Envoy::MonotonicTime scheduled_starting_time) const PURE;
+};
+
+/**
+ * Factory Interface to create Envoy::Stats::Sink in Nighthawk.
+ * Implemented for each Envoy::Stats::Sink and registered via
+ * Registry::registerFactory() or the convenience class RegisterFactory.
+ */
+class NighthawkStatsSinkFactory : public Envoy::Config::TypedFactory {
+public:
+  ~NighthawkStatsSinkFactory() override = default;
+
+  /**
+   * Create a particular Envoy::Stats::Sink implementation. If the
+   * implementation is unable to produce a Sink with the provided parameters, it
+   * should throw an EnvoyException. The returned pointer should always be
+   * valid.
+   * @param symbol_table supplies the symbol_table instance
+   */
+  virtual std::unique_ptr<Envoy::Stats::Sink>
+  createStatsSink(Envoy::Stats::SymbolTable& symbol_table) PURE;
+
+  std::string category() const override { return "nighthawk.stats_sinks"; }
 };
 
 } // namespace Nighthawk

--- a/include/nighthawk/common/factories.h
+++ b/include/nighthawk/common/factories.h
@@ -63,7 +63,8 @@ public:
    * implementation is unable to produce a Sink with the provided parameters, it
    * should throw an EnvoyException. The returned pointer should always be
    * valid.
-   * @param symbol_table supplies the symbol_table instance
+   * @param symbol_table supplies the symbol_table instance. For the definition
+   * of SymbolTable, see envoy/include/envoy/stats/symbol_table.h.
    */
   virtual std::unique_ptr<Envoy::Stats::Sink>
   createStatsSink(Envoy::Stats::SymbolTable& symbol_table) PURE;

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
         "client.cc",
         "client_worker_impl.cc",
         "factories_impl.cc",
+        "flush_worker_impl.cc",
         "options_impl.cc",
         "process_impl.cc",
         "remote_process_impl.cc",
@@ -26,6 +27,7 @@ envoy_cc_library(
         "client.h",
         "client_worker_impl.h",
         "factories_impl.h",
+        "flush_worker_impl.h",
         "options_impl.h",
         "process_impl.h",
         "remote_process_impl.h",
@@ -84,6 +86,7 @@ envoy_cc_library(
         "@envoy//source/extensions/transport_sockets:well_known_names_with_external_headers",
         "@envoy//source/extensions/transport_sockets/tls:context_lib_with_external_headers",
         "@envoy//source/server:options_lib_with_external_headers",
+        "@envoy//source/server:server_lib_with_external_headers",
         "@envoy//source/server/config_validation:admin_lib_with_external_headers",
         "@envoy//include/envoy/http:protocol_interface_with_external_headers",
     ] + select({

--- a/source/client/flush_worker_impl.cc
+++ b/source/client/flush_worker_impl.cc
@@ -1,0 +1,51 @@
+#include "client/flush_worker_impl.h"
+
+#include "external/envoy/source/common/stats/symbol_table_impl.h"
+#include "external/envoy/source/server/server.h"
+
+#include "common/utility.h"
+
+namespace Nighthawk {
+namespace Client {
+
+FlushWorkerImpl::FlushWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
+                                 Envoy::Stats::Store& store,
+                                 std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks,
+                                 const std::chrono::milliseconds& stats_flush_interval)
+    : WorkerImpl(api, tls, store), stats_flush_interval_(stats_flush_interval) {
+  for (auto& sink : stats_sinks) {
+    stats_sinks_.emplace_back(std::move(sink));
+  }
+}
+
+void FlushWorkerImpl::work() {
+  stat_flush_timer_ = dispatcher_->createTimer([this]() -> void { flushStats(); });
+  stat_flush_timer_->enableTimer(stats_flush_interval_);
+
+  dispatcher_->run(Envoy::Event::Dispatcher::RunType::RunUntilExit);
+}
+
+void FlushWorkerImpl::shutdownThread() {
+  if (stat_flush_timer_ != nullptr) {
+    stat_flush_timer_->disableTimer();
+    stat_flush_timer_.reset();
+  }
+  // Make the final flush before the flush worker gets shutdown.
+  flushStats();
+}
+
+void FlushWorkerImpl::flushStats() {
+  // Create a snapshot and flush to all sinks. Even if there are no sinks,
+  // creating the snapshot has the important property that it latches all counters on a periodic
+  // basis.
+  Envoy::Server::MetricSnapshotImpl snapshot(store_);
+  for (auto& sink : stats_sinks_) {
+    sink->flush(snapshot);
+  }
+  if (stat_flush_timer_ != nullptr) {
+    stat_flush_timer_->enableTimer(stats_flush_interval_);
+  }
+}
+
+} // namespace Client
+} // namespace Nighthawk

--- a/source/client/flush_worker_impl.cc
+++ b/source/client/flush_worker_impl.cc
@@ -21,7 +21,6 @@ FlushWorkerImpl::FlushWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Insta
 void FlushWorkerImpl::work() {
   stat_flush_timer_ = dispatcher_->createTimer([this]() -> void { flushStats(); });
   stat_flush_timer_->enableTimer(stats_flush_interval_);
-
   dispatcher_->run(Envoy::Event::Dispatcher::RunType::RunUntilExit);
 }
 

--- a/source/client/flush_worker_impl.cc
+++ b/source/client/flush_worker_impl.cc
@@ -8,10 +8,9 @@
 namespace Nighthawk {
 namespace Client {
 
-FlushWorkerImpl::FlushWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
+FlushWorkerImpl::FlushWorkerImpl(const std::chrono::milliseconds& stats_flush_interval, Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
                                  Envoy::Stats::Store& store,
-                                 std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks,
-                                 const std::chrono::milliseconds& stats_flush_interval)
+                                 std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks)
     : WorkerImpl(api, tls, store), stats_flush_interval_(stats_flush_interval) {
   for (auto& sink : stats_sinks) {
     stats_sinks_.emplace_back(std::move(sink));

--- a/source/client/flush_worker_impl.cc
+++ b/source/client/flush_worker_impl.cc
@@ -38,7 +38,7 @@ void FlushWorkerImpl::flushStats() {
   // creating the snapshot has the important property that it latches all counters on a periodic
   // basis.
   Envoy::Server::MetricSnapshotImpl snapshot(store_);
-  for (auto& sink : stats_sinks_) {
+  for (std::unique_ptr<Envoy::Stats::Sink>& sink : stats_sinks_) {
     sink->flush(snapshot);
   }
   if (stat_flush_timer_ != nullptr) {

--- a/source/client/flush_worker_impl.cc
+++ b/source/client/flush_worker_impl.cc
@@ -8,7 +8,8 @@
 namespace Nighthawk {
 namespace Client {
 
-FlushWorkerImpl::FlushWorkerImpl(const std::chrono::milliseconds& stats_flush_interval, Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
+FlushWorkerImpl::FlushWorkerImpl(const std::chrono::milliseconds& stats_flush_interval,
+                                 Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
                                  Envoy::Stats::Store& store,
                                  std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks)
     : WorkerImpl(api, tls, store), stats_flush_interval_(stats_flush_interval) {

--- a/source/client/flush_worker_impl.h
+++ b/source/client/flush_worker_impl.h
@@ -1,0 +1,50 @@
+// Flush worker implementation. Flush worker periodically flushes metrics
+// snapshot to all configured stats sinks in Nighthawk.
+#pragma once
+
+#include <vector>
+
+#include "envoy/api/api.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/stats/sink.h"
+#include "envoy/stats/store.h"
+#include "envoy/thread_local/thread_local.h"
+
+#include "common/worker_impl.h"
+
+namespace Nighthawk {
+namespace Client {
+
+// Flush worker periodically flushes metrics snapshot to all configured stats
+// sinks in Nighthawk. A single flush worker is created in Nighthawk
+// process_impl.cc. It will keep running until exitDispatcher() gets called
+// after all client workers are completed in process_impl.cc. It will make the
+// last flush before shutdown in shutdownThread().
+class FlushWorkerImpl : public WorkerImpl {
+public:
+  FlushWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
+                  Envoy::Stats::Store& store,
+                  std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks,
+                  const std::chrono::milliseconds& stats_flush_interval);
+
+  void shutdownThread() override;
+
+  // Must be called in after all client workers are completed in
+  // process_impl.cc.
+  void exitDispatcher() { dispatcher_->exit(); }
+
+protected:
+  void work() override;
+
+private:
+  // Flush the stats sinks. Note: stats flushing may not be synchronous.
+  // Therefore, this function may return prior to flushing taking place.
+  void flushStats();
+
+  std::list<std::unique_ptr<Envoy::Stats::Sink>> stats_sinks_;
+  std::chrono::milliseconds stats_flush_interval_;
+  Envoy::Event::TimerPtr stat_flush_timer_;
+};
+
+} // namespace Client
+} // namespace Nighthawk

--- a/source/client/flush_worker_impl.h
+++ b/source/client/flush_worker_impl.h
@@ -32,8 +32,8 @@ public:
   // @param store supplies the stats store instance for WorkerImpl's constructor.
   // @param stats_sinks list of configured stats sinks where the stats will be
   // flushed to.
-  FlushWorkerImpl(const std::chrono::milliseconds& stats_flush_interval, Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
-                  Envoy::Stats::Store& store,
+  FlushWorkerImpl(const std::chrono::milliseconds& stats_flush_interval, Envoy::Api::Api& api,
+                  Envoy::ThreadLocal::Instance& tls, Envoy::Stats::Store& store,
                   std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks);
 
   void shutdownThread() override;

--- a/source/client/flush_worker_impl.h
+++ b/source/client/flush_worker_impl.h
@@ -29,8 +29,9 @@ public:
 
   void shutdownThread() override;
 
-  // Must be called in after all client workers are completed in
-  // process_impl.cc.
+  // exitDispatcher() stops the dispatcher and the flush timer running in flush worker. It must be
+  // called after all client workers are completed in process_impl.cc to make sure all metrics will
+  // be flushed.
   void exitDispatcher() { dispatcher_->exit(); }
 
 protected:
@@ -42,7 +43,7 @@ private:
   void flushStats();
 
   std::list<std::unique_ptr<Envoy::Stats::Sink>> stats_sinks_;
-  std::chrono::milliseconds stats_flush_interval_;
+  const std::chrono::milliseconds stats_flush_interval_;
   Envoy::Event::TimerPtr stat_flush_timer_;
 };
 

--- a/source/client/flush_worker_impl.h
+++ b/source/client/flush_worker_impl.h
@@ -38,8 +38,8 @@ protected:
   void work() override;
 
 private:
-  // Flush the stats sinks. Note: stats flushing may not be synchronous.
-  // Therefore, this function may return prior to flushing taking place.
+  // Flush the stats sinks. Note: stats flushing may not be synchronous, depending on each stat
+  // sink's implementation. Therefore, this function may return prior to flushing taking place.
   void flushStats();
 
   std::list<std::unique_ptr<Envoy::Stats::Sink>> stats_sinks_;

--- a/source/client/flush_worker_impl.h
+++ b/source/client/flush_worker_impl.h
@@ -22,10 +22,19 @@ namespace Client {
 // process_impl.cc. It will make the last flush before shutdown in shutdownThread().
 class FlushWorkerImpl : public WorkerImpl {
 public:
-  FlushWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
+  // Constructor to call parent class's constructor and initialize member
+  // variables stats_sinks_ and stats_flush_interval_.
+  // @param stats_flush_interval time interval between each flush.
+  // @param api supplies the Api instance for WorkerImpl's constructor. See
+  // envoy/include/envoy/api/api.h for its definition.
+  // @param tls supplies the ThreadLocal::Instance for WorkerImpl's constructor.
+  // See envoy/include/envoy/thread_local/thread_local.h for its definition.
+  // @param store supplies the stats store instance for WorkerImpl's constructor.
+  // @param stats_sinks list of configured stats sinks where the stats will be
+  // flushed to.
+  FlushWorkerImpl(const std::chrono::milliseconds& stats_flush_interval, Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
                   Envoy::Stats::Store& store,
-                  std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks,
-                  const std::chrono::milliseconds& stats_flush_interval);
+                  std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks);
 
   void shutdownThread() override;
 

--- a/source/client/flush_worker_impl.h
+++ b/source/client/flush_worker_impl.h
@@ -15,11 +15,11 @@
 namespace Nighthawk {
 namespace Client {
 
-// Flush worker periodically flushes metrics snapshot to all configured stats
-// sinks in Nighthawk. A single flush worker is created in Nighthawk
-// process_impl.cc. It will keep running until exitDispatcher() gets called
-// after all client workers are completed in process_impl.cc. It will make the
-// last flush before shutdown in shutdownThread().
+// Only a single live flush worker instance can be created in Nighthawk at any
+// time.
+// Flush worker periodically flushes metrics snapshot to all configured stats sinks in Nighthawk. It
+// will keep running until exitDispatcher() gets called after all client workers are completed in
+// process_impl.cc. It will make the last flush before shutdown in shutdownThread().
 class FlushWorkerImpl : public WorkerImpl {
 public:
   FlushWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -429,6 +429,23 @@ void ProcessImpl::addRequestSourceCluster(
   socket->set_port_value(uri.port());
 }
 
+void ProcessImpl::setupStatsSinks(
+    envoy::config::bootstrap::v3::Bootstrap& bootstrap,
+    std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks) {
+  for (const envoy::config::metrics::v3::StatsSink& stats_sink :
+         bootstrap.stats_sinks()) {
+      ENVOY_LOG(info, "loading stats sink configuration in Nighthawk");
+      auto& factory =
+          Envoy::Config::Utility::getAndCheckFactory<NighthawkStatsSinkFactory>(
+              stats_sink);
+      stats_sinks.emplace_back(
+          factory.createStatsSink(store_root_.symbolTable()));
+    }
+    for (std::unique_ptr<Envoy::Stats::Sink>& sink : stats_sinks) {
+      store_root_.addSink(*sink);
+    }
+}
+
 bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriPtr>& uris,
                               const UriPtr& request_source_uri, const UriPtr& tracing_uri) {
   {
@@ -478,24 +495,13 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
     Runtime::LoaderSingleton::get().initialize(*cluster_manager_);
 
     std::list<std::unique_ptr<Envoy::Stats::Sink>> stats_sinks;
-    for (const envoy::config::metrics::v3::StatsSink& stats_sink : bootstrap.stats_sinks()) {
-      ENVOY_LOG(info, "loading stats sink configuration in Nighthawk");
-      auto& factory =
-          Envoy::Config::Utility::getAndCheckFactory<NighthawkStatsSinkFactory>(stats_sink);
-      stats_sinks.emplace_back(factory.createStatsSink(store_root_.symbolTable()));
-    }
-    for (std::unique_ptr<Envoy::Stats::Sink>& sink : stats_sinks) {
-      store_root_.addSink(*sink);
-    }
-
-    // Default flush interval is 5s.
+    setupStatsSinks(bootstrap, stats_sinks);
     std::chrono::milliseconds stats_flush_interval = std::chrono::milliseconds(
         Envoy::DurationUtil::durationToMilliseconds(bootstrap.stats_flush_interval()));
 
     if (!options_.statsSinks().empty()) {
       // There should be only a single live flush worker instance at any time.
-      flush_worker_ = std::make_unique<FlushWorkerImpl>(*api_, tls_, store_root_, stats_sinks,
-                                                        stats_flush_interval);
+      flush_worker_ = std::make_unique<FlushWorkerImpl>(stats_flush_interval, *api_, tls_, store_root_, stats_sinks);
       flush_worker_->start();
     }
 

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -204,7 +204,7 @@ void ProcessImpl::configureComponentLogLevels(spdlog::level::level_enum level) {
 
 uint32_t ProcessImpl::determineConcurrency() const {
   // Spare 1 cpu for flush worker.
-  uint32_t cpu_cores_with_affinity = Envoy::OptionsImplPlatform::getCpuCount() - 1;
+  uint32_t cpu_cores_with_affinity = Envoy::OptionsImplPlatform::getCpuCount();
   bool autoscale = options_.concurrency() == "auto";
   // TODO(oschaaf): Maybe, in the case where the concurrency flag is left out, but
   // affinity is set / we don't have affinity with all cores, we should default to autoscale.

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -429,7 +429,7 @@ void ProcessImpl::addRequestSourceCluster(
   socket->set_port_value(uri.port());
 }
 
-void ProcessImpl::setupStatsSinks(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
+void ProcessImpl::setupStatsSinks(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                                   std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks) {
   for (const envoy::config::metrics::v3::StatsSink& stats_sink : bootstrap.stats_sinks()) {
     ENVOY_LOG(info, "loading stats sink configuration in Nighthawk");

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -134,7 +134,7 @@ void ProcessImpl::shutdown() {
     // flush_worker_->shutdown() needs to happen before workers_.clear() so that
     // metrics defined in workers scope will be included in the final stats
     // flush which happens in FlushWorkerImpl::shutdownThread() after
-    // flush_worker_->shutdown(). For the order between worker shutdown() and
+    // flush_worker_->shutdown() is called. For the order between worker shutdown() and
     // shutdownThread(), see worker_impl.cc.
     if (flush_worker_) {
       flush_worker_->shutdown();
@@ -494,6 +494,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
         Envoy::DurationUtil::durationToMilliseconds(bootstrap.stats_flush_interval()));
 
     if (!options_.statsSinks().empty()) {
+      // There should be only a single live flush worker instance at any time.
       flush_worker_ = std::make_unique<FlushWorkerImpl>(*api_, tls_, store_root_, stats_sinks,
                                                         stats_flush_interval);
       flush_worker_->start();

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -203,7 +203,6 @@ void ProcessImpl::configureComponentLogLevels(spdlog::level::level_enum level) {
 }
 
 uint32_t ProcessImpl::determineConcurrency() const {
-  // Spare 1 cpu for flush worker.
   uint32_t cpu_cores_with_affinity = Envoy::OptionsImplPlatform::getCpuCount();
   bool autoscale = options_.concurrency() == "auto";
   // TODO(oschaaf): Maybe, in the case where the concurrency flag is left out, but

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -484,7 +484,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
           Envoy::Config::Utility::getAndCheckFactory<NighthawkStatsSinkFactory>(stats_sink);
       stats_sinks.emplace_back(factory.createStatsSink(store_root_.symbolTable()));
     }
-    for (auto& sink : stats_sinks) {
+    for (std::unique_ptr<Envoy::Stats::Sink>& sink : stats_sinks) {
       store_root_.addSink(*sink);
     }
 
@@ -508,7 +508,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
   }
 
   if (!options_.statsSinks().empty() && flush_worker_ != nullptr) {
-    // Stop the running dispatcher in flush_worker_. Need to be called after all
+    // Stop the running dispatcher in flush_worker_. Needs to be called after all
     // client workers are complete so that all the metrics can be flushed.
     flush_worker_->exitDispatcher();
     flush_worker_->waitForCompletion();

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -121,9 +121,8 @@ private:
    * @param bootstrap the bootstrap configuration which include the stats sink configuration.
    * @param stats_sinks a Sink list to be populated.
    */
-  void setupStatsSinks(
-      envoy::config::bootstrap::v3::Bootstrap& bootstrap,
-      std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks);
+  void setupStatsSinks(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
+                       std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks);
   bool runInternal(OutputCollector& collector, const std::vector<UriPtr>& uris,
                    const UriPtr& request_source_uri, const UriPtr& tracing_uri);
 

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -121,7 +121,7 @@ private:
    * @param bootstrap the bootstrap configuration which include the stats sink configuration.
    * @param stats_sinks a Sink list to be populated.
    */
-  void setupStatsSinks(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
+  void setupStatsSinks(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                        std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks);
   bool runInternal(OutputCollector& collector, const std::vector<UriPtr>& uris,
                    const UriPtr& request_source_uri, const UriPtr& tracing_uri);

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -114,6 +114,16 @@ private:
   std::vector<StatisticPtr>
   mergeWorkerStatistics(const std::vector<ClientWorkerPtr>& workers) const;
   void setupForHRTimers();
+  /**
+   * If there are sinks configured in bootstrap, populate stats_sinks with sinks
+   * created through NighthawkStatsSinkFactory and add them to store_root_.
+   *
+   * @param bootstrap the bootstrap configuration which include the stats sink configuration.
+   * @param stats_sinks a Sink list to be populated.
+   */
+  void setupStatsSinks(
+      envoy::config::bootstrap::v3::Bootstrap& bootstrap,
+      std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks);
   bool runInternal(OutputCollector& collector, const std::vector<UriPtr>& uris,
                    const UriPtr& request_source_uri, const UriPtr& tracing_uri);
 

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -33,6 +33,7 @@
 
 #include "client/benchmark_client_impl.h"
 #include "client/factories_impl.h"
+#include "client/flush_worker_impl.h"
 
 namespace Nighthawk {
 namespace Client {
@@ -156,6 +157,7 @@ private:
   bool shutdown_{true};
   Envoy::Thread::MutexBasicLockable workers_lock_;
   bool cancelled_{false};
+  std::unique_ptr<FlushWorkerImpl> flush_worker_;
 };
 
 } // namespace Client

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -323,6 +323,14 @@ void SinkableHdrStatistic::recordValue(uint64_t value) {
   scope_.deliverHistogramToSinks(*this, value);
 }
 
+std::string SinkableHdrStatistic::tagExtractedName() const {
+  if (worker_id().has_value()) {
+    return fmt::format("{}.", worker_id().value()) + id();
+  } else {
+    return id();
+  }
+}
+
 SinkableCircllhistStatistic::SinkableCircllhistStatistic(Envoy::Stats::Scope& scope,
                                                          absl::optional<int> worker_id)
     : SinkableStatistic(scope, worker_id) {}
@@ -332,6 +340,14 @@ void SinkableCircllhistStatistic::recordValue(uint64_t value) {
   // Currently in Envoy Scope implementation, deliverHistogramToSinks() will flush the histogram
   // value directly to stats Sinks.
   scope_.deliverHistogramToSinks(*this, value);
+}
+
+std::string SinkableCircllhistStatistic::tagExtractedName() const {
+  if (worker_id().has_value()) {
+    return fmt::format("{}.", worker_id().value()) + id();
+  } else {
+    return id();
+  }
 }
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -325,7 +325,7 @@ void SinkableHdrStatistic::recordValue(uint64_t value) {
 
 std::string SinkableHdrStatistic::tagExtractedName() const {
   if (worker_id().has_value()) {
-    return fmt::format("{}.", worker_id().value()) + id();
+    return fmt::format("{}.{}", worker_id().value(), id());
   } else {
     return id();
   }
@@ -344,7 +344,7 @@ void SinkableCircllhistStatistic::recordValue(uint64_t value) {
 
 std::string SinkableCircllhistStatistic::tagExtractedName() const {
   if (worker_id().has_value()) {
-    return fmt::format("{}.", worker_id().value()) + id();
+    return fmt::format("{}.{}", worker_id().value(), id());
   } else {
     return id();
   }

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -199,7 +199,7 @@ public:
   // Return the id of the worker where this statistic is defined. Per worker
   // statistic should always set worker_id. Return absl::nullopt when the
   // statistic is not defined per worker.
-  const absl::optional<int> worker_id() { return worker_id_; }
+  const absl::optional<int> worker_id() const { return worker_id_; }
 
 protected:
   // This is used in child class for delivering the histogram data to sinks.
@@ -222,7 +222,9 @@ public:
   bool used() const override { return count() > 0; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
-  std::string tagExtractedName() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  // Overriding tagExtractedName() to return string(worker_id) + "." + Nighthawk::Statistic::id()
+  // when worker_id is set. The worker_id prefix can be used in customized stats sinks.
+  std::string tagExtractedName() const override;
 
   // Nighthawk::Statistic
   void addValue(uint64_t value) override { recordValue(value); }
@@ -241,7 +243,9 @@ public:
   bool used() const override { return count() > 0; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
-  std::string tagExtractedName() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  // Overriding tagExtractedName() to return string(worker_id) + "." + Nighthawk::Statistic::id()
+  // when worker_id is set. The worker_id prefix can be used in customized stats sinks.
+  std::string tagExtractedName() const override;
 
   // Nighthawk::Statistic
   void addValue(uint64_t value) override { recordValue(value); }

--- a/test/BUILD
+++ b/test/BUILD
@@ -63,6 +63,23 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "flush_worker_test",
+    srcs = ["flush_worker_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/client:nighthawk_client_lib",
+        "@envoy//source/common/api:api_lib",
+        "@envoy//source/common/event:dispatcher_includes_with_external_headers",
+        "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
+        "@envoy//test/mocks/api:api_mocks",
+        "@envoy//test/mocks/local_info:local_info_mocks",
+        "@envoy//test/mocks/protobuf:protobuf_mocks",
+        "@envoy//test/mocks/thread_local:thread_local_mocks",
+        "@envoy//test/test_common:simulated_time_system_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "factories_test",
     srcs = ["factories_test.cc"],
     repository = "@envoy",
@@ -135,6 +152,7 @@ envoy_cc_test(
         "//test/client:utility_lib",
         "//test/test_common:environment_lib",
         "@envoy//test/test_common:network_utility_lib",
+        "@envoy//test/test_common:registry_lib",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -75,7 +75,6 @@ envoy_cc_test(
         "@envoy//test/mocks/local_info:local_info_mocks",
         "@envoy//test/mocks/protobuf:protobuf_mocks",
         "@envoy//test/mocks/thread_local:thread_local_mocks",
-        "@envoy//test/test_common:simulated_time_system_lib",
     ],
 )
 

--- a/test/flush_worker_test.cc
+++ b/test/flush_worker_test.cc
@@ -25,6 +25,7 @@ using ::testing::ReturnRef;
 using ::testing::StrictMock;
 using ::testing::Test;
 
+// Number of times the simulated timer loops run in simulateTimerLoop().
 const int kNumTimerLoops = 100;
 
 class FlushWorkerTest : public Test {

--- a/test/flush_worker_test.cc
+++ b/test/flush_worker_test.cc
@@ -57,8 +57,7 @@ public:
         .WillRepeatedly(Invoke([&](const std::chrono::microseconds,
                                    const Envoy::ScopeTrackedObject*) { timer_set_ = true; }));
     EXPECT_CALL(*timer_, disableTimer()).WillOnce(Invoke([&]() { timer_set_ = false; }));
-    EXPECT_CALL(*dispatcher_, exit()).WillOnce(Invoke([&]() {
-    }));
+    EXPECT_CALL(*dispatcher_, exit()).WillOnce(Invoke([&]() {}));
   }
 
   // Set up expected behaviors when run() is called on dispatcher_.
@@ -75,7 +74,8 @@ public:
         }));
   }
 
-  // Simulate the periodical timer which runs kNumTimerLoops iterations before signaling another thread to call dispatcher->exit().
+  // Simulate the periodical timer which runs kNumTimerLoops iterations before signaling another
+  // thread to call dispatcher->exit().
   void simulateTimerLoop() {
     int loop_iterations = 0;
     do {
@@ -101,7 +101,7 @@ public:
   // owned by FlushWorkerImpl's stat_flush_timer_ member variable.
   NiceMock<Envoy::Event::MockTimer>* timer_;
   Envoy::Event::TimerCb timer_cb_;
-  bool timer_set_{};  // used to simulate whether the timer is enabled.
+  bool timer_set_{}; // used to simulate whether the timer is enabled.
   std::promise<void> signal_dispatcher_to_exit_;
 
   Envoy::Stats::MockSink* sink_ = nullptr; // owned by stats_sinks_
@@ -123,7 +123,7 @@ TEST_F(FlushWorkerTest, WorkerFlushStatsPeriodically) {
   });
 
   expectDispatcherRun();
-  // Check flush() is called at least kNumTimerLoops times in simulateTimerLoop().
+  // Check flush() is called kNumTimerLoops times in simulateTimerLoop().
   EXPECT_CALL(*sink_, flush(_)).Times(kNumTimerLoops);
 
   worker.start();

--- a/test/flush_worker_test.cc
+++ b/test/flush_worker_test.cc
@@ -136,12 +136,11 @@ TEST_F(FlushWorkerTest, FinalFlush) {
   auto worker = std::make_unique<FlushWorkerImpl>(mock_api_, tls_, store_, stats_sinks_,
                                                   stats_flush_interval_);
 
+  worker->start();
+  worker->waitForCompletion();
   // Stats flush should happen exactly once as the final flush is done in
   // FlushWorkerImpl::shutdownThread().
   EXPECT_CALL(*sink_, flush(_)).Times(1);
-
-  worker->start();
-  worker->waitForCompletion();
   worker->shutdown();
 }
 

--- a/test/flush_worker_test.cc
+++ b/test/flush_worker_test.cc
@@ -1,0 +1,130 @@
+#include <functional>
+#include <thread>
+
+#include "external/envoy/source/common/common/random_generator.h"
+#include "external/envoy/source/common/event/dispatcher_impl.h"
+#include "external/envoy/source/common/runtime/runtime_impl.h"
+#include "external/envoy/source/common/stats/isolated_store_impl.h"
+#include "external/envoy/test/mocks/api/mocks.h"
+#include "external/envoy/test/mocks/local_info/mocks.h"
+#include "external/envoy/test/mocks/protobuf/mocks.h"
+#include "external/envoy/test/mocks/stats/mocks.h"
+#include "external/envoy/test/mocks/thread_local/mocks.h"
+#include "external/envoy/test/test_common/simulated_time_system.h"
+
+#include "client/flush_worker_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Nighthawk {
+namespace Client {
+
+using namespace testing;
+
+class FlushWorkerTest : public Test {
+public:
+  FlushWorkerTest() : thread_factory_(Envoy::Thread::threadFactoryForTest()) {
+    dispatcher_ = new NiceMock<Envoy::Event::MockDispatcher>();
+    loader_ = std::make_unique<Envoy::Runtime::ScopedLoaderSingleton>(
+        Envoy::Runtime::LoaderPtr{new Envoy::Runtime::LoaderImpl(
+            *dispatcher_, tls_, {}, local_info_, store_, rand_, validation_visitor_, mock_api_)});
+    sink_ = new StrictMock<Envoy::Stats::MockSink>();
+    stats_sinks_.emplace_back(sink_);
+
+    EXPECT_CALL(mock_api_, threadFactory()).WillRepeatedly(ReturnRef(thread_factory_));
+    EXPECT_CALL(mock_api_, allocateDispatcher_(_, _)).WillOnce(Return(dispatcher_));
+  }
+
+  // We set up emulating timer firing and moving simulated time forward in
+  // simulateTimerloop() below.
+  void setupDispatcherTimerEmulation() {
+    timer_ = new NiceMock<Envoy::Event::MockTimer>();
+    EXPECT_CALL(*dispatcher_, createTimer_(_)).WillOnce(Invoke([&](Envoy::Event::TimerCb cb) {
+      timer_cb_ = std::move(cb);
+      return timer_;
+    }));
+    EXPECT_CALL(*timer_, enableTimer(_, _))
+        .WillRepeatedly(Invoke([&](const std::chrono::microseconds,
+                                   const Envoy::ScopeTrackedObject*) { timer_set_ = true; }));
+    EXPECT_CALL(*timer_, disableTimer()).WillOnce(Invoke([&]() { timer_set_ = false; }));
+    EXPECT_CALL(*dispatcher_, exit()).WillOnce(Invoke([&]() { stopped_ = true; }));
+  }
+
+  void expectDispatcherRun() {
+    EXPECT_CALL(*dispatcher_, run(_))
+        .WillOnce(Invoke([&](Envoy::Event::DispatcherImpl::RunType type) {
+          // The first dispatcher run is in WorkerImpl::start().
+          ASSERT_EQ(Envoy::Event::DispatcherImpl::RunType::NonBlock, type);
+        }))
+        .WillOnce(Invoke([&](Envoy::Event::DispatcherImpl::RunType type) {
+          // The second dispatcher run is in FlushWorkerImpl::work().
+          ASSERT_EQ(Envoy::Event::DispatcherImpl::RunType::RunUntilExit, type);
+          simulateTimerLoop();
+        }));
+  }
+
+  void simulateTimerLoop() {
+    while (!stopped_) {
+      if (timer_set_) {
+        timer_set_ = false;
+        timer_cb_();
+      }
+    }
+  }
+
+  NiceMock<Envoy::Api::MockApi> mock_api_;
+  Envoy::Thread::ThreadFactory& thread_factory_;
+  Envoy::Stats::IsolatedStoreImpl store_;
+  NiceMock<Envoy::ThreadLocal::MockInstance> tls_;
+  Envoy::Random::RandomGeneratorImpl rand_;
+  NiceMock<Envoy::Event::MockDispatcher>* dispatcher_ = nullptr;
+  std::unique_ptr<Envoy::Runtime::ScopedLoaderSingleton> loader_;
+  NiceMock<Envoy::LocalInfo::MockLocalInfo> local_info_;
+  NiceMock<Envoy::ProtobufMessage::MockValidationVisitor> validation_visitor_;
+
+  NiceMock<Envoy::Event::MockTimer>* timer_; // not owned
+  Envoy::Event::TimerCb timer_cb_;
+  bool timer_set_{};
+  bool stopped_{};
+
+  Envoy::Stats::MockSink* sink_ = nullptr;
+  std::list<std::unique_ptr<Envoy::Stats::Sink>> stats_sinks_;
+  std::chrono::milliseconds stats_flush_interval_{10};
+};
+
+TEST_F(FlushWorkerTest, WorkerFlushStatsPeriodically) {
+  setupDispatcherTimerEmulation();
+
+  auto worker = std::make_unique<FlushWorkerImpl>(mock_api_, tls_, store_, stats_sinks_,
+                                                  stats_flush_interval_);
+
+  std::thread thread = std::thread([&worker] {
+    sleep(1);
+    worker->exitDispatcher();
+  });
+
+  expectDispatcherRun();
+  // During the 1s sleep, timer_cb_ in simulateTimerLoop() should be called at
+  // least 100 times.
+  EXPECT_CALL(*sink_, flush(_)).Times(testing::AtLeast(100));
+
+  worker->start();
+  worker->waitForCompletion();
+  thread.join();
+  worker->shutdown();
+}
+
+TEST_F(FlushWorkerTest, FinalFlush) {
+  auto worker = std::make_unique<FlushWorkerImpl>(mock_api_, tls_, store_, stats_sinks_,
+                                                  stats_flush_interval_);
+
+  // Final flush should be done in FlushWorkerImpl::shutdownThread().
+  EXPECT_CALL(*sink_, flush(_)).Times(1);
+
+  worker->start();
+  worker->waitForCompletion();
+  worker->shutdown();
+}
+
+} // namespace Client
+} // namespace Nighthawk

--- a/test/flush_worker_test.cc
+++ b/test/flush_worker_test.cc
@@ -23,8 +23,9 @@ using namespace testing;
 
 class FlushWorkerTest : public Test {
 public:
-  FlushWorkerTest() : thread_factory_(Envoy::Thread::threadFactoryForTest()),
-  dispatcher_(new NiceMock<Envoy::Event::MockDispatcher>()) {
+  FlushWorkerTest()
+      : thread_factory_(Envoy::Thread::threadFactoryForTest()),
+        dispatcher_(new NiceMock<Envoy::Event::MockDispatcher>()) {
     loader_ = std::make_unique<Envoy::Runtime::ScopedLoaderSingleton>(
         Envoy::Runtime::LoaderPtr{new Envoy::Runtime::LoaderImpl(
             *dispatcher_, tls_, {}, local_info_, store_, rand_, validation_visitor_, mock_api_)});

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -18,10 +18,12 @@
 
 #include "gtest/gtest.h"
 
-using namespace testing;
-
 namespace Nighthawk {
 namespace Client {
+namespace {
+
+using ::testing::TestWithParam;
+using ::testing::ValuesIn;
 
 constexpr absl::string_view kSinkName = "{name:\"nighthawk.fake_stats_sink\"}";
 // Global variable keeps count of number of flushes in FakeStatsSink. It is reset
@@ -168,5 +170,6 @@ TEST_P(ProcessTest, CancelExecutionBeforeBeginLoadTest) {
   EXPECT_EQ(numFlushes, 0);
 }
 
+} // namespace
 } // namespace Client
 } // namespace Nighthawk

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -125,8 +125,8 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ProcessTest,
 
 TEST_P(ProcessTest, TwoProcessInSequence) {
   runProcess(RunExpectation::EXPECT_FAILURE);
-  options_ = TestUtility::createOptionsImpl(fmt::format(
-      "foo --h2 --duration 1 --rps 10 https://{}/", loopback_address_));
+  options_ = TestUtility::createOptionsImpl(
+      fmt::format("foo --h2 --duration 1 --rps 10 https://{}/", loopback_address_));
   runProcess(RunExpectation::EXPECT_FAILURE);
 }
 

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -23,19 +23,19 @@ using namespace testing;
 namespace Nighthawk {
 namespace Client {
 
-constexpr absl::string_view kSinkName = "{name:\"nighthawk.dummy_stats_sink\"}";
+constexpr const char kSinkName[] = "{name:\"nighthawk.dummy_stats_sink\"}";
 int kNumFlushes = 0;
 
+// DummyStatsSink is a simple Envoy::Stats::Sink implementation used to prove
+// the logic to configure Sink in Nighthawk works as expected.
 class DummyStatsSink : public Envoy::Stats::Sink {
 public:
-  DummyStatsSink() : dummy_(1) { kNumFlushes = 0; }
+  DummyStatsSink() : Envoy::Stats::Sink() { kNumFlushes = 0; }
 
   // Envoy::Stats::Sink
   void flush(Envoy::Stats::MetricSnapshot&) override { kNumFlushes++; }
 
   void onHistogramComplete(const Envoy::Stats::Histogram&, uint64_t) override {}
-
-  int dummy_ = 0;
 };
 
 // DummyStatsSinkFactory creates DummyStatsSink.

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -403,7 +403,7 @@ TYPED_TEST(SinkableStatisticTest, EmptySinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_FALSE(stat.used());
   EXPECT_EQ("", stat.name());
-  EXPECT_DEATH(stat.tagExtractedName(), ".*");
+  EXPECT_EQ("", stat.tagExtractedName());
   EXPECT_EQ(absl::nullopt, stat.worker_id());
 }
 
@@ -428,7 +428,7 @@ TYPED_TEST(SinkableStatisticTest, SimpleSinkableStatistic) {
   EXPECT_EQ(Envoy::Stats::Histogram::Unit::Unspecified, stat.unit());
   EXPECT_TRUE(stat.used());
   EXPECT_EQ(stat_name, stat.name());
-  EXPECT_DEATH(stat.tagExtractedName(), ".*");
+  EXPECT_EQ("0.stat_name", stat.tagExtractedName());
   EXPECT_TRUE(stat.worker_id().has_value());
   EXPECT_EQ(worker_id, stat.worker_id().value());
 }


### PR DESCRIPTION
Add a flush worker to periodically flush stats to sinks.

Add the functionality to configure sinks in process_impl.cc

Start the flush worker in process_impl.cc when there is stats sink configured.

Change the SinkableStatistic's tagExtractedName() to return `worker_id + "." + Nighthawk::Statistic::id()` which can be used in customized sinks.

Linked Issues: #344

Signed-off-by: Qin Qin <qqin@google.com>