### PR TITLE
Fix (enable) integration test coverage in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ workflows:
       - test_gcc
       - clang_tidy
       - coverage
+      - integration_test_coverage
       - asan
       - tsan
       - benchmark


### PR DESCRIPTION
Whoops, I think I found why the integration test coverage task in not
showing in CircleCI. Next to defining it, it should be separately enabled too.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>