### PR TITLE
Update Envoy to 933e67a9ecac814839f514fb5c31c78f3d33e5fe

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -192,6 +192,11 @@ build:rbe-toolchain-msvc-cl --platforms=@rbe_windows_msvc_cl//config:platform
 build:rbe-toolchain-msvc-cl --crosstool_top=@rbe_windows_msvc_cl//cc:toolchain
 build:rbe-toolchain-msvc-cl --extra_toolchains=@rbe_windows_msvc_cl//config:cc-toolchain
 
+build:rbe-toolchain-clang-cl --host_platform=@rbe_windows_clang_cl//config:platform
+build:rbe-toolchain-clang-cl --platforms=@rbe_windows_clang_cl//config:platform
+build:rbe-toolchain-clang-cl --crosstool_top=@rbe_windows_clang_cl//cc:toolchain
+build:rbe-toolchain-clang-cl --extra_toolchains=@rbe_windows_clang_cl//config:cc-toolchain
+
 build:remote --spawn_strategy=remote,sandboxed,local
 build:remote --strategy=Javac=remote,sandboxed,local
 build:remote --strategy=Closure=remote,sandboxed,local
@@ -223,11 +228,16 @@ build:remote-msan --config=rbe-toolchain-clang-libc++
 build:remote-msan --config=rbe-toolchain-msan
 
 build:remote-msvc-cl --config=remote-windows
+build:remote-msvc-cl --config=msvc-cl
 build:remote-msvc-cl --config=rbe-toolchain-msvc-cl
+
+build:remote-clang-cl --config=remote-windows
+build:remote-clang-cl --config=clang-cl
+build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:923df85a4ba7f30dcd0cb6b0c6d8d604f0e20f48
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:f741613fc395cc489a630122eeb5e611b3cb1a5e
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
   envoy-build-image: &envoy-build-image # July 29th, 2020
-    envoyproxy/envoy-build-ubuntu:923df85a4ba7f30dcd0cb6b0c6d8d604f0e20f48
+    envoyproxy/envoy-build-ubuntu:f741613fc395cc489a630122eeb5e611b3cb1a5e
 version: 2
 jobs:
   build:

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "3147d91a40d6aca684cfb4fd159c8876995502d1"  # August 20th, 2020
-ENVOY_SHA = "fce665401000734d20f35d895e46097db37fff427a2d882759bdeeece1857c88"
+ENVOY_COMMIT = "933e67a9ecac814839f514fb5c31c78f3d33e5fe"  # August 24th, 2020
+ENVOY_SHA = "412a38b5312e755a46c8ddc1fd3e4d6a6fbe202c4b1beb3aded70c2de443276d"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.0"  # July 14th, 2020
 HDR_HISTOGRAM_C_SHA = "c00696b3d81776675aa2bc62d3642e31bd8a48cc9619c9bd7d4a78762896e353"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -174,7 +174,7 @@ if [ -n "$CIRCLECI" ]; then
     fi
     NUM_CPUS=8
     if [[ "$1" == "test_gcc" ]]; then
-        NUM_CPUS=6
+        NUM_CPUS=4
     fi
 fi
 


### PR DESCRIPTION
Updated Envoy, plus a tweak to deflake the gcc test in CI.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>