### PR TITLE
Update Envoy to f1c0031819ddc7b8a9f6352ad6722f4abf8ab664

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "d3abda8a32cb11e9b251deb5ffd2601096c80b57"  # August 28th, 2020
-ENVOY_SHA = "2f9d58366df6c8bc66629c22cc9d4c5b6059f16d697ffcd1965daf1e3d65e86b"
+ENVOY_COMMIT = "f1c0031819ddc7b8a9f6352ad6722f4abf8ab664"  # September 2nd, 2020
+ENVOY_SHA = "9a2fd92512f361db47cf9bdaee8c3547a4789fa987a297a0906c7478d28a9446"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.0"  # July 14th, 2020
 HDR_HISTOGRAM_C_SHA = "c00696b3d81776675aa2bc62d3642e31bd8a48cc9619c9bd7d4a78762896e353"


### PR DESCRIPTION
This gets us a bunch of sparse logging macros:

ENVOY_LOG_FIRST_N
ENVOY_LOG_ONCE
ENVOY_LOG_EVERY_NTH
ENVOY_LOG_EVERY_POW_2

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>