### PR TITLE
CI: minimal fix to unbreak

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -159,6 +159,13 @@ if grep 'docker\|lxc' /proc/1/cgroup; then
     export USER=bazel
     export TEST_TMPDIR=/build/tmp
     export BAZEL="bazel"
+
+    ## TODO(#452): Get rid of the package install and symlinking below.   
+    export DEBIAN_FRONTEND=noninteractive
+    sudo apt -yq update
+    sudo apt install -yq python3.6-dev
+    # We do this, because python's psutil install looks for x86_64-linux-gnu-gcc
+    ln -s /usr/bin/x86_64-linux-gnu-gcc-9 /usr/bin/x86_64-linux-gnu-gcc
 fi
 
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"


### PR DESCRIPTION
Python's psutil, which gets pulled in via pytest-xdist, needs gcc
to build. While doing it that it runs into that:
a) It can't find python.h, which we solve by installing python3-dev
b) It can't find /usr/bin/x86_64-linux-gnu-gcc which we resolve by
   symlinking in an existing version at the expected place.

Pinning the packages to specific versions doesn't solve the problem
by itself, at least not in a combination of versions that I could
find. Instead, I'll create a follow up to pin them to recent versions
in a follow-up.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>