### PR TITLE
Eliminate configuration references to Envoy's fault filter.

### DIFF
--- a/ci/docker/default-config.yaml
+++ b/ci/docker/default-config.yaml
@@ -23,13 +23,8 @@ static_resources:
               domains:
               - "*"
           http_filters:
-          - name: envoy.fault
-            config:
-              max_active_faults: 100
-              delay:
-                header_delay: {}
-                percentage:
-                  numerator: 100
+          - name: time-tracking
+          - name: dynamic-delay
           - name: test-server
             config:
               response_body_size: 10

--- a/test/integration/configurations/nighthawk_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_http_origin.yaml
@@ -24,13 +24,6 @@ static_resources:
               - "*"
           http_filters:
           - name: dynamic-delay
-          - name: envoy.fault
-            config:
-              max_active_faults: 100
-              delay:
-                header_delay: {}
-                percentage:
-                  numerator: 100
           - name: test-server
             config:
               response_body_size: 10


### PR DESCRIPTION
Our own dynamic delay extension owns this now. We no longer
need it in tests.

Split out from #512 

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>