### PR TITLE
Update run_clang_tidy.sh

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies,-modernize-use-trailing-return-type,-modernize-avoid-bind,-modernize-use-nodiscard,-modernize-concat-nested-namespaces'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-modernize-concat-nested-namespaces'
 
 WarningsAsErrors:  '*'
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-modernize-concat-nested-namespaces'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies,-modernize-use-trailing-return-type,-modernize-avoid-bind,-modernize-use-nodiscard,-modernize-concat-nested-namespaces'
 
 WarningsAsErrors:  '*'
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/coverage/BUILD
 *.bak
 default.profraw
 tmp-*
+clang-tidy-fixes.yaml

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -221,7 +221,7 @@ case "$1" in
     ;;
     clang_tidy)
         setup_clang_toolchain
-        do_clang_tidy
+        RUN_FULL_CLANG_TIDY=1 do_clang_tidy
         exit 0
     ;;
     coverage)

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
+# ENVOY_SRCDIR should point to where Envoy source lives, while SRCDIR could be a downstream build
+# (for example envoy-filter-example).
+[[ -z "${ENVOY_SRCDIR}" ]] && ENVOY_SRCDIR="${PWD}"
+[[ -z "${SRCDIR}" ]] && SRCDIR="${ENVOY_SRCDIR}"
+
+export LLVM_CONFIG=${LLVM_CONFIG:-llvm-config}
+LLVM_PREFIX=${LLVM_PREFIX:-$(${LLVM_CONFIG} --prefix)}
+CLANG_TIDY=${CLANG_TIDY:-$(${LLVM_CONFIG} --bindir)/clang-tidy}
+CLANG_APPLY_REPLACEMENTS=${CLANG_APPLY_REPLACEMENTS:-$(${LLVM_CONFIG} --bindir)/clang-apply-replacements}
+FIX_YAML=clang-tidy-fixes.yaml
 
 # Quick syntax check of .clang-tidy.
-clang-tidy -dump-config > /dev/null 2> clang-tidy-config-errors.txt
+${CLANG_TIDY} -dump-config > /dev/null 2> clang-tidy-config-errors.txt
 if [[ -s clang-tidy-config-errors.txt ]]; then
   cat clang-tidy-config-errors.txt
   rm clang-tidy-config-errors.txt
@@ -13,17 +23,73 @@ rm clang-tidy-config-errors.txt
 
 echo "Generating compilation database..."
 
-cp -f .bazelrc .bazelrc.bak
-
-function cleanup() {
-  cp -f .bazelrc.bak .bazelrc
-  rm -f .bazelrc.bak
-}
-trap cleanup EXIT
-
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
-tools/gen_compilation_database.py --include_headers
+"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --include_headers
 
-LLVM_PREFIX=$(llvm-config --prefix)
-"${LLVM_PREFIX}/share/clang/run-clang-tidy.py" -extra-arg-before=-xc++ -quiet -j ${NUM_CPUS}
+# Do not run clang-tidy against win32 impl
+# TODO(scw00): We should run clang-tidy against win32 impl once we have clang-cl support for Windows
+function exclude_win32_impl() {
+  grep -v source/common/filesystem/win32/ | grep -v source/common/common/win32 | grep -v source/exe/win32 | grep -v source/common/api/win32
+}
+
+# Do not run clang-tidy against macOS impl
+# TODO: We should run clang-tidy against macOS impl for completeness
+function exclude_macos_impl() {
+  grep -v source/common/filesystem/kqueue/
+}
+
+# Do not run incremental clang-tidy on check_format testdata files.
+function exclude_testdata() {
+  grep -v tools/testdata/check_format/
+}
+
+# Exclude files in third_party which are temporary forks from other OSS projects.
+function exclude_third_party() {
+  grep -v third_party/
+}
+
+function filter_excludes() {
+  exclude_testdata | exclude_win32_impl | exclude_macos_impl | exclude_third_party
+}
+
+function run_clang_tidy() {
+  python3 "${LLVM_PREFIX}/share/clang/run-clang-tidy.py" \
+    -clang-tidy-binary=${CLANG_TIDY} -header-filter='-external' \
+    -clang-apply-replacements-binary=${CLANG_APPLY_REPLACEMENTS} \
+    -export-fixes=${FIX_YAML} -j ${NUM_CPUS:-0} -p ${SRCDIR} -quiet \
+    ${APPLY_CLANG_TIDY_FIXES:+-fix} $@
+}
+
+function run_clang_tidy_diff() {
+  git diff $1 | filter_excludes | \
+    python3 "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
+      -clang-tidy-binary=${CLANG_TIDY} \
+      -export-fixes=${FIX_YAML} -j ${NUM_CPUS:-0} -p 1 -quiet
+}
+
+if [[ $# -gt 0 ]]; then
+  echo "Running clang-tidy on: $@"
+  run_clang_tidy $@
+elif [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
+  echo "Running a full clang-tidy"
+  run_clang_tidy
+else
+  if [[ -z "${DIFF_REF}" ]]; then
+    if [[ "${BUILD_REASON}" == "PullRequest" ]]; then
+      DIFF_REF="remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}"
+    elif [[ "${BUILD_REASON}" == *CI ]]; then
+      DIFF_REF="HEAD^"
+    else
+      DIFF_REF=$(${ENVOY_SRCDIR}/tools/git/last_github_commit.sh)
+    fi
+  fi
+  echo "Running clang-tidy-diff against ${DIFF_REF} ($(git rev-parse ${DIFF_REF})), current HEAD ($(git rev-parse HEAD))"
+  run_clang_tidy_diff ${DIFF_REF}
+fi
+
+if [[ -s "${FIX_YAML}" ]]; then
+  echo "clang-tidy check failed, potentially fixed by clang-apply-replacements:"
+  cat ${FIX_YAML}
+  exit 1
+fi


### PR DESCRIPTION
- Update run_clang_tidy.sh from Envoy's version.

- doesn't enable `[[nodiscard]]` because that introduced problems
with gtest: google/googletest#2416
- doesn't collapse nested namespaces, as the auto-fix is
imperfect: it doesn't update the command at the closing '}'

With this clang_tidy's automatic fix feature can be applied
as follows:

```bash
ci/do_ci.sh clang_tidy
/opt/llvm/bin/clang-apply-replacements  .
```

Related: #414

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>