### PR TITLE
Python requirements.txt - pin to (recent) versions 

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -159,6 +159,13 @@ if grep 'docker\|lxc' /proc/1/cgroup; then
     export USER=bazel
     export TEST_TMPDIR=/build/tmp
     export BAZEL="bazel"
+
+    ## TODO(#452): Get rid of the package install and symlinking below.   
+    export DEBIAN_FRONTEND=noninteractive
+    sudo apt -yq update
+    sudo apt install -yq python3.6-dev
+    # We do this, because python's psutil install looks for x86_64-linux-gnu-gcc
+    ln -s /usr/bin/x86_64-linux-gnu-gcc-9 /usr/bin/x86_64-linux-gnu-gcc
 fi
 
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -159,13 +159,6 @@ if grep 'docker\|lxc' /proc/1/cgroup; then
     export USER=bazel
     export TEST_TMPDIR=/build/tmp
     export BAZEL="bazel"
-
-    ## TODO(#452): Get rid of the package install and symlinking below.   
-    export DEBIAN_FRONTEND=noninteractive
-    sudo apt -yq update
-    sudo apt install -yq python3.6-dev
-    # We do this, because python's psutil install looks for x86_64-linux-gnu-gcc
-    ln -s /usr/bin/x86_64-linux-gnu-gcc-9 /usr/bin/x86_64-linux-gnu-gcc
 fi
 
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-requests
-pytest
-pytest-dependency
-pytest-xdist
-pyyaml
-zipp
-importlib_metadata
+requests==2.24.0
+pytest==6.0.1
+pytest-dependency==0.5.1
+pytest-xdist==1.34.0
+pyyaml==5.3.1
+zipp==3.1.0
+importlib_metadata==1.7.0


### PR DESCRIPTION
Pin python versions to recent versions. 
CI broke on pytest-xdist releasing `2.0.0` which got pulled in.

Signed-off-by: Otto van der Schaaf oschaaf@we-amp.com

