### PR TITLE
Allow 0s as a value to the jitter-uniform option.

### DIFF
--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -180,7 +180,7 @@ message CommandLineOptions {
   google.protobuf.BoolValue open_loop = 21;
   // Add uniformly distributed absolute request-release timing jitter. For example, to add 10 us of
   // jitter, specify .00001s. Default is empty / no uniform jitter.
-  google.protobuf.Duration jitter_uniform = 25 [(validate.rules).duration.gte.nanos = 1];
+  google.protobuf.Duration jitter_uniform = 25 [(validate.rules).duration.gte.nanos = 0];
   // Nighthawk service uri for running CLI in remote host mode. Example: grpc://localhost:8843/.
   // Default is empty.
   // NOTE: not relevant to gRPC service

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -380,7 +380,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   if (jitter_uniform.isSet()) {
     Envoy::ProtobufWkt::Duration duration;
     if (Envoy::Protobuf::util::TimeUtil::FromString(jitter_uniform.getValue(), &duration)) {
-      if (duration.nanos() > 0 || duration.seconds() > 0) {
+      if (duration.nanos() >= 0 && duration.seconds() >= 0) {
         jitter_uniform_ = std::chrono::nanoseconds(
             Envoy::Protobuf::util::TimeUtil::DurationToNanoseconds(duration));
       } else {

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -273,7 +273,9 @@ std::string FortioOutputFormatterImpl::formatProto(const nighthawk::client::Outp
   *fortio_output.mutable_requestedduration() = output.options().duration();
   auto actual_duration = getAverageExecutionDuration(output);
   fortio_output.set_actualduration(actual_duration.count());
-  fortio_output.set_jitter(output.options().has_jitter_uniform());
+  fortio_output.set_jitter(output.options().has_jitter_uniform() &&
+                           (output.options().jitter_uniform().nanos() > 0 ||
+                            output.options().jitter_uniform().seconds() > 0));
   fortio_output.set_runtype("HTTP");
 
   // The stock Envoy h2 pool doesn't offer support for multiple connections here. So we must ignore

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -509,11 +509,11 @@ TEST_F(OptionsImplTest, JitterValueRangeTest) {
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format("{} --jitter-uniform -1s {}",
                                                                      client_name_, good_test_uri_)),
                           MalformedArgvException, "--jitter-uniform is out of range");
-  // No 0 duration accepted
-  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format("{} --jitter-uniform 0s {}",
-                                                                     client_name_, good_test_uri_)),
-                          MalformedArgvException, "--jitter-uniform is out of range");
-  // No durations >= 1s are accepted
+  // Durations >= 0s are accepted
+  EXPECT_NO_THROW(TestUtility::createOptionsImpl(
+      fmt::format("{} --jitter-uniform 0s {}", client_name_, good_test_uri_)));
+  EXPECT_NO_THROW(TestUtility::createOptionsImpl(
+      fmt::format("{} --jitter-uniform 0.1s {}", client_name_, good_test_uri_)));
   EXPECT_NO_THROW(TestUtility::createOptionsImpl(
       fmt::format("{} --jitter-uniform 1s {}", client_name_, good_test_uri_)));
   EXPECT_NO_THROW(TestUtility::createOptionsImpl(

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -192,6 +192,15 @@ TEST_F(MediumOutputCollectorTest, FortioFormatter) {
                         "test/test_data/output_formatter.medium.fortio.gold");
 }
 
+TEST_F(MediumOutputCollectorTest, FortioFormatter0sJitterUniformGetsReflected) {
+  nighthawk::client::Output input_proto =
+      loadProtoFromFile("test/test_data/output_formatter.medium.proto.gold");
+  FortioOutputFormatterImpl formatter;
+  input_proto.mutable_options()->mutable_jitter_uniform()->set_nanos(0);
+  input_proto.mutable_options()->mutable_jitter_uniform()->set_seconds(0);
+  EXPECT_NE(formatter.formatProto(input_proto).find(" \"Jitter\": false,"), std::string::npos);
+}
+
 TEST_F(MediumOutputCollectorTest, ConsoleOutputFormatter) {
   const auto input_proto = loadProtoFromFile("test/test_data/percentile-column-overflow.json");
   ConsoleOutputFormatterImpl formatter;


### PR DESCRIPTION
Fixes #513

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>