### PR TITLE
Lower integration test coverage threshold

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -46,7 +46,7 @@ function do_unit_test_coverage() {
 
 function do_integration_test_coverage() {
     export TEST_TARGETS="//test:python_test"
-    export COVERAGE_THRESHOLD=78.1
+    export COVERAGE_THRESHOLD=78.0
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
     exit 0


### PR DESCRIPTION
Recently integration test coverage started to occasionally flake just below the configured threshold.
While not passing the coverage integration threshold isn't blocking merge of PRs,  the red cross marking CI failure for a PR isn't encouraging.
  
Therefore I'm proposing to lower this threshold to avoid further flakes, and make it more valuable as a signal to authors/reviewers to inspect its reports upon failure.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>