### PR TITLE
Eliminate instances of "using namespace Envoy"

### DIFF
--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -58,7 +58,7 @@ Http1PoolImpl::newStream(Envoy::Http::ResponseDecoder& response_decoder,
       // updating connections().canCreate() above. We would risk an infinite loop.
       Envoy::ConnectionPool::ActiveClientPtr client = instantiateActiveClient();
       connecting_stream_capacity_ += client->effectiveConcurrentRequestLimit();
-      LinkedList::moveIntoList(std::move(client), owningList(client->state_));
+      Envoy::LinkedList::moveIntoList(std::move(client), owningList(client->state_));
     }
   }
 

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -31,8 +31,6 @@ namespace Client {
 
 using namespace std::chrono_literals;
 
-using namespace Envoy; // We need this because of macro expectations.
-
 #define ALL_BENCHMARK_CLIENT_COUNTERS(COUNTER)                                                     \
   COUNTER(stream_resets)                                                                           \
   COUNTER(http_1xx)                                                                                \

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -391,9 +391,9 @@ void ProcessImpl::maybeCreateTracingDriver(const envoy::config::trace::v3::Traci
     // in which we do not have, and creating a fake for that means we risk code-churn because of
     // upstream code changes.
     auto& factory =
-        Config::Utility::getAndCheckFactory<Envoy::Server::Configuration::TracerFactory>(
+        Envoy::Config::Utility::getAndCheckFactory<Envoy::Server::Configuration::TracerFactory>(
             configuration.http());
-    ProtobufTypes::MessagePtr message = Envoy::Config::Utility::translateToFactoryConfig(
+    Envoy::ProtobufTypes::MessagePtr message = Envoy::Config::Utility::translateToFactoryConfig(
         configuration.http(), Envoy::ProtobufMessage::getStrictValidationVisitor(), factory);
     auto zipkin_config = dynamic_cast<const envoy::config::trace::v3::ZipkinConfig&>(*message);
     Envoy::Tracing::DriverPtr zipkin_driver =
@@ -467,7 +467,8 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
             *dispatcher_, tls_, {}, *local_info_, store_root_, generator_,
             Envoy::ProtobufMessage::getStrictValidationVisitor(), *api_)});
     ssl_context_manager_ =
-        std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(time_system_);
+        std::make_unique<Envoy::Extensions::TransportSockets::Tls::ContextManagerImpl>(
+            time_system_);
     cluster_manager_factory_ = std::make_unique<ClusterManagerFactory>(
         admin_, Envoy::Runtime::LoaderSingleton::get(), store_root_, tls_, generator_,
         dispatcher_->createDnsResolver({}, false), *ssl_context_manager_, *dispatcher_,
@@ -488,7 +489,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
     cluster_manager_->setInitializedCb(
         [this]() -> void { init_manager_.initialize(init_watcher_); });
 
-    Runtime::LoaderSingleton::get().initialize(*cluster_manager_);
+    Envoy::Runtime::LoaderSingleton::get().initialize(*cluster_manager_);
 
     std::list<std::unique_ptr<Envoy::Stats::Sink>> stats_sinks;
     setupStatsSinks(bootstrap, stats_sinks);

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -158,9 +158,9 @@ private:
 
   std::unique_ptr<ClusterManagerFactory> cluster_manager_factory_;
   Envoy::Upstream::ClusterManagerPtr cluster_manager_{};
-  std::unique_ptr<Runtime::ScopedLoaderSingleton> runtime_singleton_;
+  std::unique_ptr<Envoy::Runtime::ScopedLoaderSingleton> runtime_singleton_;
   Envoy::Init::WatcherImpl init_watcher_;
-  Tracing::HttpTracerSharedPtr http_tracer_;
+  Envoy::Tracing::HttpTracerSharedPtr http_tracer_;
   Envoy::Server::ValidationAdmin admin_;
   Envoy::ProtobufMessage::ProdValidationContextImpl validation_context_;
   bool shutdown_{true};

--- a/source/common/sequencer_impl.h
+++ b/source/common/sequencer_impl.h
@@ -23,8 +23,6 @@ constexpr std::chrono::microseconds NighthawkTimerResolution = 25us;
 
 } // namespace
 
-using namespace Envoy; // We need this because of macro expectations.
-
 #define ALL_SEQUENCER_STATS(COUNTER) COUNTER(failed_terminations)
 
 struct SequencerStats {


### PR DESCRIPTION
Envoy's statistics macros seem to no longer need this,
so we can do without "using namespace Envoy".
Also fix things that have crept in and relied on this.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>