### PR TITLE
Use only Nighthawk as a namespace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies,-modernize-use-trailing-return-type,-modernize-avoid-bind,-modernize-use-nodiscard,-modernize-concat-nested-namespaces'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies,-modernize-use-trailing-return-type,-modernize-avoid-bind,-modernize-use-nodiscard'
 
 WarningsAsErrors:  '*'
 

--- a/include/nighthawk/adaptive_load/adaptive_load_controller.h
+++ b/include/nighthawk/adaptive_load/adaptive_load_controller.h
@@ -5,7 +5,7 @@
 #include "api/adaptive_load/adaptive_load.pb.h"
 #include "api/client/service.grpc.pb.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Performs an adaptive load session consisting of the Adjusting Stage and the
@@ -31,4 +31,4 @@ nighthawk::adaptive_load::AdaptiveLoadSessionOutput PerformAdaptiveLoadSession(
     nighthawk::client::NighthawkService::StubInterface* nighthawk_service_stub,
     const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec, Envoy::TimeSource& time_source);
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/adaptive_load/input_variable_setter.h
+++ b/include/nighthawk/adaptive_load/input_variable_setter.h
@@ -12,7 +12,7 @@
 
 #include "absl/status/status.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * An interface for plugins that apply a StepController-computed input value to a CommandLineOptions
@@ -60,4 +60,4 @@ public:
   createInputVariableSetter(const Envoy::Protobuf::Message& message) PURE;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/adaptive_load/metrics_plugin.h
+++ b/include/nighthawk/adaptive_load/metrics_plugin.h
@@ -6,7 +6,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/typed_config.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * An interface for plugins that retrieve platform-specific metrics from outside data sources.
@@ -53,4 +53,4 @@ public:
   virtual MetricsPluginPtr createMetricsPlugin(const Envoy::Protobuf::Message& message) PURE;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/adaptive_load/scoring_function.h
+++ b/include/nighthawk/adaptive_load/scoring_function.h
@@ -6,7 +6,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/typed_config.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * An interface for custom functions that score a metric relative to a threshold.
@@ -50,4 +50,4 @@ public:
   virtual ScoringFunctionPtr createScoringFunction(const Envoy::Protobuf::Message& message) PURE;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/adaptive_load/step_controller.h
+++ b/include/nighthawk/adaptive_load/step_controller.h
@@ -10,7 +10,7 @@
 
 #include "api/adaptive_load/benchmark_result.pb.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * An interface for StepControllers that compute load adjustments and check for convergence.
@@ -83,4 +83,4 @@ public:
       const nighthawk::client::CommandLineOptions& command_line_options_template) PURE;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/client/benchmark_client.h
+++ b/include/nighthawk/client/benchmark_client.h
@@ -11,7 +11,7 @@
 #include "nighthawk/common/statistic.h"
 #include "nighthawk/common/uri.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using CompletionCallback = OperationCallback;
 
@@ -63,4 +63,4 @@ public:
 
 using BenchmarkClientPtr = std::unique_ptr<BenchmarkClient>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/client/benchmark_client.h
+++ b/include/nighthawk/client/benchmark_client.h
@@ -12,7 +12,6 @@
 #include "nighthawk/common/uri.h"
 
 namespace Nighthawk {
-namespace Client {
 
 using CompletionCallback = OperationCallback;
 
@@ -64,5 +63,4 @@ public:
 
 using BenchmarkClientPtr = std::unique_ptr<BenchmarkClient>;
 
-} // namespace Client
 } // namespace Nighthawk

--- a/include/nighthawk/client/client_worker.h
+++ b/include/nighthawk/client/client_worker.h
@@ -11,7 +11,6 @@
 #include "nighthawk/common/worker.h"
 
 namespace Nighthawk {
-namespace Client {
 
 /**
  * Interface for a threaded benchmark client worker.
@@ -43,5 +42,4 @@ public:
 
 using ClientWorkerPtr = std::unique_ptr<ClientWorker>;
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/include/nighthawk/client/client_worker.h
+++ b/include/nighthawk/client/client_worker.h
@@ -42,4 +42,4 @@ public:
 
 using ClientWorkerPtr = std::unique_ptr<ClientWorker>;
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/include/nighthawk/client/client_worker.h
+++ b/include/nighthawk/client/client_worker.h
@@ -10,7 +10,7 @@
 #include "nighthawk/common/statistic.h"
 #include "nighthawk/common/worker.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Interface for a threaded benchmark client worker.
@@ -42,4 +42,4 @@ public:
 
 using ClientWorkerPtr = std::unique_ptr<ClientWorker>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/client/factories.h
+++ b/include/nighthawk/client/factories.h
@@ -64,4 +64,4 @@ public:
   create(const nighthawk::client::OutputFormat_OutputFormatOptions options) const PURE;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/include/nighthawk/client/factories.h
+++ b/include/nighthawk/client/factories.h
@@ -18,7 +18,7 @@
 #include "nighthawk/common/termination_predicate.h"
 #include "nighthawk/common/uri.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class BenchmarkClientFactory {
 public:
@@ -64,4 +64,4 @@ public:
   create(const nighthawk::client::OutputFormat_OutputFormatOptions options) const PURE;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/client/factories.h
+++ b/include/nighthawk/client/factories.h
@@ -19,7 +19,6 @@
 #include "nighthawk/common/uri.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class BenchmarkClientFactory {
 public:
@@ -65,5 +64,4 @@ public:
   create(const nighthawk::client::OutputFormat_OutputFormatOptions options) const PURE;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -81,4 +81,4 @@ public:
 
 using OptionsPtr = std::unique_ptr<Options>;
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -17,7 +17,6 @@
 #include "absl/types/optional.h"
 
 namespace Nighthawk {
-namespace Client {
 
 using CommandLineOptionsPtr = std::unique_ptr<nighthawk::client::CommandLineOptions>;
 using TerminationPredicateMap = std::map<std::string, uint64_t>;
@@ -82,5 +81,4 @@ public:
 
 using OptionsPtr = std::unique_ptr<Options>;
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -16,7 +16,7 @@
 
 #include "absl/types/optional.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using CommandLineOptionsPtr = std::unique_ptr<nighthawk::client::CommandLineOptions>;
 using TerminationPredicateMap = std::map<std::string, uint64_t>;
@@ -81,4 +81,4 @@ public:
 
 using OptionsPtr = std::unique_ptr<Options>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/client/output_collector.h
+++ b/include/nighthawk/client/output_collector.h
@@ -6,7 +6,7 @@
 
 #include "nighthawk/common/statistic.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Facilitates building up an output proto from Nighthawk's native data structures.
@@ -41,4 +41,4 @@ public:
 
 using OutputCollectorPtr = std::unique_ptr<OutputCollector>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/client/output_collector.h
+++ b/include/nighthawk/client/output_collector.h
@@ -41,4 +41,4 @@ public:
 
 using OutputCollectorPtr = std::unique_ptr<OutputCollector>;
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/include/nighthawk/client/output_collector.h
+++ b/include/nighthawk/client/output_collector.h
@@ -7,7 +7,6 @@
 #include "nighthawk/common/statistic.h"
 
 namespace Nighthawk {
-namespace Client {
 
 /**
  * Facilitates building up an output proto from Nighthawk's native data structures.
@@ -42,5 +41,4 @@ public:
 
 using OutputCollectorPtr = std::unique_ptr<OutputCollector>;
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/include/nighthawk/client/output_formatter.h
+++ b/include/nighthawk/client/output_formatter.h
@@ -26,4 +26,4 @@ public:
 
 using OutputFormatterPtr = std::unique_ptr<OutputFormatter>;
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/include/nighthawk/client/output_formatter.h
+++ b/include/nighthawk/client/output_formatter.h
@@ -8,7 +8,7 @@
 
 #include "api/client/output.pb.validate.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Transforms from nighthawk::client::Output to an output format.
@@ -26,4 +26,4 @@ public:
 
 using OutputFormatterPtr = std::unique_ptr<OutputFormatter>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/client/output_formatter.h
+++ b/include/nighthawk/client/output_formatter.h
@@ -9,7 +9,6 @@
 #include "api/client/output.pb.validate.h"
 
 namespace Nighthawk {
-namespace Client {
 
 /**
  * Transforms from nighthawk::client::Output to an output format.
@@ -27,5 +26,4 @@ public:
 
 using OutputFormatterPtr = std::unique_ptr<OutputFormatter>;
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/include/nighthawk/client/process.h
+++ b/include/nighthawk/client/process.h
@@ -31,4 +31,4 @@ public:
 
 using ProcessPtr = std::unique_ptr<Process>;
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/include/nighthawk/client/process.h
+++ b/include/nighthawk/client/process.h
@@ -3,7 +3,6 @@
 #include "nighthawk/client/output_collector.h"
 
 namespace Nighthawk {
-namespace Client {
 
 /**
  * Process context is shared between the CLI and grpc service. It is capable of executing
@@ -32,5 +31,4 @@ public:
 
 using ProcessPtr = std::unique_ptr<Process>;
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/include/nighthawk/client/process.h
+++ b/include/nighthawk/client/process.h
@@ -2,7 +2,7 @@
 
 #include "nighthawk/client/output_collector.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Process context is shared between the CLI and grpc service. It is capable of executing
@@ -31,4 +31,4 @@ public:
 
 using ProcessPtr = std::unique_ptr<Process>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/exception.h
+++ b/include/nighthawk/common/exception.h
@@ -32,4 +32,4 @@ public:
 };
 
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/include/nighthawk/common/exception.h
+++ b/include/nighthawk/common/exception.h
@@ -13,7 +13,6 @@ public:
 };
 
 // TODO(oschaaf): restructure.
-namespace Client {
 
 /**
  * We translate certain exceptions thrown by TCLAP to NoServingException, for example when
@@ -32,6 +31,5 @@ public:
   MalformedArgvException(const std::string& what) : NighthawkException(what) {}
 };
 
-} // namespace Client
 
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/include/nighthawk/common/exception.h
+++ b/include/nighthawk/common/exception.h
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace Nighthawk {
+namespace nighthawk {
 /**
  * Base class for all Nighthawk exceptions.
  */
@@ -32,4 +32,4 @@ public:
 };
 
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/factories.h
+++ b/include/nighthawk/common/factories.h
@@ -14,7 +14,7 @@
 #include "nighthawk/common/statistic.h"
 #include "nighthawk/common/termination_predicate.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class SequencerFactory {
 public:
@@ -48,4 +48,4 @@ public:
          const Envoy::MonotonicTime scheduled_starting_time) const PURE;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/operation_callback.h
+++ b/include/nighthawk/common/operation_callback.h
@@ -1,6 +1,6 @@
 #include <functional>
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Callback specification. Done will be true if the flow was fully executed,
@@ -9,4 +9,4 @@ namespace Nighthawk {
  * a success, and is meaningful only when done equals true.
  */
 using OperationCallback = std::function<void(bool done, bool success)>;
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/phase.h
+++ b/include/nighthawk/common/phase.h
@@ -7,7 +7,7 @@
 
 #include "nighthawk/common/sequencer.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Phase represents a distinct phase of a benchmmark execution, like warmup and cooldown.
@@ -48,4 +48,4 @@ public:
 
 using PhasePtr = std::unique_ptr<Phase>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/platform_util.h
+++ b/include/nighthawk/common/platform_util.h
@@ -5,7 +5,7 @@
 
 #include "envoy/common/pure.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * A place to store platform specific utilities.
@@ -26,4 +26,4 @@ public:
 
 using PlatformUtilPtr = std::unique_ptr<PlatformUtil>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/rate_limiter.h
+++ b/include/nighthawk/common/rate_limiter.h
@@ -8,7 +8,7 @@
 
 #include "absl/types/optional.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Abstract rate limiter interface.
@@ -64,4 +64,4 @@ public:
 
 using DiscreteNumericDistributionSamplerPtr = std::unique_ptr<DiscreteNumericDistributionSampler>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/request.h
+++ b/include/nighthawk/common/request.h
@@ -4,7 +4,7 @@
 
 #include "envoy/http/header_map.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using HeaderMapPtr = std::shared_ptr<const Envoy::Http::RequestHeaderMap>;
 
@@ -25,4 +25,4 @@ public:
 
 using RequestPtr = std::unique_ptr<Request>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/request_source.h
+++ b/include/nighthawk/common/request_source.h
@@ -6,7 +6,7 @@
 
 #include "nighthawk/common/request.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using RequestGenerator = std::function<RequestPtr()>;
 
@@ -27,4 +27,4 @@ public:
 
 using RequestSourcePtr = std::unique_ptr<RequestSource>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/request_stream_grpc_client.h
+++ b/include/nighthawk/common/request_stream_grpc_client.h
@@ -4,7 +4,7 @@
 
 #include "nighthawk/common/request.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Interface for a gRPC client used to pull request data from a gRPC service.
@@ -29,4 +29,4 @@ public:
 
 using RequestStreamGrpcClientPtr = std::unique_ptr<RequestStreamGrpcClient>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/sequencer.h
+++ b/include/nighthawk/common/sequencer.h
@@ -9,7 +9,7 @@
 #include "nighthawk/common/operation_callback.h"
 #include "nighthawk/common/statistic.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using SequencerTarget = std::function<bool(OperationCallback)>;
 
@@ -53,4 +53,4 @@ public:
 
 using SequencerPtr = std::unique_ptr<Sequencer>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/statistic.h
+++ b/include/nighthawk/common/statistic.h
@@ -13,7 +13,7 @@
 
 #include "absl/strings/string_view.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class Statistic;
 
@@ -117,4 +117,4 @@ public:
   virtual void setId(absl::string_view id) PURE;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/termination_predicate.h
+++ b/include/nighthawk/common/termination_predicate.h
@@ -4,7 +4,7 @@
 
 #include "envoy/common/pure.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class TerminationPredicate;
 
@@ -55,4 +55,4 @@ public:
   virtual Status evaluate() PURE;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/uri.h
+++ b/include/nighthawk/common/uri.h
@@ -9,7 +9,7 @@
 
 #include "absl/strings/string_view.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Any exception thrown by Uri shall inherit from UriException.
@@ -75,4 +75,4 @@ public:
 
 using UriPtr = std::unique_ptr<Uri>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/include/nighthawk/common/worker.h
+++ b/include/nighthawk/common/worker.h
@@ -6,7 +6,7 @@
 
 #include "nighthawk/common/statistic.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Interface for a threaded worker.
@@ -40,4 +40,4 @@ public:
 
 using WorkerPtr = std::unique_ptr<Worker>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/adaptive_load/input_variable_setter_impl.cc
+++ b/source/adaptive_load/input_variable_setter_impl.cc
@@ -4,7 +4,7 @@
 
 #include "external/envoy/source/common/protobuf/protobuf.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 RequestsPerSecondInputVariableSetter::RequestsPerSecondInputVariableSetter(
     const nighthawk::adaptive_load::RequestsPerSecondInputVariableSetterConfig&) {}
@@ -40,4 +40,4 @@ InputVariableSetterPtr RequestsPerSecondInputVariableSetterConfigFactory::create
 REGISTER_FACTORY(RequestsPerSecondInputVariableSetterConfigFactory,
                  InputVariableSetterConfigFactory);
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/adaptive_load/input_variable_setter_impl.h
+++ b/source/adaptive_load/input_variable_setter_impl.h
@@ -6,7 +6,7 @@
 
 #include "api/adaptive_load/input_variable_setter_impl.pb.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * An InputVariableSetter that sets the |requests_per_second| field in the CommandLineOptions proto.
@@ -39,4 +39,4 @@ public:
 // This factory is activated through LoadInputVariableSetterPlugin in plugin_util.h.
 DECLARE_FACTORY(RequestsPerSecondInputVariableSetterConfigFactory);
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -17,7 +17,7 @@
 
 using namespace std::chrono_literals;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 BenchmarkClientStatistic::BenchmarkClientStatistic(BenchmarkClientStatistic&& statistic) noexcept
     : connect_statistic(std::move(statistic.connect_statistic)),
@@ -223,4 +223,4 @@ void BenchmarkClientHttpImpl::exportLatency(const uint32_t response_code,
   }
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -18,7 +18,6 @@
 using namespace std::chrono_literals;
 
 namespace Nighthawk {
-namespace Client {
 
 BenchmarkClientStatistic::BenchmarkClientStatistic(BenchmarkClientStatistic&& statistic) noexcept
     : connect_statistic(std::move(statistic.connect_statistic)),
@@ -224,5 +223,4 @@ void BenchmarkClientHttpImpl::exportLatency(const uint32_t response_code,
   }
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -223,4 +223,4 @@ void BenchmarkClientHttpImpl::exportLatency(const uint32_t response_code,
   }
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -26,7 +26,7 @@
 
 #include "client/stream_decoder.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using namespace std::chrono_literals;
 
@@ -163,4 +163,4 @@ private:
   const bool provide_resource_backpressure_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -163,4 +163,4 @@ private:
   const bool provide_resource_backpressure_;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -27,7 +27,6 @@
 #include "client/stream_decoder.h"
 
 namespace Nighthawk {
-namespace Client {
 
 using namespace std::chrono_literals;
 
@@ -164,5 +163,4 @@ private:
   const bool provide_resource_backpressure_;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/client.cc
+++ b/source/client/client.cc
@@ -37,12 +37,11 @@
 using namespace std::chrono_literals;
 
 namespace Nighthawk {
-namespace Client {
 
 Main::Main(int argc, const char* const* argv)
-    : Main(std::make_unique<Client::OptionsImpl>(argc, argv)) {}
+    : Main(std::make_unique<OptionsImpl>(argc, argv)) {}
 
-Main::Main(Client::OptionsPtr&& options) : options_(std::move(options)) {}
+Main::Main(OptionsPtr&& options) : options_(std::move(options)) {}
 
 bool Main::run() {
   Envoy::Thread::MutexBasicLockable log_lock;
@@ -91,5 +90,4 @@ bool Main::run() {
   return result;
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/client.cc
+++ b/source/client/client.cc
@@ -90,4 +90,4 @@ bool Main::run() {
   return result;
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/client.cc
+++ b/source/client/client.cc
@@ -36,7 +36,7 @@
 
 using namespace std::chrono_literals;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 Main::Main(int argc, const char* const* argv)
     : Main(std::make_unique<OptionsImpl>(argc, argv)) {}
@@ -90,4 +90,4 @@ bool Main::run() {
   return result;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/client.h
+++ b/source/client/client.h
@@ -14,12 +14,11 @@
 #include "process_impl.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class Main : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
   Main(int argc, const char* const* argv);
-  Main(Client::OptionsPtr&& options);
+  Main(OptionsPtr&& options);
   bool run();
 
 private:
@@ -27,5 +26,4 @@ private:
   std::unique_ptr<Envoy::Logger::Context> logging_context_;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/client.h
+++ b/source/client/client.h
@@ -26,4 +26,4 @@ private:
   std::unique_ptr<Envoy::Logger::Context> logging_context_;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/client.h
+++ b/source/client/client.h
@@ -13,7 +13,7 @@
 
 #include "process_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class Main : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -26,4 +26,4 @@ private:
   std::unique_ptr<Envoy::Logger::Context> logging_context_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/client_worker_impl.cc
+++ b/source/client/client_worker_impl.cc
@@ -104,4 +104,4 @@ StatisticPtrMap ClientWorkerImpl::statistics() const {
   return statistics;
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/client_worker_impl.cc
+++ b/source/client/client_worker_impl.cc
@@ -8,7 +8,6 @@
 #include "common/utility.h"
 
 namespace Nighthawk {
-namespace Client {
 
 using namespace std::chrono_literals;
 
@@ -105,5 +104,4 @@ StatisticPtrMap ClientWorkerImpl::statistics() const {
   return statistics;
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/client_worker_impl.cc
+++ b/source/client/client_worker_impl.cc
@@ -7,7 +7,7 @@
 #include "common/termination_predicate_impl.h"
 #include "common/utility.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using namespace std::chrono_literals;
 
@@ -104,4 +104,4 @@ StatisticPtrMap ClientWorkerImpl::statistics() const {
   return statistics;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/client_worker_impl.h
+++ b/source/client/client_worker_impl.h
@@ -70,4 +70,4 @@ private:
 
 using ClientWorkerImplPtr = std::unique_ptr<ClientWorkerImpl>;
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/client_worker_impl.h
+++ b/source/client/client_worker_impl.h
@@ -19,7 +19,7 @@
 
 #include "common/worker_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class ClientWorkerImpl : public WorkerImpl, virtual public ClientWorker {
 public:
@@ -70,4 +70,4 @@ private:
 
 using ClientWorkerImplPtr = std::unique_ptr<ClientWorkerImpl>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/client_worker_impl.h
+++ b/source/client/client_worker_impl.h
@@ -20,7 +20,6 @@
 #include "common/worker_impl.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class ClientWorkerImpl : public WorkerImpl, virtual public ClientWorker {
 public:
@@ -71,5 +70,4 @@ private:
 
 using ClientWorkerImplPtr = std::unique_ptr<ClientWorkerImpl>;
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -20,7 +20,6 @@
 using namespace std::chrono_literals;
 
 namespace Nighthawk {
-namespace Client {
 
 OptionBasedFactoryImpl::OptionBasedFactoryImpl(const Options& options) : options_(options) {}
 
@@ -98,15 +97,15 @@ OutputFormatterPtr OutputFormatterFactoryImpl::create(
     const nighthawk::client::OutputFormat_OutputFormatOptions output_format) const {
   switch (output_format) {
   case nighthawk::client::OutputFormat::HUMAN:
-    return std::make_unique<Client::ConsoleOutputFormatterImpl>();
+    return std::make_unique<ConsoleOutputFormatterImpl>();
   case nighthawk::client::OutputFormat::JSON:
-    return std::make_unique<Client::JsonOutputFormatterImpl>();
+    return std::make_unique<JsonOutputFormatterImpl>();
   case nighthawk::client::OutputFormat::YAML:
-    return std::make_unique<Client::YamlOutputFormatterImpl>();
+    return std::make_unique<YamlOutputFormatterImpl>();
   case nighthawk::client::OutputFormat::DOTTED:
-    return std::make_unique<Client::DottedStringOutputFormatterImpl>();
+    return std::make_unique<DottedStringOutputFormatterImpl>();
   case nighthawk::client::OutputFormat::FORTIO:
-    return std::make_unique<Client::FortioOutputFormatterImpl>();
+    return std::make_unique<FortioOutputFormatterImpl>();
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
@@ -220,5 +219,4 @@ TerminationPredicate* TerminationPredicateFactoryImpl::linkConfiguredPredicates(
   return current_predicate;
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -19,7 +19,7 @@
 
 using namespace std::chrono_literals;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 OptionBasedFactoryImpl::OptionBasedFactoryImpl(const Options& options) : options_(options) {}
 
@@ -219,4 +219,4 @@ TerminationPredicate* TerminationPredicateFactoryImpl::linkConfiguredPredicates(
   return current_predicate;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -219,4 +219,4 @@ TerminationPredicate* TerminationPredicateFactoryImpl::linkConfiguredPredicates(
   return current_predicate;
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/factories_impl.h
+++ b/source/client/factories_impl.h
@@ -12,7 +12,6 @@
 #include "common/platform_util_impl.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class OptionBasedFactoryImpl : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -79,5 +78,4 @@ public:
       const TerminationPredicate::Status termination_status, Envoy::Stats::Scope& scope) const;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/factories_impl.h
+++ b/source/client/factories_impl.h
@@ -11,7 +11,7 @@
 
 #include "common/platform_util_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class OptionBasedFactoryImpl : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -78,4 +78,4 @@ public:
       const TerminationPredicate::Status termination_status, Envoy::Stats::Scope& scope) const;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/factories_impl.h
+++ b/source/client/factories_impl.h
@@ -78,4 +78,4 @@ public:
       const TerminationPredicate::Status termination_status, Envoy::Stats::Scope& scope) const;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -16,7 +16,7 @@
 #include "absl/types/optional.h"
 #include "fmt/ranges.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 #define TCLAP_SET_IF_SPECIFIED(command, value_member)                                              \
   ((value_member) = (((command).isSet()) ? ((command).getValue()) : (value_member)))
@@ -783,4 +783,4 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
   return command_line_options;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -783,4 +783,4 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
   return command_line_options;
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -17,7 +17,6 @@
 #include "fmt/ranges.h"
 
 namespace Nighthawk {
-namespace Client {
 
 #define TCLAP_SET_IF_SPECIFIED(command, value_member)                                              \
   ((value_member) = (((command).isSet()) ? ((command).getValue()) : (value_member)))
@@ -784,5 +783,4 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
   return command_line_options;
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -14,7 +14,6 @@
 #include "tclap/CmdLine.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class OptionsImpl : public Options, public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -24,7 +23,7 @@ public:
 
   OptionsImpl(int argc, const char* const* argv);
   OptionsImpl(const nighthawk::client::CommandLineOptions& options);
-  Client::CommandLineOptionsPtr toCommandLineOptions() const override;
+  CommandLineOptionsPtr toCommandLineOptions() const override;
 
   uint32_t requestsPerSecond() const override { return requests_per_second_; }
   uint32_t connections() const override { return connections_; }
@@ -91,7 +90,7 @@ private:
                        TerminationPredicateMap& predicates);
   void setNonTrivialDefaults();
   void validate() const;
-  Client::CommandLineOptionsPtr toCommandLineOptionsInternal() const;
+  CommandLineOptionsPtr toCommandLineOptionsInternal() const;
 
   uint32_t requests_per_second_{5};
   uint32_t connections_{100};
@@ -140,5 +139,4 @@ private:
   uint32_t stats_flush_interval_{5};
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -13,7 +13,7 @@
 #include "absl/types/optional.h"
 #include "tclap/CmdLine.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class OptionsImpl : public Options, public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -139,4 +139,4 @@ private:
   uint32_t stats_flush_interval_{5};
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -139,4 +139,4 @@ private:
   uint32_t stats_flush_interval_{5};
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/output_collector_impl.cc
+++ b/source/client/output_collector_impl.cc
@@ -10,7 +10,6 @@
 #include "common/version_info.h"
 
 namespace Nighthawk {
-namespace Client {
 
 OutputCollectorImpl::OutputCollectorImpl(Envoy::TimeSource& time_source, const Options& options) {
   *(output_.mutable_timestamp()) = Envoy::Protobuf::util::TimeUtil::NanosecondsToTimestamp(
@@ -48,5 +47,4 @@ void OutputCollectorImpl::addResult(absl::string_view name,
       Envoy::Protobuf::util::TimeUtil::NanosecondsToDuration(execution_duration.count());
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/output_collector_impl.cc
+++ b/source/client/output_collector_impl.cc
@@ -47,4 +47,4 @@ void OutputCollectorImpl::addResult(absl::string_view name,
       Envoy::Protobuf::util::TimeUtil::NanosecondsToDuration(execution_duration.count());
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/output_collector_impl.cc
+++ b/source/client/output_collector_impl.cc
@@ -9,7 +9,7 @@
 
 #include "common/version_info.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 OutputCollectorImpl::OutputCollectorImpl(Envoy::TimeSource& time_source, const Options& options) {
   *(output_.mutable_timestamp()) = Envoy::Protobuf::util::TimeUtil::NanosecondsToTimestamp(
@@ -47,4 +47,4 @@ void OutputCollectorImpl::addResult(absl::string_view name,
       Envoy::Protobuf::util::TimeUtil::NanosecondsToDuration(execution_duration.count());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/output_collector_impl.h
+++ b/source/client/output_collector_impl.h
@@ -8,7 +8,6 @@
 #include "nighthawk/client/output_collector.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class OutputCollectorImpl : public OutputCollector {
 public:
@@ -29,5 +28,4 @@ private:
   nighthawk::client::Output output_;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/output_collector_impl.h
+++ b/source/client/output_collector_impl.h
@@ -7,7 +7,7 @@
 #include "nighthawk/client/options.h"
 #include "nighthawk/client/output_collector.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class OutputCollectorImpl : public OutputCollector {
 public:
@@ -28,4 +28,4 @@ private:
   nighthawk::client::Output output_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/output_collector_impl.h
+++ b/source/client/output_collector_impl.h
@@ -28,4 +28,4 @@ private:
   nighthawk::client::Output output_;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -16,7 +16,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/strip.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 std::vector<std::string> OutputFormatterImpl::getLowerCaseOutputFormats() {
   const Envoy::Protobuf::EnumDescriptor* enum_descriptor =
@@ -390,4 +390,4 @@ const nighthawk::client::DurationHistogram FortioOutputFormatterImpl::renderFort
   return fortio_histogram;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -17,7 +17,6 @@
 #include "absl/strings/strip.h"
 
 namespace Nighthawk {
-namespace Client {
 
 std::vector<std::string> OutputFormatterImpl::getLowerCaseOutputFormats() {
   const Envoy::Protobuf::EnumDescriptor* enum_descriptor =
@@ -391,5 +390,4 @@ const nighthawk::client::DurationHistogram FortioOutputFormatterImpl::renderFort
   return fortio_histogram;
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -390,4 +390,4 @@ const nighthawk::client::DurationHistogram FortioOutputFormatterImpl::renderFort
   return fortio_histogram;
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/output_formatter_impl.h
+++ b/source/client/output_formatter_impl.h
@@ -13,7 +13,7 @@
 
 #include "absl/strings/string_view.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class OutputFormatterImpl : public OutputFormatter {
 public:
@@ -107,4 +107,4 @@ protected:
   double durationToSeconds(const Envoy::ProtobufWkt::Duration& duration) const;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/output_formatter_impl.h
+++ b/source/client/output_formatter_impl.h
@@ -107,4 +107,4 @@ protected:
   double durationToSeconds(const Envoy::ProtobufWkt::Duration& duration) const;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/output_formatter_impl.h
+++ b/source/client/output_formatter_impl.h
@@ -14,7 +14,6 @@
 #include "absl/strings/string_view.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class OutputFormatterImpl : public OutputFormatter {
 public:
@@ -108,5 +107,4 @@ protected:
   double durationToSeconds(const Envoy::ProtobufWkt::Duration& duration) const;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/output_transform_main.cc
+++ b/source/client/output_transform_main.cc
@@ -19,7 +19,6 @@
 #include "tclap/CmdLine.h"
 
 namespace Nighthawk {
-namespace Client {
 
 OutputTransformMain::OutputTransformMain(int argc, const char* const* argv, std::istream& input)
     : input_(input) {
@@ -62,5 +61,4 @@ uint32_t OutputTransformMain::run() {
   return 0;
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/output_transform_main.cc
+++ b/source/client/output_transform_main.cc
@@ -61,4 +61,4 @@ uint32_t OutputTransformMain::run() {
   return 0;
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/output_transform_main.cc
+++ b/source/client/output_transform_main.cc
@@ -18,7 +18,7 @@
 #include "fmt/ranges.h"
 #include "tclap/CmdLine.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 OutputTransformMain::OutputTransformMain(int argc, const char* const* argv, std::istream& input)
     : input_(input) {
@@ -61,4 +61,4 @@ uint32_t OutputTransformMain::run() {
   return 0;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/output_transform_main.h
+++ b/source/client/output_transform_main.h
@@ -17,4 +17,4 @@ private:
   std::istream& input_;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/output_transform_main.h
+++ b/source/client/output_transform_main.h
@@ -4,7 +4,6 @@
 #include "external/envoy/source/common/event/real_time_system.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class OutputTransformMain : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -18,5 +17,4 @@ private:
   std::istream& input_;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/output_transform_main.h
+++ b/source/client/output_transform_main.h
@@ -3,7 +3,7 @@
 #include "external/envoy/source/common/common/logger.h"
 #include "external/envoy/source/common/event/real_time_system.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class OutputTransformMain : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -17,4 +17,4 @@ private:
   std::istream& input_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -53,7 +53,7 @@
 
 using namespace std::chrono_literals;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 // We customize ProdClusterManagerFactory for the sole purpose of returning our specialized
 // http1 pool to the benchmark client, which allows us to offer connection prefetching.
@@ -543,4 +543,4 @@ void ProcessImpl::setupForHRTimers() {
   putenv(const_cast<char*>("EVENT_PRECISE_TIMER=1"));
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -54,7 +54,6 @@
 using namespace std::chrono_literals;
 
 namespace Nighthawk {
-namespace Client {
 
 // We customize ProdClusterManagerFactory for the sole purpose of returning our specialized
 // http1 pool to the benchmark client, which allows us to offer connection prefetching.
@@ -544,5 +543,4 @@ void ProcessImpl::setupForHRTimers() {
   putenv(const_cast<char*>("EVENT_PRECISE_TIMER=1"));
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -543,4 +543,4 @@ void ProcessImpl::setupForHRTimers() {
   putenv(const_cast<char*>("EVENT_PRECISE_TIMER=1"));
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -35,7 +35,6 @@
 #include "client/factories_impl.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class ClusterManagerFactory;
 /**
@@ -158,5 +157,4 @@ private:
   bool cancelled_{false};
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -34,7 +34,7 @@
 #include "client/benchmark_client_impl.h"
 #include "client/factories_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class ClusterManagerFactory;
 /**
@@ -157,4 +157,4 @@ private:
   bool cancelled_{false};
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -157,4 +157,4 @@ private:
   bool cancelled_{false};
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/remote_process_impl.cc
+++ b/source/client/remote_process_impl.cc
@@ -13,7 +13,7 @@
 
 #include "client/options_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 RemoteProcessImpl::RemoteProcessImpl(const Options& options,
                                      nighthawk::client::NighthawkService::Stub& stub)
@@ -59,4 +59,4 @@ bool RemoteProcessImpl::requestExecutionCancellation() {
   return false;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/remote_process_impl.cc
+++ b/source/client/remote_process_impl.cc
@@ -59,4 +59,4 @@ bool RemoteProcessImpl::requestExecutionCancellation() {
   return false;
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/remote_process_impl.cc
+++ b/source/client/remote_process_impl.cc
@@ -14,7 +14,6 @@
 #include "client/options_impl.h"
 
 namespace Nighthawk {
-namespace Client {
 
 RemoteProcessImpl::RemoteProcessImpl(const Options& options,
                                      nighthawk::client::NighthawkService::Stub& stub)
@@ -60,5 +59,4 @@ bool RemoteProcessImpl::requestExecutionCancellation() {
   return false;
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/remote_process_impl.h
+++ b/source/client/remote_process_impl.h
@@ -8,7 +8,7 @@
 
 #include "api/client/service.grpc.pb.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Will delegate execution to a remote nighthawk_service using gRPC.
@@ -40,4 +40,4 @@ private:
   nighthawk::client::NighthawkService::Stub& stub_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/remote_process_impl.h
+++ b/source/client/remote_process_impl.h
@@ -9,7 +9,6 @@
 #include "api/client/service.grpc.pb.h"
 
 namespace Nighthawk {
-namespace Client {
 
 /**
  * Will delegate execution to a remote nighthawk_service using gRPC.
@@ -41,5 +40,4 @@ private:
   nighthawk::client::NighthawkService::Stub& stub_;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/remote_process_impl.h
+++ b/source/client/remote_process_impl.h
@@ -40,4 +40,4 @@ private:
   nighthawk::client::NighthawkService::Stub& stub_;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/service_impl.cc
+++ b/source/client/service_impl.cc
@@ -8,7 +8,7 @@
 #include "client/options_impl.h"
 #include "client/output_collector_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 void ServiceImpl::handleExecutionRequest(const nighthawk::client::ExecutionRequest& request) {
   std::unique_ptr<Envoy::Thread::LockGuard> busy_lock;
@@ -161,4 +161,4 @@ RequestSourcePtr RequestSourceServiceImpl::createStaticEmptyRequestSource(const 
   return ok ? grpc::Status::OK : grpc::Status(grpc::StatusCode::INTERNAL, std::string("error"));
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/service_impl.cc
+++ b/source/client/service_impl.cc
@@ -9,7 +9,6 @@
 #include "client/output_collector_impl.h"
 
 namespace Nighthawk {
-namespace Client {
 
 void ServiceImpl::handleExecutionRequest(const nighthawk::client::ExecutionRequest& request) {
   std::unique_ptr<Envoy::Thread::LockGuard> busy_lock;
@@ -162,5 +161,4 @@ RequestSourcePtr RequestSourceServiceImpl::createStaticEmptyRequestSource(const 
   return ok ? grpc::Status::OK : grpc::Status(grpc::StatusCode::INTERNAL, std::string("error"));
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/service_impl.cc
+++ b/source/client/service_impl.cc
@@ -161,4 +161,4 @@ RequestSourcePtr RequestSourceServiceImpl::createStaticEmptyRequestSource(const 
   return ok ? grpc::Status::OK : grpc::Status(grpc::StatusCode::INTERNAL, std::string("error"));
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/service_impl.h
+++ b/source/client/service_impl.h
@@ -22,7 +22,6 @@
 #include "nighthawk/common/request_source.h"
 
 namespace Nighthawk {
-namespace Client {
 
 /**
  * Implements Nighthawk's gRPC service. This service allows load generation to be
@@ -85,5 +84,4 @@ private:
   RequestSourcePtr createStaticEmptyRequestSource(const uint32_t amount);
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/service_impl.h
+++ b/source/client/service_impl.h
@@ -84,4 +84,4 @@ private:
   RequestSourcePtr createStaticEmptyRequestSource(const uint32_t amount);
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/service_impl.h
+++ b/source/client/service_impl.h
@@ -21,7 +21,7 @@
 #include "nighthawk/client/process.h"
 #include "nighthawk/common/request_source.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Implements Nighthawk's gRPC service. This service allows load generation to be
@@ -84,4 +84,4 @@ private:
   RequestSourcePtr createStaticEmptyRequestSource(const uint32_t amount);
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/service_main.cc
+++ b/source/client/service_main.cc
@@ -91,4 +91,4 @@ void ServiceMain::wait() {
 
 void ServiceMain::shutdown() { ENVOY_LOG(info, "Nighthawk grpc service exits"); }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/service_main.cc
+++ b/source/client/service_main.cc
@@ -14,7 +14,6 @@
 #include "tclap/CmdLine.h"
 
 namespace Nighthawk {
-namespace Client {
 
 ServiceMain::ServiceMain(int argc, const char** argv) {
   const char* descr = "L7 (HTTP/HTTPS/HTTP2) performance characterization tool.";
@@ -92,5 +91,4 @@ void ServiceMain::wait() {
 
 void ServiceMain::shutdown() { ENVOY_LOG(info, "Nighthawk grpc service exits"); }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/service_main.cc
+++ b/source/client/service_main.cc
@@ -13,7 +13,7 @@
 #include "absl/strings/strip.h"
 #include "tclap/CmdLine.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 ServiceMain::ServiceMain(int argc, const char** argv) {
   const char* descr = "L7 (HTTP/HTTPS/HTTP2) performance characterization tool.";
@@ -91,4 +91,4 @@ void ServiceMain::wait() {
 
 void ServiceMain::shutdown() { ENVOY_LOG(info, "Nighthawk grpc service exits"); }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/service_main.h
+++ b/source/client/service_main.h
@@ -19,7 +19,6 @@
 #include "tclap/CmdLine.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class ServiceMain : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -50,5 +49,4 @@ private:
   SignalHandlerPtr signal_handler_;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/service_main.h
+++ b/source/client/service_main.h
@@ -18,7 +18,7 @@
 
 #include "tclap/CmdLine.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class ServiceMain : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -49,4 +49,4 @@ private:
   SignalHandlerPtr signal_handler_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/service_main.h
+++ b/source/client/service_main.h
@@ -49,4 +49,4 @@ private:
   SignalHandlerPtr signal_handler_;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/sni_utility.cc
+++ b/source/client/sni_utility.cc
@@ -2,7 +2,7 @@
 
 #include "absl/strings/strip.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 std::string SniUtility::computeSniHost(const std::vector<UriPtr>& uris,
                                        const std::vector<std::string>& request_headers,
@@ -41,4 +41,4 @@ std::string SniUtility::computeSniHost(const std::vector<UriPtr>& uris,
   return sni_host;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/sni_utility.cc
+++ b/source/client/sni_utility.cc
@@ -41,4 +41,4 @@ std::string SniUtility::computeSniHost(const std::vector<UriPtr>& uris,
   return sni_host;
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/sni_utility.cc
+++ b/source/client/sni_utility.cc
@@ -3,7 +3,6 @@
 #include "absl/strings/strip.h"
 
 namespace Nighthawk {
-namespace Client {
 
 std::string SniUtility::computeSniHost(const std::vector<UriPtr>& uris,
                                        const std::vector<std::string>& request_headers,
@@ -42,5 +41,4 @@ std::string SniUtility::computeSniHost(const std::vector<UriPtr>& uris,
   return sni_host;
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/sni_utility.h
+++ b/source/client/sni_utility.h
@@ -8,7 +8,6 @@
 #include "external/envoy/include/envoy/http/protocol.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class SniUtility : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -30,5 +29,4 @@ public:
                                     const Envoy::Http::Protocol protocol);
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/sni_utility.h
+++ b/source/client/sni_utility.h
@@ -7,7 +7,7 @@
 
 #include "external/envoy/include/envoy/http/protocol.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class SniUtility : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -29,4 +29,4 @@ public:
                                     const Envoy::Http::Protocol protocol);
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/sni_utility.h
+++ b/source/client/sni_utility.h
@@ -29,4 +29,4 @@ public:
                                     const Envoy::Http::Protocol protocol);
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -8,7 +8,7 @@
 #include "external/envoy/source/common/network/address_impl.h"
 #include "external/envoy/source/common/stream_info/stream_info_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 void StreamDecoder::decodeHeaders(Envoy::Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ASSERT(!complete_);
@@ -163,4 +163,4 @@ void StreamDecoder::setupForTracing() {
   stream_info_.setDownstreamRemoteAddress(remote_address);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -9,7 +9,6 @@
 #include "external/envoy/source/common/stream_info/stream_info_impl.h"
 
 namespace Nighthawk {
-namespace Client {
 
 void StreamDecoder::decodeHeaders(Envoy::Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ASSERT(!complete_);
@@ -164,5 +163,4 @@ void StreamDecoder::setupForTracing() {
   stream_info_.setDownstreamRemoteAddress(remote_address);
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -163,4 +163,4 @@ void StreamDecoder::setupForTracing() {
   stream_info_.setDownstreamRemoteAddress(remote_address);
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/stream_decoder.h
+++ b/source/client/stream_decoder.h
@@ -118,4 +118,4 @@ private:
   Envoy::StreamInfo::UpstreamTiming upstream_timing_;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/source/client/stream_decoder.h
+++ b/source/client/stream_decoder.h
@@ -18,7 +18,6 @@
 #include "external/envoy/source/common/tracing/http_tracer_impl.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class StreamDecoderCompletionCallback {
 public:
@@ -119,5 +118,4 @@ private:
   Envoy::StreamInfo::UpstreamTiming upstream_timing_;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/source/client/stream_decoder.h
+++ b/source/client/stream_decoder.h
@@ -17,7 +17,7 @@
 #include "external/envoy/source/common/stream_info/stream_info_impl.h"
 #include "external/envoy/source/common/tracing/http_tracer_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class StreamDecoderCompletionCallback {
 public:
@@ -118,4 +118,4 @@ private:
   Envoy::StreamInfo::UpstreamTiming upstream_timing_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/cached_time_source_impl.h
+++ b/source/common/cached_time_source_impl.h
@@ -5,7 +5,7 @@
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Time source which caches monotonic time. Intended for usage accross components to get a
@@ -34,4 +34,4 @@ private:
   Envoy::Event::Dispatcher& dispatcher_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/frequency.h
+++ b/source/common/frequency.h
@@ -3,7 +3,7 @@
 #include <chrono>
 #include <cmath>
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class Frequency {
 public:
@@ -20,4 +20,4 @@ private:
 constexpr Frequency operator"" _Hz(unsigned long long hz) { return Frequency{hz}; }
 constexpr Frequency operator"" _kHz(unsigned long long khz) { return Frequency{khz * 1000}; }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/phase_impl.cc
+++ b/source/common/phase_impl.cc
@@ -1,6 +1,6 @@
 #include "common/phase_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 absl::string_view PhaseImpl::id() const { return id_; }
 
@@ -15,4 +15,4 @@ void PhaseImpl::run() const {
   ENVOY_LOG(trace, "finished '{}' phase", id());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/phase_impl.h
+++ b/source/common/phase_impl.h
@@ -9,7 +9,7 @@
 
 #include "absl/types/optional.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class PhaseImpl : public Phase, public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -35,4 +35,4 @@ private:
   const bool should_measure_latencies_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/platform_util_impl.h
+++ b/source/common/platform_util_impl.h
@@ -6,7 +6,7 @@
 
 #include "nighthawk/common/platform_util.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using namespace std::chrono_literals;
 
@@ -24,4 +24,4 @@ public:
   };
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/rate_limiter_impl.cc
+++ b/source/common/rate_limiter_impl.cc
@@ -4,7 +4,7 @@
 
 #include "external/envoy/source/common/common/assert.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using namespace std::chrono_literals;
 
@@ -241,4 +241,4 @@ ZipfRateLimiterImpl::ZipfRateLimiterImpl(RateLimiterPtr&& rate_limiter, double q
   dist_ = absl::zipf_distribution<uint64_t>(1, q, v);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/rate_limiter_impl.h
+++ b/source/common/rate_limiter_impl.h
@@ -14,7 +14,7 @@
 #include "absl/random/zipf_distribution.h"
 #include "absl/types/optional.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Rate limiter base class, which implements some shared functionality for derivations that
@@ -251,4 +251,4 @@ private:
   ZipfBehavior behavior_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/request_impl.h
+++ b/source/common/request_impl.h
@@ -4,7 +4,7 @@
 
 #include "nighthawk/common/request.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class RequestImpl : public Request {
 public:
@@ -15,4 +15,4 @@ private:
   HeaderMapPtr header_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/request_source_impl.cc
+++ b/source/common/request_source_impl.cc
@@ -6,7 +6,7 @@
 
 #include "common/request_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using namespace std::chrono_literals;
 
@@ -62,4 +62,4 @@ RequestGenerator RemoteRequestSourceImpl::get() {
   return [this]() -> RequestPtr { return grpc_client_->maybeDequeue(); };
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/request_source_impl.h
+++ b/source/common/request_source_impl.h
@@ -9,7 +9,7 @@
 
 #include "common/request_stream_grpc_client_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class BaseRequestSourceImpl : public RequestSource,
                               public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {};
@@ -67,4 +67,4 @@ private:
   const uint32_t header_buffer_length_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/request_stream_grpc_client_impl.cc
+++ b/source/common/request_stream_grpc_client_impl.cc
@@ -10,7 +10,7 @@
 
 #include "common/request_impl.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 const std::string RequestStreamGrpcClientImpl::METHOD_NAME =
     "nighthawk.request_source.NighthawkRequestSourceService.RequestStream";
@@ -128,4 +128,4 @@ void RequestStreamGrpcClientImpl::emplaceMessage(
   messages_.emplace(std::move(message));
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/request_stream_grpc_client_impl.h
+++ b/source/common/request_stream_grpc_client_impl.h
@@ -25,7 +25,7 @@
 #pragma clang diagnostic pop
 #endif
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class ProtoRequestHelper {
 public:
@@ -85,4 +85,4 @@ private:
   const uint32_t header_buffer_length_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/sequencer_impl.cc
+++ b/source/common/sequencer_impl.cc
@@ -7,7 +7,7 @@
 
 using namespace std::chrono_literals;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 SequencerImpl::SequencerImpl(
     const PlatformUtil& platform_util, Envoy::Event::Dispatcher& dispatcher,
@@ -175,4 +175,4 @@ StatisticPtrMap SequencerImpl::statistics() const {
   return statistics;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/sequencer_impl.h
+++ b/source/common/sequencer_impl.h
@@ -12,7 +12,7 @@
 
 #include "external/envoy/source/common/common/logger.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 namespace {
 
@@ -136,4 +136,4 @@ private:
   SequencerStats sequencer_stats_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/signal_handler.cc
+++ b/source/common/signal_handler.cc
@@ -5,7 +5,7 @@
 #include "external/envoy/source/common/common/assert.h"
 #include "external/envoy/source/common/common/macros.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 namespace {
 std::function<void(int)> signal_handler_delegate;
@@ -47,4 +47,4 @@ void SignalHandler::initiateShutdown() {
 
 void SignalHandler::onSignal() { initiateShutdown(); }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/signal_handler.h
+++ b/source/common/signal_handler.h
@@ -7,7 +7,7 @@
 
 #include "external/envoy/source/common/common/logger.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Callback definition for providing a delegate that should be executed after a signal
@@ -73,4 +73,4 @@ private:
 
 using SignalHandlerPtr = std::unique_ptr<SignalHandler>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -7,7 +7,7 @@
 #include "external/envoy/source/common/common/assert.h"
 #include "external/envoy/source/common/protobuf/utility.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 namespace {
 
@@ -334,4 +334,4 @@ void SinkableCircllhistStatistic::recordValue(uint64_t value) {
   scope_.deliverHistogramToSinks(*this, value);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -11,7 +11,7 @@
 
 #include "common/frequency.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Base class for all statistics implementations.
@@ -192,7 +192,7 @@ public:
   ~SinkableStatistic() override;
 
   // Currently Envoy Histogram Unit supports {Unspecified, Bytes, Microseconds, Milliseconds}. By
-  // default, Nighthawk::Statistic uses nanosecond as the unit of latency histograms, so Unspecified
+  // default, nighthawk::Statistic uses nanosecond as the unit of latency histograms, so Unspecified
   // is returned here to isolate Nighthawk Statistic from Envoy Histogram Unit.
   Envoy::Stats::Histogram::Unit unit() const override;
   Envoy::Stats::SymbolTable& symbolTable() override;
@@ -220,11 +220,11 @@ public:
   // Envoy::Stats::Histogram
   void recordValue(uint64_t value) override;
   bool used() const override { return count() > 0; }
-  // Overriding name() to return Nighthawk::Statistic::id().
+  // Overriding name() to return nighthawk::Statistic::id().
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
-  // Nighthawk::Statistic
+  // nighthawk::Statistic
   void addValue(uint64_t value) override { recordValue(value); }
 };
 
@@ -239,12 +239,12 @@ public:
   // Envoy::Stats::Histogram
   void recordValue(uint64_t value) override;
   bool used() const override { return count() > 0; }
-  // Overriding name() to return Nighthawk::Statistic::id().
+  // Overriding name() to return nighthawk::Statistic::id().
   std::string name() const override { return id(); }
   std::string tagExtractedName() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
-  // Nighthawk::Statistic
+  // nighthawk::Statistic
   void addValue(uint64_t value) override { recordValue(value); }
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/termination_predicate_impl.cc
+++ b/source/common/termination_predicate_impl.cc
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-namespace Nighthawk {
+namespace nighthawk {
 
 TerminationPredicate::Status TerminationPredicateBaseImpl::evaluateChain() {
   auto status = TerminationPredicate::Status::PROCEED;
@@ -25,4 +25,4 @@ TerminationPredicate::Status StatsCounterAbsoluteThresholdTerminationPredicateIm
                                            : TerminationPredicate::Status::PROCEED;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/termination_predicate_impl.h
+++ b/source/common/termination_predicate_impl.h
@@ -5,7 +5,7 @@
 
 #include "nighthawk/common/termination_predicate.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class TerminationPredicateBaseImpl : public TerminationPredicate {
 public:
@@ -59,4 +59,4 @@ private:
   const TerminationPredicate::Status termination_status_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/uri_impl.cc
+++ b/source/common/uri_impl.cc
@@ -9,7 +9,7 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 bool UriImpl::isValid() const {
   return (scheme_ == "http" || scheme_ == "https" || scheme_ == "zipkin" || scheme_ == "grpc") &&
@@ -109,4 +109,4 @@ UriImpl::resolve(Envoy::Event::Dispatcher& dispatcher,
   return address_;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/uri_impl.h
+++ b/source/common/uri_impl.h
@@ -13,7 +13,7 @@
 
 #include "absl/strings/string_view.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class UriImpl : public Uri, public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -48,4 +48,4 @@ private:
   bool resolve_attempted_{};
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/utility.cc
+++ b/source/common/utility.cc
@@ -10,7 +10,7 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 std::map<std::string, uint64_t>
 Utility::mapCountersFromStore(const Envoy::Stats::Store& store,
@@ -82,4 +82,4 @@ bool Utility::parseHostPort(const std::string& host_port, std::string* address, 
          RE2::FullMatch(host_port, R"(([-.0-9a-zA-Z]+):(\d+))", address, port);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/utility.cc
+++ b/source/common/utility.cc
@@ -67,12 +67,12 @@ void Utility::parseCommand(TCLAP::CmdLine& cmd, const int argc, const char* cons
     } catch (const TCLAP::ExitException&) {
       // failure() has already written an informative message to stderr, so all that's left to do
       // is throw our own exception with the original message.
-      throw Client::MalformedArgvException(e.what());
+      throw MalformedArgvException(e.what());
     }
   } catch (const TCLAP::ExitException& e) {
     // parse() throws an ExitException with status 0 after printing the output for --help and
     // --version.
-    throw Client::NoServingException();
+    throw NoServingException();
   }
 }
 

--- a/source/common/utility.h
+++ b/source/common/utility.h
@@ -14,7 +14,7 @@
 #include "re2/re2.h"
 #include "tclap/CmdLine.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using StoreCounterFilter = std::function<bool(absl::string_view, const uint64_t)>;
 
@@ -66,4 +66,4 @@ public:
   static bool parseHostPort(const std::string& host_port, std::string* host, int* port);
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/version_info.cc
+++ b/source/common/version_info.cc
@@ -9,7 +9,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 const std::string& VersionInfo::version() {
   CONSTRUCT_ON_FIRST_USE(std::string, NIGHTHAWK_BUILD_VERSION_NUMBER);
@@ -42,4 +42,4 @@ VersionInfo::toVersionString(const envoy::config::core::v3::BuildVersion& build_
   return absl::StrCat(version.major_number(), ".", version.minor_number(), ".", version.patch());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/version_info.h
+++ b/source/common/version_info.h
@@ -4,7 +4,7 @@
 
 #define NIGHTHAWK_BUILD_VERSION_NUMBER "0.3.0"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /*
  * TODO(#267): This class is heavily based on Envoy's source/common/common/version.h
@@ -35,4 +35,4 @@ private:
   static envoy::config::core::v3::BuildVersion makeBuildVersion(const char* version);
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/worker_impl.cc
+++ b/source/common/worker_impl.cc
@@ -3,7 +3,7 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 WorkerImpl::WorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Instance& tls,
                        Envoy::Stats::Store& store)
@@ -38,4 +38,4 @@ void WorkerImpl::start() {
 
 void WorkerImpl::waitForCompletion() { complete_.get_future().wait(); }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/common/worker_impl.h
+++ b/source/common/worker_impl.h
@@ -13,7 +13,7 @@
 #include "external/envoy/source/common/common/logger.h"
 #include "external/envoy/source/common/common/thread.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class WorkerImpl : virtual public Worker, public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
@@ -44,4 +44,4 @@ private:
   bool shutdown_{true};
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/exe/client_main_entry.cc
+++ b/source/exe/client_main_entry.cc
@@ -12,16 +12,16 @@ int main(int argc, char** argv) {
   // handling, such as running in a chroot jail.
   absl::InitializeSymbolizer(argv[0]);
 #endif
-  std::unique_ptr<Nighthawk::Main> client;
+  std::unique_ptr<nighthawk::Main> client;
 
   try {
-    client = std::make_unique<Nighthawk::Main>(argc, argv);
-  } catch (const Nighthawk::NoServingException& e) {
+    client = std::make_unique<nighthawk::Main>(argc, argv);
+  } catch (const nighthawk::NoServingException& e) {
     return EXIT_SUCCESS;
-  } catch (const Nighthawk::MalformedArgvException& e) {
+  } catch (const nighthawk::MalformedArgvException& e) {
     std::cerr << "Bad argument: " << e.what() << std::endl;
     return EXIT_FAILURE;
-  } catch (const Nighthawk::NighthawkException& e) {
+  } catch (const nighthawk::NighthawkException& e) {
     std::cerr << "An unknown error occurred: " << e.what() << std::endl;
     return EXIT_FAILURE;
   }

--- a/source/exe/client_main_entry.cc
+++ b/source/exe/client_main_entry.cc
@@ -12,13 +12,13 @@ int main(int argc, char** argv) {
   // handling, such as running in a chroot jail.
   absl::InitializeSymbolizer(argv[0]);
 #endif
-  std::unique_ptr<Nighthawk::Client::Main> client;
+  std::unique_ptr<Nighthawk::Main> client;
 
   try {
-    client = std::make_unique<Nighthawk::Client::Main>(argc, argv);
-  } catch (const Nighthawk::Client::NoServingException& e) {
+    client = std::make_unique<Nighthawk::Main>(argc, argv);
+  } catch (const Nighthawk::NoServingException& e) {
     return EXIT_SUCCESS;
-  } catch (const Nighthawk::Client::MalformedArgvException& e) {
+  } catch (const Nighthawk::MalformedArgvException& e) {
     std::cerr << "Bad argument: " << e.what() << std::endl;
     return EXIT_FAILURE;
   } catch (const Nighthawk::NighthawkException& e) {

--- a/source/exe/output_transform_main_entry.cc
+++ b/source/exe/output_transform_main_entry.cc
@@ -16,11 +16,11 @@ int main(int argc, char** argv) {
   absl::InitializeSymbolizer(argv[0]);
 #endif
   try {
-    Nighthawk::Client::OutputTransformMain program(argc, argv, std::cin); // NOLINT
+    Nighthawk::OutputTransformMain program(argc, argv, std::cin); // NOLINT
     return program.run();
-  } catch (const Nighthawk::Client::NoServingException& e) {
+  } catch (const Nighthawk::NoServingException& e) {
     return EXIT_SUCCESS;
-  } catch (const Nighthawk::Client::MalformedArgvException& e) {
+  } catch (const Nighthawk::MalformedArgvException& e) {
     std::cerr << "Invalid args: " << e.what() << std::endl;
     return EXIT_FAILURE;
   } catch (const Nighthawk::NighthawkException& e) {

--- a/source/exe/output_transform_main_entry.cc
+++ b/source/exe/output_transform_main_entry.cc
@@ -16,14 +16,14 @@ int main(int argc, char** argv) {
   absl::InitializeSymbolizer(argv[0]);
 #endif
   try {
-    Nighthawk::OutputTransformMain program(argc, argv, std::cin); // NOLINT
+    nighthawk::OutputTransformMain program(argc, argv, std::cin); // NOLINT
     return program.run();
-  } catch (const Nighthawk::NoServingException& e) {
+  } catch (const nighthawk::NoServingException& e) {
     return EXIT_SUCCESS;
-  } catch (const Nighthawk::MalformedArgvException& e) {
+  } catch (const nighthawk::MalformedArgvException& e) {
     std::cerr << "Invalid args: " << e.what() << std::endl;
     return EXIT_FAILURE;
-  } catch (const Nighthawk::NighthawkException& e) {
+  } catch (const nighthawk::NighthawkException& e) {
     std::cerr << "Failure: " << e.what() << std::endl;
     return EXIT_FAILURE;
   }

--- a/source/exe/service_main_entry.cc
+++ b/source/exe/service_main_entry.cc
@@ -6,8 +6,6 @@
 
 // NOLINT(namespace-nighthawk)
 
-using namespace Nighthawk::Client;
-
 int main(int argc, const char** argv) {
 #ifndef __APPLE__
   // absl::Symbolize mostly works without this, but this improves corner case
@@ -15,12 +13,12 @@ int main(int argc, const char** argv) {
   absl::InitializeSymbolizer(argv[0]);
 #endif
   try {
-    ServiceMain service(argc, argv); // NOLINT
+    Nighthawk::ServiceMain service(argc, argv); // NOLINT
     service.start();
     service.wait();
-  } catch (const Nighthawk::Client::NoServingException& e) {
+  } catch (const Nighthawk::NoServingException& e) {
     return EXIT_SUCCESS;
-  } catch (const Nighthawk::Client::MalformedArgvException& e) {
+  } catch (const Nighthawk::MalformedArgvException& e) {
     return EXIT_FAILURE;
   } catch (const Nighthawk::NighthawkException& e) {
     std::cerr << "Failure: " << e.what() << std::endl;

--- a/source/exe/service_main_entry.cc
+++ b/source/exe/service_main_entry.cc
@@ -13,14 +13,14 @@ int main(int argc, const char** argv) {
   absl::InitializeSymbolizer(argv[0]);
 #endif
   try {
-    Nighthawk::ServiceMain service(argc, argv); // NOLINT
+    nighthawk::ServiceMain service(argc, argv); // NOLINT
     service.start();
     service.wait();
-  } catch (const Nighthawk::NoServingException& e) {
+  } catch (const nighthawk::NoServingException& e) {
     return EXIT_SUCCESS;
-  } catch (const Nighthawk::MalformedArgvException& e) {
+  } catch (const nighthawk::MalformedArgvException& e) {
     return EXIT_FAILURE;
-  } catch (const Nighthawk::NighthawkException& e) {
+  } catch (const nighthawk::NighthawkException& e) {
     std::cerr << "Failure: " << e.what() << std::endl;
     return EXIT_FAILURE;
   }

--- a/source/server/configuration.cc
+++ b/source/server/configuration.cc
@@ -9,7 +9,7 @@
 
 #include "absl/strings/numbers.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions& config,
                      std::string& error_message) {
@@ -38,4 +38,4 @@ void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_heade
   }
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/server/configuration.cc
+++ b/source/server/configuration.cc
@@ -10,8 +10,6 @@
 #include "absl/strings/numbers.h"
 
 namespace Nighthawk {
-namespace Server {
-namespace Configuration {
 
 bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions& config,
                      std::string& error_message) {
@@ -40,6 +38,4 @@ void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_heade
   }
 }
 
-} // namespace Configuration
-} // namespace Server
 } // namespace Nighthawk

--- a/source/server/configuration.h
+++ b/source/server/configuration.h
@@ -6,7 +6,7 @@
 
 #include "api/server/response_options.pb.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Merges a json string containing configuration into a ResponseOptions instance.
@@ -29,4 +29,4 @@ bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions&
 void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_headers,
                                   nighthawk::server::ResponseOptions& response_options);
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/server/configuration.h
+++ b/source/server/configuration.h
@@ -7,8 +7,6 @@
 #include "api/server/response_options.pb.h"
 
 namespace Nighthawk {
-namespace Server {
-namespace Configuration {
 
 /**
  * Merges a json string containing configuration into a ResponseOptions instance.
@@ -31,6 +29,4 @@ bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions&
 void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_headers,
                                   nighthawk::server::ResponseOptions& response_options);
 
-} // namespace Configuration
-} // namespace Server
 } // namespace Nighthawk

--- a/source/server/http_dynamic_delay_filter.cc
+++ b/source/server/http_dynamic_delay_filter.cc
@@ -10,7 +10,6 @@
 #include "absl/strings/str_cat.h"
 
 namespace Nighthawk {
-namespace Server {
 
 HttpDynamicDelayDecoderFilterConfig::HttpDynamicDelayDecoderFilterConfig(
     nighthawk::server::ResponseOptions proto_config, Envoy::Runtime::Loader& runtime,
@@ -58,9 +57,9 @@ HttpDynamicDelayDecoderFilter::decodeHeaders(Envoy::Http::RequestHeaderMap& head
 bool HttpDynamicDelayDecoderFilter::computeResponseOptions(
     const Envoy::Http::RequestHeaderMap& headers, std::string& error_message) {
   response_options_ = config_->server_config();
-  const auto* request_config_header = headers.get(TestServer::HeaderNames::get().TestServerConfig);
+  const auto* request_config_header = headers.get(HeaderNames::get().TestServerConfig);
   if (request_config_header) {
-    if (!Configuration::mergeJsonConfig(request_config_header->value().getStringView(),
+    if (!mergeJsonConfig(request_config_header->value().getStringView(),
                                         response_options_, error_message)) {
       return false;
     }
@@ -109,5 +108,4 @@ void HttpDynamicDelayDecoderFilter::setDecoderFilterCallbacks(
   Envoy::Extensions::HttpFilters::Fault::FaultFilter::setDecoderFilterCallbacks(callbacks);
 }
 
-} // namespace Server
 } // namespace Nighthawk

--- a/source/server/http_dynamic_delay_filter.cc
+++ b/source/server/http_dynamic_delay_filter.cc
@@ -9,7 +9,7 @@
 
 #include "absl/strings/str_cat.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 HttpDynamicDelayDecoderFilterConfig::HttpDynamicDelayDecoderFilterConfig(
     nighthawk::server::ResponseOptions proto_config, Envoy::Runtime::Loader& runtime,
@@ -108,4 +108,4 @@ void HttpDynamicDelayDecoderFilter::setDecoderFilterCallbacks(
   Envoy::Extensions::HttpFilters::Fault::FaultFilter::setDecoderFilterCallbacks(callbacks);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -9,7 +9,7 @@
 
 #include "api/server/response_options.pb.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Filter configuration container class for the dynamic delay extension.
@@ -182,4 +182,4 @@ private:
   bool destroyed_{false};
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -10,7 +10,6 @@
 #include "api/server/response_options.pb.h"
 
 namespace Nighthawk {
-namespace Server {
 
 /**
  * Filter configuration container class for the dynamic delay extension.
@@ -183,5 +182,4 @@ private:
   bool destroyed_{false};
 };
 
-} // namespace Server
 } // namespace Nighthawk

--- a/source/server/http_dynamic_delay_filter_config.cc
+++ b/source/server/http_dynamic_delay_filter_config.cc
@@ -10,8 +10,6 @@
 #include "server/http_dynamic_delay_filter.h"
 
 namespace Nighthawk {
-namespace Server {
-namespace Configuration {
 namespace {
 
 class HttpDynamicDelayDecoderFilterConfigFactory
@@ -37,14 +35,14 @@ public:
 private:
   Envoy::Http::FilterFactoryCb createFilter(const nighthawk::server::ResponseOptions& proto_config,
                                             Envoy::Server::Configuration::FactoryContext& context) {
-    Nighthawk::Server::HttpDynamicDelayDecoderFilterConfigSharedPtr config =
-        std::make_shared<Nighthawk::Server::HttpDynamicDelayDecoderFilterConfig>(
-            Nighthawk::Server::HttpDynamicDelayDecoderFilterConfig(
+    HttpDynamicDelayDecoderFilterConfigSharedPtr config =
+        std::make_shared<HttpDynamicDelayDecoderFilterConfig>(
+            HttpDynamicDelayDecoderFilterConfig(
                 proto_config, context.runtime(), "" /*stats_prefix*/, context.scope(),
                 context.timeSource()));
 
     return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      auto* filter = new Nighthawk::Server::HttpDynamicDelayDecoderFilter(config);
+      auto* filter = new HttpDynamicDelayDecoderFilter(config);
       callbacks.addStreamDecoderFilter(Envoy::Http::StreamDecoderFilterSharedPtr{filter});
     };
   }
@@ -55,6 +53,4 @@ private:
 static Envoy::Registry::RegisterFactory<HttpDynamicDelayDecoderFilterConfigFactory,
                                         Envoy::Server::Configuration::NamedHttpFilterConfigFactory>
     register_;
-} // namespace Configuration
-} // namespace Server
 } // namespace Nighthawk

--- a/source/server/http_dynamic_delay_filter_config.cc
+++ b/source/server/http_dynamic_delay_filter_config.cc
@@ -9,7 +9,7 @@
 
 #include "server/http_dynamic_delay_filter.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 namespace {
 
 class HttpDynamicDelayDecoderFilterConfigFactory
@@ -53,4 +53,4 @@ private:
 static Envoy::Registry::RegisterFactory<HttpDynamicDelayDecoderFilterConfigFactory,
                                         Envoy::Server::Configuration::NamedHttpFilterConfigFactory>
     register_;
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/server/http_test_server_filter.cc
+++ b/source/server/http_test_server_filter.cc
@@ -9,7 +9,7 @@
 
 #include "absl/strings/numbers.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 HttpTestServerDecoderFilterConfig::HttpTestServerDecoderFilterConfig(
     nighthawk::server::ResponseOptions proto_config)
@@ -80,4 +80,4 @@ void HttpTestServerDecoderFilter::setDecoderFilterCallbacks(
   decoder_callbacks_ = &callbacks;
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/server/http_test_server_filter.cc
+++ b/source/server/http_test_server_filter.cc
@@ -10,7 +10,6 @@
 #include "absl/strings/numbers.h"
 
 namespace Nighthawk {
-namespace Server {
 
 HttpTestServerDecoderFilterConfig::HttpTestServerDecoderFilterConfig(
     nighthawk::server::ResponseOptions proto_config)
@@ -31,7 +30,7 @@ void HttpTestServerDecoderFilter::sendReply() {
     decoder_callbacks_->sendLocalReply(
         static_cast<Envoy::Http::Code>(200), response_body,
         [this](Envoy::Http::ResponseHeaderMap& direct_response_headers) {
-          Configuration::applyConfigToResponseHeaders(direct_response_headers, base_config_);
+          applyConfigToResponseHeaders(direct_response_headers, base_config_);
         },
         absl::nullopt, "");
   } else {
@@ -47,9 +46,9 @@ HttpTestServerDecoderFilter::decodeHeaders(Envoy::Http::RequestHeaderMap& header
                                            bool end_stream) {
   // TODO(oschaaf): Add functionality to clear fields
   base_config_ = config_->server_config();
-  const auto* request_config_header = headers.get(TestServer::HeaderNames::get().TestServerConfig);
+  const auto* request_config_header = headers.get(HeaderNames::get().TestServerConfig);
   if (request_config_header) {
-    json_merge_error_ = !Configuration::mergeJsonConfig(
+    json_merge_error_ = !mergeJsonConfig(
         request_config_header->value().getStringView(), base_config_, error_message_);
   }
   if (base_config_.echo_request_headers()) {
@@ -81,5 +80,4 @@ void HttpTestServerDecoderFilter::setDecoderFilterCallbacks(
   decoder_callbacks_ = &callbacks;
 }
 
-} // namespace Server
 } // namespace Nighthawk

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -7,7 +7,6 @@
 #include "api/server/response_options.pb.h"
 
 namespace Nighthawk {
-namespace Server {
 
 // Basically this is left in as a placeholder for further configuration.
 class HttpTestServerDecoderFilterConfig {
@@ -45,5 +44,4 @@ private:
   absl::optional<std::string> request_headers_dump_;
 };
 
-} // namespace Server
 } // namespace Nighthawk

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -6,7 +6,7 @@
 
 #include "api/server/response_options.pb.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 // Basically this is left in as a placeholder for further configuration.
 class HttpTestServerDecoderFilterConfig {
@@ -44,4 +44,4 @@ private:
   absl::optional<std::string> request_headers_dump_;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/server/http_test_server_filter_config.cc
+++ b/source/server/http_test_server_filter_config.cc
@@ -9,7 +9,7 @@
 
 #include "server/http_test_server_filter.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class HttpTestServerDecoderFilterConfigFactory
     : public Envoy::Server::Configuration::NamedHttpFilterConfigFactory {
@@ -49,4 +49,4 @@ static Envoy::Registry::RegisterFactory<HttpTestServerDecoderFilterConfigFactory
                                         Envoy::Server::Configuration::NamedHttpFilterConfigFactory>
     register_;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/source/server/http_test_server_filter_config.cc
+++ b/source/server/http_test_server_filter_config.cc
@@ -10,10 +10,8 @@
 #include "server/http_test_server_filter.h"
 
 namespace Nighthawk {
-namespace Server {
-namespace Configuration {
 
-class HttpTestServerDecoderFilterConfig
+class HttpTestServerDecoderFilterConfigFactory
     : public Envoy::Server::Configuration::NamedHttpFilterConfigFactory {
 public:
   Envoy::Http::FilterFactoryCb
@@ -36,20 +34,19 @@ public:
 private:
   Envoy::Http::FilterFactoryCb createFilter(const nighthawk::server::ResponseOptions& proto_config,
                                             Envoy::Server::Configuration::FactoryContext&) {
-    Nighthawk::Server::HttpTestServerDecoderFilterConfigSharedPtr config =
-        std::make_shared<Nighthawk::Server::HttpTestServerDecoderFilterConfig>(
-            Nighthawk::Server::HttpTestServerDecoderFilterConfig(proto_config));
+    HttpTestServerDecoderFilterConfigSharedPtr config =
+        std::make_shared<HttpTestServerDecoderFilterConfig>(
+            HttpTestServerDecoderFilterConfig(proto_config));
 
     return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      auto* filter = new Nighthawk::Server::HttpTestServerDecoderFilter(config);
+      auto* filter = new HttpTestServerDecoderFilter(config);
       callbacks.addStreamDecoderFilter(Envoy::Http::StreamDecoderFilterSharedPtr{filter});
     };
   }
 };
 
-static Envoy::Registry::RegisterFactory<HttpTestServerDecoderFilterConfig,
+static Envoy::Registry::RegisterFactory<HttpTestServerDecoderFilterConfigFactory,
                                         Envoy::Server::Configuration::NamedHttpFilterConfigFactory>
     register_;
-} // namespace Configuration
-} // namespace Server
+
 } // namespace Nighthawk

--- a/source/server/well_known_headers.h
+++ b/source/server/well_known_headers.h
@@ -7,8 +7,6 @@
 #include "external/envoy/source/common/singleton/const_singleton.h"
 
 namespace Nighthawk {
-namespace Server {
-namespace TestServer {
 
 class HeaderNameValues {
 public:
@@ -17,6 +15,4 @@ public:
 
 using HeaderNames = Envoy::ConstSingleton<HeaderNameValues>;
 
-} // namespace TestServer
-} // namespace Server
 } // namespace Nighthawk

--- a/source/server/well_known_headers.h
+++ b/source/server/well_known_headers.h
@@ -6,7 +6,7 @@
 
 #include "external/envoy/source/common/singleton/const_singleton.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class HeaderNameValues {
 public:
@@ -15,4 +15,4 @@ public:
 
 using HeaderNames = Envoy::ConstSingleton<HeaderNameValues>;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/adaptive_load/input_variable_setter_test.cc
+++ b/test/adaptive_load/input_variable_setter_test.cc
@@ -4,7 +4,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 namespace {
 
@@ -74,4 +74,4 @@ TEST(RequestsPerSecondInputVariableSetter, SetInputVariableReturnsErrorWithOvers
 
 } // namespace
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -26,7 +26,7 @@ using namespace testing;
 
 namespace Nighthawk {
 
-class BenchmarkClientHttpTest : public Test {
+class BenchmarkClientHttpTest : public testing::Test {
 public:
   BenchmarkClientHttpTest()
       : api_(Envoy::Api::createApiForTest(time_system_)),
@@ -92,7 +92,7 @@ public:
     const uint64_t amount = amount_of_request;
     uint64_t inflight_response_count = 0;
 
-    Client::CompletionCallback f = [this, &inflight_response_count](bool, bool) {
+    CompletionCallback f = [this, &inflight_response_count](bool, bool) {
       --inflight_response_count;
       if (inflight_response_count == 0) {
         dispatcher_->exit();
@@ -129,7 +129,7 @@ public:
   }
 
   void setupBenchmarkClient() {
-    client_ = std::make_unique<Client::BenchmarkClientHttpImpl>(
+    client_ = std::make_unique<BenchmarkClientHttpImpl>(
         *api_, *dispatcher_, store_, statistic_, false, cluster_manager_, http_tracer_, "benchmark",
         request_generator_, true);
   }
@@ -153,7 +153,7 @@ public:
   Envoy::Random::RandomGeneratorImpl generator_;
   NiceMock<Envoy::ThreadLocal::MockInstance> tls_;
   NiceMock<Envoy::Runtime::MockLoader> runtime_;
-  std::unique_ptr<Client::BenchmarkClientHttpImpl> client_;
+  std::unique_ptr<BenchmarkClientHttpImpl> client_;
   Envoy::Upstream::ClusterManagerPtr cluster_manager_;
   Envoy::Http::ConnectionPool::MockInstance pool_;
   Envoy::ProcessWide process_wide;
@@ -165,7 +165,7 @@ public:
   std::string response_code_;
   RequestGenerator request_generator_;
   int worker_number_{0};
-  Client::BenchmarkClientStatistic statistic_;
+  BenchmarkClientStatistic statistic_;
 };
 
 TEST_F(BenchmarkClientHttpTest, BasicTestH1200) {

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -24,7 +24,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class BenchmarkClientHttpTest : public testing::Test {
 public:
@@ -314,4 +314,4 @@ TEST_F(BenchmarkClientHttpTest, BadContentLength) {
   EXPECT_EQ(1, getCounter("http_2xx"));
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/client/utility.cc
+++ b/test/client/utility.cc
@@ -24,4 +24,4 @@ std::unique_ptr<OptionsImpl> TestUtility::createOptionsImpl(const std::vector<co
   return std::make_unique<OptionsImpl>(argv.size(), argv.data());
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/client/utility.cc
+++ b/test/client/utility.cc
@@ -3,7 +3,6 @@
 #include "external/envoy/test/test_common/utility.h"
 
 namespace Nighthawk {
-namespace Client {
 
 std::unique_ptr<OptionsImpl> TestUtility::createOptionsImpl(absl::string_view args) {
   std::vector<std::string> words = Envoy::TestUtility::split(std::string(args), ' ');
@@ -25,5 +24,4 @@ std::unique_ptr<OptionsImpl> TestUtility::createOptionsImpl(const std::vector<co
   return std::make_unique<OptionsImpl>(argv.size(), argv.data());
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/client/utility.cc
+++ b/test/client/utility.cc
@@ -2,7 +2,7 @@
 
 #include "external/envoy/test/test_common/utility.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 std::unique_ptr<OptionsImpl> TestUtility::createOptionsImpl(absl::string_view args) {
   std::vector<std::string> words = Envoy::TestUtility::split(std::string(args), ' ');
@@ -24,4 +24,4 @@ std::unique_ptr<OptionsImpl> TestUtility::createOptionsImpl(const std::vector<co
   return std::make_unique<OptionsImpl>(argv.size(), argv.data());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/client/utility.h
+++ b/test/client/utility.h
@@ -8,7 +8,6 @@
 #include "absl/strings/string_view.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class TestUtility {
 public:
@@ -23,5 +22,4 @@ private:
   TestUtility() = default;
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/client/utility.h
+++ b/test/client/utility.h
@@ -7,7 +7,7 @@
 
 #include "absl/strings/string_view.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class TestUtility {
 public:
@@ -22,4 +22,4 @@ private:
   TestUtility() = default;
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/client/utility.h
+++ b/test/client/utility.h
@@ -22,4 +22,4 @@ private:
   TestUtility() = default;
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -12,7 +12,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class ClientTest : public testing::Test {};
 
@@ -23,7 +23,7 @@ class ClientTest : public testing::Test {};
 // Note: these tests do not have a backend set up to talk to.
 // That's why we expect exit codes indicating failure.
 TEST_F(ClientTest, NormalRun) {
-  Main program(Nighthawk::TestUtility::createOptionsImpl(
+  Main program(nighthawk::TestUtility::createOptionsImpl(
       "foo --duration 1 --rps 10 http://localhost:63657/"));
 
   EXPECT_FALSE(program.run());
@@ -74,9 +74,9 @@ TEST_F(ClientTest, TracingRun) {
 }
 
 TEST_F(ClientTest, BadRun) {
-  Main program(Nighthawk::TestUtility::createOptionsImpl(
+  Main program(nighthawk::TestUtility::createOptionsImpl(
       "foo --duration 1 --rps 1 https://unresolveable.host/"));
   EXPECT_FALSE(program.run());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -79,4 +79,4 @@ TEST_F(ClientTest, BadRun) {
   EXPECT_FALSE(program.run());
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -13,7 +13,6 @@ using namespace std::chrono_literals;
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 class ClientTest : public testing::Test {};
 
@@ -24,7 +23,7 @@ class ClientTest : public testing::Test {};
 // Note: these tests do not have a backend set up to talk to.
 // That's why we expect exit codes indicating failure.
 TEST_F(ClientTest, NormalRun) {
-  Main program(Nighthawk::Client::TestUtility::createOptionsImpl(
+  Main program(Nighthawk::TestUtility::createOptionsImpl(
       "foo --duration 1 --rps 10 http://localhost:63657/"));
 
   EXPECT_FALSE(program.run());
@@ -75,10 +74,9 @@ TEST_F(ClientTest, TracingRun) {
 }
 
 TEST_F(ClientTest, BadRun) {
-  Main program(Nighthawk::Client::TestUtility::createOptionsImpl(
+  Main program(Nighthawk::TestUtility::createOptionsImpl(
       "foo --duration 1 --rps 1 https://unresolveable.host/"));
   EXPECT_FALSE(program.run());
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -130,4 +130,4 @@ TEST_F(ClientWorkerTest, BasicTest) {
   worker->shutdown();
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -30,7 +30,6 @@ using namespace testing;
 using namespace std::chrono_literals;
 
 namespace Nighthawk {
-namespace Client {
 
 class ClientWorkerTest : public Test {
 public:
@@ -131,5 +130,4 @@ TEST_F(ClientWorkerTest, BasicTest) {
   worker->shutdown();
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -29,7 +29,7 @@
 using namespace testing;
 using namespace std::chrono_literals;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class ClientWorkerTest : public Test {
 public:
@@ -130,4 +130,4 @@ TEST_F(ClientWorkerTest, BasicTest) {
   worker->shutdown();
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -16,7 +16,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class FactoriesTest : public Test {
 public:
@@ -127,4 +127,4 @@ INSTANTIATE_TEST_SUITE_P(
               nighthawk::client::OutputFormat::YAML, nighthawk::client::OutputFormat::DOTTED,
               nighthawk::client::OutputFormat::FORTIO}));
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -17,7 +17,6 @@
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 class FactoriesTest : public Test {
 public:
@@ -128,5 +127,4 @@ INSTANTIATE_TEST_SUITE_P(
               nighthawk::client::OutputFormat::YAML, nighthawk::client::OutputFormat::DOTTED,
               nighthawk::client::OutputFormat::FORTIO}));
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -127,4 +127,4 @@ INSTANTIATE_TEST_SUITE_P(
               nighthawk::client::OutputFormat::YAML, nighthawk::client::OutputFormat::DOTTED,
               nighthawk::client::OutputFormat::FORTIO}));
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/frequency_test.cc
+++ b/test/frequency_test.cc
@@ -4,7 +4,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class FrequencyTest : public Test {};
 
@@ -18,4 +18,4 @@ TEST_F(FrequencyTest, BasicTest) {
   EXPECT_EQ(std::chrono::duration<double>(1.0 / (1000 * 1000)), f2.interval());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/client/mock_benchmark_client.cc
+++ b/test/mocks/client/mock_benchmark_client.cc
@@ -1,9 +1,7 @@
 #include "test/mocks/client/mock_benchmark_client.h"
 
 namespace Nighthawk {
-namespace Client {
 
 MockBenchmarkClient::MockBenchmarkClient() = default;
 
-}
 } // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client.cc
+++ b/test/mocks/client/mock_benchmark_client.cc
@@ -1,7 +1,7 @@
 #include "test/mocks/client/mock_benchmark_client.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockBenchmarkClient::MockBenchmarkClient() = default;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/client/mock_benchmark_client.h
+++ b/test/mocks/client/mock_benchmark_client.h
@@ -5,7 +5,6 @@
 #include "gmock/gmock.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class MockBenchmarkClient : public BenchmarkClient {
 public:
@@ -14,11 +13,10 @@ public:
   MOCK_METHOD0(terminate, void());
   MOCK_METHOD1(setShouldMeasureLatencies, void(bool));
   MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
-  MOCK_METHOD1(tryStartRequest, bool(Client::CompletionCallback));
+  MOCK_METHOD1(tryStartRequest, bool(CompletionCallback));
   MOCK_CONST_METHOD0(scope, Envoy::Stats::Scope&());
   MOCK_CONST_METHOD0(shouldMeasureLatencies, bool());
   MOCK_CONST_METHOD0(requestHeaders, const Envoy::Http::RequestHeaderMap&());
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client.h
+++ b/test/mocks/client/mock_benchmark_client.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockBenchmarkClient : public BenchmarkClient {
 public:
@@ -19,4 +19,4 @@ public:
   MOCK_CONST_METHOD0(requestHeaders, const Envoy::Http::RequestHeaderMap&());
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/client/mock_benchmark_client.h
+++ b/test/mocks/client/mock_benchmark_client.h
@@ -19,4 +19,4 @@ public:
   MOCK_CONST_METHOD0(requestHeaders, const Envoy::Http::RequestHeaderMap&());
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client_factory.cc
+++ b/test/mocks/client/mock_benchmark_client_factory.cc
@@ -1,7 +1,7 @@
 #include "test/mocks/client/mock_benchmark_client_factory.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockBenchmarkClientFactory::MockBenchmarkClientFactory() = default;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/client/mock_benchmark_client_factory.cc
+++ b/test/mocks/client/mock_benchmark_client_factory.cc
@@ -1,9 +1,7 @@
 #include "test/mocks/client/mock_benchmark_client_factory.h"
 
 namespace Nighthawk {
-namespace Client {
 
 MockBenchmarkClientFactory::MockBenchmarkClientFactory() = default;
 
-}
 } // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client_factory.h
+++ b/test/mocks/client/mock_benchmark_client_factory.h
@@ -9,7 +9,6 @@
 #include "gmock/gmock.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class MockBenchmarkClientFactory : public BenchmarkClientFactory {
 public:
@@ -21,5 +20,4 @@ public:
                                         int, RequestSource& request_generator));
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client_factory.h
+++ b/test/mocks/client/mock_benchmark_client_factory.h
@@ -20,4 +20,4 @@ public:
                                         int, RequestSource& request_generator));
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client_factory.h
+++ b/test/mocks/client/mock_benchmark_client_factory.h
@@ -8,7 +8,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockBenchmarkClientFactory : public BenchmarkClientFactory {
 public:
@@ -20,4 +20,4 @@ public:
                                         int, RequestSource& request_generator));
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/client/mock_options.cc
+++ b/test/mocks/client/mock_options.cc
@@ -1,7 +1,7 @@
 #include "test/mocks/client/mock_options.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockOptions::MockOptions() = default;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/client/mock_options.cc
+++ b/test/mocks/client/mock_options.cc
@@ -1,9 +1,7 @@
 #include "test/mocks/client/mock_options.h"
 
 namespace Nighthawk {
-namespace Client {
 
 MockOptions::MockOptions() = default;
 
-}
 } // namespace Nighthawk

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -5,7 +5,7 @@
 #include "absl/types/optional.h"
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockOptions : public Options {
 public:
@@ -55,4 +55,4 @@ public:
   MOCK_CONST_METHOD0(statsFlushInterval, uint32_t());
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -6,7 +6,6 @@
 #include "gmock/gmock.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class MockOptions : public Options {
 public:
@@ -56,5 +55,4 @@ public:
   MOCK_CONST_METHOD0(statsFlushInterval, uint32_t());
 };
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -55,4 +55,4 @@ public:
   MOCK_CONST_METHOD0(statsFlushInterval, uint32_t());
 };
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/mocks/common/mock_platform_util.cc
+++ b/test/mocks/common/mock_platform_util.cc
@@ -1,6 +1,6 @@
 #include "test/mocks/common/mock_platform_util.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockPlatformUtil::MockPlatformUtil() = default;
 

--- a/test/mocks/common/mock_platform_util.h
+++ b/test/mocks/common/mock_platform_util.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockPlatformUtil : public PlatformUtil {
 public:
@@ -14,4 +14,4 @@ public:
   MOCK_CONST_METHOD1(sleep, void(std::chrono::microseconds));
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_rate_limiter.cc
+++ b/test/mocks/common/mock_rate_limiter.cc
@@ -1,9 +1,9 @@
 #include "test/mocks/common/mock_rate_limiter.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockRateLimiter::MockRateLimiter() = default;
 
 MockDiscreteNumericDistributionSampler::MockDiscreteNumericDistributionSampler() = default;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_rate_limiter.h
+++ b/test/mocks/common/mock_rate_limiter.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockRateLimiter : public RateLimiter {
 public:
@@ -24,4 +24,4 @@ public:
   MOCK_CONST_METHOD0(max, uint64_t());
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_request_source.cc
+++ b/test/mocks/common/mock_request_source.cc
@@ -1,7 +1,7 @@
 #include "test/mocks/common/mock_request_source.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockRequestSource::MockRequestSource() = default;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_request_source.h
+++ b/test/mocks/common/mock_request_source.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockRequestSource : public RequestSource {
 public:
@@ -13,4 +13,4 @@ public:
   MOCK_METHOD0(initOnThread, void());
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_request_source_factory.cc
+++ b/test/mocks/common/mock_request_source_factory.cc
@@ -1,7 +1,7 @@
 #include "test/mocks/common/mock_request_source_factory.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockRequestSourceFactory::MockRequestSourceFactory() = default;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_request_source_factory.h
+++ b/test/mocks/common/mock_request_source_factory.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockRequestSourceFactory : public RequestSourceFactory {
 public:
@@ -16,4 +16,4 @@ public:
                                       absl::string_view service_cluster_name));
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_sequencer.cc
+++ b/test/mocks/common/mock_sequencer.cc
@@ -1,6 +1,6 @@
 #include "test/mocks/common/mock_sequencer.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockSequencer::MockSequencer() = default;
 

--- a/test/mocks/common/mock_sequencer.h
+++ b/test/mocks/common/mock_sequencer.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockSequencer : public Sequencer {
 public:
@@ -18,4 +18,4 @@ public:
   MOCK_METHOD0(cancel, void());
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_sequencer_factory.cc
+++ b/test/mocks/common/mock_sequencer_factory.cc
@@ -1,7 +1,7 @@
 #include "test/mocks/common/mock_sequencer_factory.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockSequencerFactory::MockSequencerFactory() = default;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_sequencer_factory.h
+++ b/test/mocks/common/mock_sequencer_factory.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockSequencerFactory : public SequencerFactory {
 public:
@@ -17,4 +17,4 @@ public:
                                           const Envoy::MonotonicTime scheduled_starting_time));
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_termination_predicate.cc
+++ b/test/mocks/common/mock_termination_predicate.cc
@@ -1,6 +1,6 @@
 #include "test/mocks/common/mock_termination_predicate.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockTerminationPredicate::MockTerminationPredicate() = default;
 

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockTerminationPredicate : public TerminationPredicate {
 public:
@@ -15,4 +15,4 @@ public:
   MOCK_METHOD0(evaluate, TerminationPredicate::Status());
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_termination_predicate_factory.cc
+++ b/test/mocks/common/mock_termination_predicate_factory.cc
@@ -1,7 +1,7 @@
 #include "test/mocks/common/mock_termination_predicate_factory.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 MockTerminationPredicateFactory::MockTerminationPredicateFactory() = default;
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/mocks/common/mock_termination_predicate_factory.h
+++ b/test/mocks/common/mock_termination_predicate_factory.h
@@ -4,7 +4,7 @@
 
 #include "gmock/gmock.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class MockTerminationPredicateFactory : public TerminationPredicateFactory {
 public:
@@ -15,4 +15,4 @@ public:
                                              const Envoy::MonotonicTime scheduled_starting_time));
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -804,4 +804,4 @@ TEST_F(OptionsImplTest, H1ConnectionReuseStrategyValuesAreConstrained) {
       MalformedArgvException, "experimental-h1-connection-reuse-strategy");
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -9,7 +9,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class OptionsImplTest : public Test {
 public:
@@ -804,4 +804,4 @@ TEST_F(OptionsImplTest, H1ConnectionReuseStrategyValuesAreConstrained) {
       MalformedArgvException, "experimental-h1-connection-reuse-strategy");
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -10,7 +10,6 @@ using namespace std::chrono_literals;
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 class OptionsImplTest : public Test {
 public:
@@ -805,5 +804,4 @@ TEST_F(OptionsImplTest, H1ConnectionReuseStrategyValuesAreConstrained) {
       MalformedArgvException, "experimental-h1-connection-reuse-strategy");
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -27,7 +27,6 @@ using namespace std::chrono_literals;
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 class OutputCollectorTest : public Test {
 public:
@@ -215,5 +214,4 @@ TEST_F(StatidToNameTest, TestTranslations) {
   }
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -26,7 +26,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class OutputCollectorTest : public Test {
 public:
@@ -214,4 +214,4 @@ TEST_F(StatidToNameTest, TestTranslations) {
   }
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -214,4 +214,4 @@ TEST_F(StatidToNameTest, TestTranslations) {
   }
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/output_transform_main_test.cc
+++ b/test/output_transform_main_test.cc
@@ -62,4 +62,4 @@ TEST_F(OutputTransformMainTest, HappyFlow) {
   EXPECT_EQ(main.run(), 0);
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/output_transform_main_test.cc
+++ b/test/output_transform_main_test.cc
@@ -13,7 +13,6 @@
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 class OutputTransformMainTest : public Test {
 public:
@@ -63,5 +62,4 @@ TEST_F(OutputTransformMainTest, HappyFlow) {
   EXPECT_EQ(main.run(), 0);
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/output_transform_main_test.cc
+++ b/test/output_transform_main_test.cc
@@ -12,7 +12,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class OutputTransformMainTest : public Test {
 public:
@@ -62,4 +62,4 @@ TEST_F(OutputTransformMainTest, HappyFlow) {
   EXPECT_EQ(main.run(), 0);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/platform_util_test.cc
+++ b/test/platform_util_test.cc
@@ -7,7 +7,7 @@
 using namespace testing;
 using namespace std::chrono_literals;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class PlatformUtilTest : public Test {
 public:
@@ -22,4 +22,4 @@ TEST_F(PlatformUtilTest, NoFatalFailureForSleep) {
   EXPECT_NO_FATAL_FAILURE(platform_util_.sleep(1us));
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -20,7 +20,6 @@
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 // TODO(https://github.com/envoyproxy/nighthawk/issues/179): Mock Process in client_test, and move
 // it's tests in here. Note: these tests do not have a backend set up to talk to. That's why we
@@ -118,5 +117,4 @@ TEST_P(ProcessTest, CancelExecutionBeforeBeginLoadTest) {
   runProcess(RunExpectation::EXPECT_SUCCESS, true, true);
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -19,7 +19,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 // TODO(https://github.com/envoyproxy/nighthawk/issues/179): Mock Process in client_test, and move
 // it's tests in here. Note: these tests do not have a backend set up to talk to. That's why we
@@ -117,4 +117,4 @@ TEST_P(ProcessTest, CancelExecutionBeforeBeginLoadTest) {
   runProcess(RunExpectation::EXPECT_SUCCESS, true, true);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -117,4 +117,4 @@ TEST_P(ProcessTest, CancelExecutionBeforeBeginLoadTest) {
   runProcess(RunExpectation::EXPECT_SUCCESS, true, true);
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/python_test.cc
+++ b/test/python_test.cc
@@ -5,7 +5,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class PythonTest : public Test {};
 
@@ -20,4 +20,4 @@ TEST_F(PythonTest, IntegrationTests) {
   ASSERT_EQ(0, system(path.c_str()));
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/rate_limiter_test.cc
+++ b/test/rate_limiter_test.cc
@@ -14,7 +14,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class RateLimiterTest : public Test {};
 
@@ -445,4 +445,4 @@ TEST_F(ZipfRateLimiterImplTest, BadArgumentsTest) {
   }
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/request_generator_test.cc
+++ b/test/request_generator_test.cc
@@ -6,7 +6,7 @@
 
 #include "gtest/gtest.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class RequestSourceTest : public testing::Test {};
 
@@ -22,4 +22,4 @@ TEST_F(RequestSourceTest, StaticRequestSourceImpl) {
   ASSERT_EQ(generator(), nullptr);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/request_generator_test.cc
+++ b/test/request_generator_test.cc
@@ -7,7 +7,6 @@
 #include "gtest/gtest.h"
 
 namespace Nighthawk {
-namespace Client {
 
 class RequestSourceTest : public testing::Test {};
 
@@ -23,5 +22,4 @@ TEST_F(RequestSourceTest, StaticRequestSourceImpl) {
   ASSERT_EQ(generator(), nullptr);
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/request_generator_test.cc
+++ b/test/request_generator_test.cc
@@ -22,4 +22,4 @@ TEST_F(RequestSourceTest, StaticRequestSourceImpl) {
   ASSERT_EQ(generator(), nullptr);
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/request_stream_grpc_client_test.cc
+++ b/test/request_stream_grpc_client_test.cc
@@ -7,7 +7,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 // The grpc client itself is tested via the python based integration tests.
 // It is convenient to test message translation here.
@@ -74,4 +74,4 @@ TEST_F(ProtoRequestHelperTest, AmbiguousHost) {
   translateExpectingEqual();
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -23,7 +23,7 @@ using namespace std::chrono_literals;
 using namespace nighthawk::client;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class FakeSequencerTarget {
 public:
@@ -301,4 +301,4 @@ TEST_F(SequencerIntegrationTest, CallbacksDoNotInfluenceTestDuration) {
   EXPECT_EQ(0, sequencer.blockedStatistic().count());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/server/http_dynamic_delay_filter_integration_test.cc
+++ b/test/server/http_dynamic_delay_filter_integration_test.cc
@@ -9,7 +9,7 @@
 
 #include "gtest/gtest.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 /**
  * Support class for testing the dynamic delay filter. We rely on the fault filter for
@@ -181,4 +181,4 @@ TEST_F(ComputeTest, ComputeConcurrencyBasedLinearDelayMs) {
   EXPECT_EQ(compute(4, 1, 500000, 1, 500000), 5003);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/server/http_dynamic_delay_filter_integration_test.cc
+++ b/test/server/http_dynamic_delay_filter_integration_test.cc
@@ -163,7 +163,7 @@ public:
     minimal_delay.set_nanos(minimal_delay_nanos);
     delay_factor.set_seconds(delay_factor_seconds);
     delay_factor.set_nanos(delay_factor_nanos);
-    return Server::HttpDynamicDelayDecoderFilter::computeConcurrencyBasedLinearDelayMs(
+    return HttpDynamicDelayDecoderFilter::computeConcurrencyBasedLinearDelayMs(
         concurrency, minimal_delay, delay_factor);
   }
 };

--- a/test/server/http_test_server_filter_integration_test.cc
+++ b/test/server/http_test_server_filter_integration_test.cc
@@ -13,7 +13,7 @@
 
 #include "gtest/gtest.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using namespace testing;
 constexpr absl::string_view kBadJson = "bad_json";
@@ -87,7 +87,7 @@ public:
           const std::string header_config =
               fmt::format("{{response_body_size:{}}}", response_body_size);
           request_headers.addCopy(
-              Nighthawk::HeaderNames::get().TestServerConfig, header_config);
+              nighthawk::HeaderNames::get().TestServerConfig, header_config);
         });
     ASSERT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().Status()->value().getStringView());
@@ -111,7 +111,7 @@ public:
           const std::string header_config =
               fmt::format("{{response_body_size:{}}}", response_body_size);
           request_headers.addCopy(
-              Nighthawk::HeaderNames::get().TestServerConfig, header_config);
+              nighthawk::HeaderNames::get().TestServerConfig, header_config);
         });
     ASSERT_TRUE(response->complete());
     EXPECT_EQ("500", response->headers().Status()->value().getStringView());
@@ -362,4 +362,4 @@ TEST_F(HttpTestServerDecoderFilterTest, HeaderMerge) {
   EXPECT_EQ(3, options.response_headers_size());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/service_main_test.cc
+++ b/test/service_main_test.cc
@@ -16,7 +16,6 @@ using namespace testing;
 // See if we can add some python integration tests.
 
 namespace Nighthawk {
-namespace Client {
 
 class ServiceMainTest : public Test {};
 
@@ -80,5 +79,4 @@ TEST_P(ServiceMainTestP, PortZero) {
   service_main.shutdown();
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/service_main_test.cc
+++ b/test/service_main_test.cc
@@ -15,7 +15,7 @@ using namespace testing;
 // TODO(oschaaf): this gets us some coverage, but we need more functional testing.
 // See if we can add some python integration tests.
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class ServiceMainTest : public Test {};
 
@@ -79,4 +79,4 @@ TEST_P(ServiceMainTestP, PortZero) {
   service_main.shutdown();
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/service_main_test.cc
+++ b/test/service_main_test.cc
@@ -79,4 +79,4 @@ TEST_P(ServiceMainTestP, PortZero) {
   service_main.shutdown();
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/service_test.cc
+++ b/test/service_test.cc
@@ -17,7 +17,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class ServiceTest : public TestWithParam<Envoy::Network::Address::IpVersion> {
 public:
@@ -197,4 +197,4 @@ TEST_P(ServiceTest, Unresolvable) {
   runWithFailingValidationExpectations(true, "Unknown failure");
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/service_test.cc
+++ b/test/service_test.cc
@@ -18,7 +18,6 @@ using namespace std::chrono_literals;
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 class ServiceTest : public TestWithParam<Envoy::Network::Address::IpVersion> {
 public:
@@ -198,5 +197,4 @@ TEST_P(ServiceTest, Unresolvable) {
   runWithFailingValidationExpectations(true, "Unknown failure");
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/service_test.cc
+++ b/test/service_test.cc
@@ -197,4 +197,4 @@ TEST_P(ServiceTest, Unresolvable) {
   runWithFailingValidationExpectations(true, "Unknown failure");
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/sni_utility_test.cc
+++ b/test/sni_utility_test.cc
@@ -42,4 +42,4 @@ TEST_F(SniUtilityTest, SniHostComputation) {
   }
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/sni_utility_test.cc
+++ b/test/sni_utility_test.cc
@@ -9,7 +9,6 @@
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 class SniUtilityTest : public Test {
 public:
@@ -43,5 +42,4 @@ TEST_F(SniUtilityTest, SniHostComputation) {
   }
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/sni_utility_test.cc
+++ b/test/sni_utility_test.cc
@@ -8,7 +8,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class SniUtilityTest : public Test {
 public:
@@ -42,4 +42,4 @@ TEST_F(SniUtilityTest, SniHostComputation) {
   }
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -20,7 +20,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 using MyTypes = Types<SimpleStatistic, InMemoryStatistic, HdrStatistic, StreamingStatistic,
                       CircllhistStatistic>;
@@ -433,4 +433,4 @@ TYPED_TEST(SinkableStatisticTest, SimpleSinkableStatistic) {
   EXPECT_EQ(worker_id, stat.worker_id().value());
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -17,7 +17,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class StreamDecoderTest : public Test, public StreamDecoderCompletionCallback {
 public:
@@ -207,4 +207,4 @@ TEST_F(StreamDecoderTest, StreamResetReasonToResponseFlag) {
             Envoy::StreamInfo::ResponseFlag::UpstreamRemoteReset);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -18,7 +18,6 @@ using namespace std::chrono_literals;
 using namespace testing;
 
 namespace Nighthawk {
-namespace Client {
 
 class StreamDecoderTest : public Test, public StreamDecoderCompletionCallback {
 public:
@@ -208,5 +207,4 @@ TEST_F(StreamDecoderTest, StreamResetReasonToResponseFlag) {
             Envoy::StreamInfo::ResponseFlag::UpstreamRemoteReset);
 }
 
-} // namespace Client
-} // namespace Nighthawk
+ } // namespace Nighthawk

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -207,4 +207,4 @@ TEST_F(StreamDecoderTest, StreamResetReasonToResponseFlag) {
             Envoy::StreamInfo::ResponseFlag::UpstreamRemoteReset);
 }
 
- } // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/termination_predicate_test.cc
+++ b/test/termination_predicate_test.cc
@@ -12,7 +12,7 @@
 using namespace std::chrono_literals;
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class TerminationPredicateTest : public Test {
 public:
@@ -79,4 +79,4 @@ TEST_F(TerminationPredicateTest, AppendToChain) {
   EXPECT_EQ(predicate.evaluateChain(), TerminationPredicate::Status::FAIL);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -4,7 +4,7 @@
 
 #include "external/envoy/test/test_common/environment.h"
 
-namespace Nighthawk {
+namespace nighthawk {
 
 // For now we delegate most things 1:1 to Envoy::TestEnvironment.
 // We hide the original versions of runfilesDirectory() & runfilesPath(),
@@ -20,4 +20,4 @@ public:
   }
 };
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/utility_test.cc
+++ b/test/utility_test.cc
@@ -13,7 +13,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class UtilityTest : public Test {
 public:
@@ -177,4 +177,4 @@ TEST_F(UtilityTest, MapCountersFromStore) {
   EXPECT_EQ(counters.begin()->second, 2);
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk

--- a/test/worker_test.cc
+++ b/test/worker_test.cc
@@ -13,7 +13,7 @@
 
 using namespace testing;
 
-namespace Nighthawk {
+namespace nighthawk {
 
 class TestWorker : public WorkerImpl {
 public:
@@ -62,4 +62,4 @@ TEST_F(WorkerTest, WorkerExecutesOnThread) {
   worker.shutdown();
 }
 
-} // namespace Nighthawk
+} // namespace nighthawk


### PR DESCRIPTION
As discussed earlier, we'd like to move towards using a single
namespace, Nighthawk.

This strips the following namespaces in the c++ code.
- Nighthawk::Client
- Nighthawk::Server
- Nighthawk::Server::Configuration

The proto api's still follow the old convention of having namespaces
follow directory layout, as changing that would cause compatibility
issues.

While there's some large code churn, this change should be a no-op.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>