### PR TITLE
Fix uri parsing bug & add some unit test coverage for client.cc

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -34,7 +34,7 @@ function do_clang_tidy() {
 
 function do_unit_test_coverage() {
     export TEST_TARGETS="//test/... -//test:python_test"
-    export COVERAGE_THRESHOLD=93.3
+    export COVERAGE_THRESHOLD=93.2
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
     exit 0
@@ -42,7 +42,7 @@ function do_unit_test_coverage() {
 
 function do_integration_test_coverage() {
     export TEST_TARGETS="//test:python_test"
-    export COVERAGE_THRESHOLD=78.2
+    export COVERAGE_THRESHOLD=78.1
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
     exit 0

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -34,7 +34,7 @@ function do_clang_tidy() {
 
 function do_unit_test_coverage() {
     export TEST_TARGETS="//test/... -//test:python_test"
-    export COVERAGE_THRESHOLD=92.3
+    export COVERAGE_THRESHOLD=93.3
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
     exit 0

--- a/source/common/uri_impl.cc
+++ b/source/common/uri_impl.cc
@@ -49,8 +49,11 @@ UriImpl::UriImpl(absl::string_view uri, absl::string_view default_scheme)
     host_without_port_ = host_and_port_;
     host_and_port_ = fmt::format("{}:{}", host_and_port_, port_);
   } else {
-    port_ = std::stoi(host_and_port_.substr(colon_index + 1));
-    host_without_port_ = host_and_port_.substr(0, colon_index);
+    if (absl::SimpleAtoi(host_and_port_.substr(colon_index + 1), &port_)) {
+      host_without_port_ = host_and_port_.substr(0, colon_index);
+    } else {
+      throw UriException("Invalid URI, couldn't parse port");
+    }
   }
   if (!isValid()) {
     throw UriException("Invalid URI");

--- a/test/client_test.cc
+++ b/test/client_test.cc
@@ -80,5 +80,19 @@ TEST_F(ClientTest, BadRun) {
   EXPECT_FALSE(program.run());
 }
 
+TEST_F(ClientTest, BadRemoteRun) {
+  Main program(Nighthawk::Client::TestUtility::createOptionsImpl(
+      "foo --duration 1 --nighthawk-service grpc://unresolveable.host:8843 --rps 1 "
+      "http://localhost:63657/"));
+  EXPECT_FALSE(program.run());
+}
+
+TEST_F(ClientTest, RemoteRun) {
+  Main program(Nighthawk::Client::TestUtility::createOptionsImpl(
+      "foo --duration 1 --nighthawk-service grpc://localhost:8843 --rps 1 "
+      "http://localhost:63657/"));
+  EXPECT_FALSE(program.run());
+}
+
 } // namespace Client
 } // namespace Nighthawk

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -716,3 +716,11 @@ def test_client_bad_arg():
   (exit_code, output) = _run_client_with_args("127.0.0.1 --foo")
   asserts.assertEqual(exit_code, 1)
   asserts.assertIn("PARSE ERROR: Argument: --foo", output)
+
+
+def test_client_cli_bad_uri(http_test_server_fixture):
+  """Test that passing a bad URI to the client results in nice behavior."""
+  _, err = http_test_server_fixture.runNighthawkClient(["http://http://foo"],
+                                                       expect_failure=True,
+                                                       as_json=False)
+  assert "Invalid target URI" in err

--- a/test/utility_test.cc
+++ b/test/utility_test.cc
@@ -177,4 +177,8 @@ TEST_F(UtilityTest, MapCountersFromStore) {
   EXPECT_EQ(counters.begin()->second, 2);
 }
 
+TEST_F(UtilityTest, MultipleSemicolons) {
+  EXPECT_THROW(UriImpl("HTTP://HTTP://a:111"), UriException);
+}
+
 } // namespace Nighthawk


### PR DESCRIPTION
- Avoid std::stoi exception during uri parsing
- Add unit tests for client.cc to improve coverage

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>