### PR TITLE
Avoid high frequency logging

### DIFF
--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -156,7 +156,7 @@ bool BenchmarkClientHttpImpl::tryStartRequest(CompletionCallback caller_completi
   if (content_length_header != nullptr) {
     auto s_content_length = content_length_header->value().getStringView();
     if (!absl::SimpleAtoi(s_content_length, &content_length)) {
-      ENVOY_LOG(error, "Ignoring bad content length of {}", s_content_length);
+      ENVOY_LOG_EVERY_POW_2(error, "Ignoring bad content length of {}", s_content_length);
       content_length = 0;
     }
   }

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -28,8 +28,7 @@ void StreamDecoder::decodeHeaders(Envoy::Http::ResponseHeaderMapPtr&& headers, b
     if (absl::SimpleAtoi(timing_value, &origin_delta) && origin_delta >= 0) {
       origin_latency_statistic_.addValue(origin_delta);
     } else {
-      // TODO(#484): avoid high frequency logging.
-      ENVOY_LOG(warn, "Bad origin delta: '{}'.", timing_value);
+      ENVOY_LOG_EVERY_POW_2(warn, "Bad origin delta: '{}'.", timing_value);
     }
   }
 
@@ -69,7 +68,7 @@ void StreamDecoder::onComplete(bool success) {
           stream_info_.response_code_.value(),
           (time_source_.monotonicTime() - request_start_).count());
     } else {
-      ENVOY_LOG(warn, "response_code is not available in onComplete");
+      ENVOY_LOG_EVERY_POW_2(warn, "response_code is not available in onComplete");
     }
   }
   upstream_timing_.onLastUpstreamRxByteReceived(time_source_);

--- a/source/common/statistic_impl.cc
+++ b/source/common/statistic_impl.cc
@@ -180,7 +180,7 @@ void HdrStatistic::addValue(uint64_t value) {
   // Failure to record a value can happen when it exceeds the configured minimum
   // or maximum value we passed when initializing histogram_.
   if (!hdr_record_value(histogram_, value)) {
-    ENVOY_LOG(warn, "Failed to record value into HdrHistogram.");
+    ENVOY_LOG_EVERY_POW_2(warn, "Failed to record value into HdrHistogram.");
   } else {
     StatisticImpl::addValue(value);
   }


### PR DESCRIPTION
Throttle log emission in a few potentially high frequency paths.

Fixes #484

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>