### PR TITLE
Enhance end-to-end test for POST requests with an entity body.

### DIFF
--- a/test/integration/configurations/nighthawk_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_http_origin.yaml
@@ -23,6 +23,7 @@ static_resources:
               domains:
               - "*"
           http_filters:
+          - name: time-tracking
           - name: dynamic-delay
           - name: test-server
             config:

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -418,7 +418,7 @@ def test_cli_output_format(http_test_server_fixture):
     'filter_configs',
     ["{}", "{static_delay: \"0.01s\"}", "{emit_previous_request_delta_in_response_header: \"aa\"}"])
 def test_request_body_gets_transmitted(http_test_server_fixture, filter_configs):
-  """Test request body transmission with.
+  """Test request body transmission handling code for our extensions.
 
   Ensure that the number of bytes we request for the request body gets reflected in the upstream
   connection transmitted bytes counter for h1 and h2.
@@ -436,10 +436,8 @@ def test_request_body_gets_transmitted(http_test_server_fixture, filter_configs)
                                       "http.ingress_http.downstream_cx_rx_bytes_total"),
         expected_received_bytes)
 
-  upload_bytes = 1024 * 1024 * 3
   # TODO(#531): The dynamic-delay extension hangs unless we lower the request entity body size.
-  if "static_delay" in filter_configs:
-    upload_bytes = int(upload_bytes / 3)
+  upload_bytes = 1024 * 1024 if "static_delay" in filter_configs else 1024 * 1024 * 3
   requests = 10
   args = [
       http_test_server_fixture.getTestServerRootUri(), "--duration", "100", "--rps", "100",

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -414,8 +414,11 @@ def test_cli_output_format(http_test_server_fixture):
   asserts.assertIn("Percentile", output)
 
 
-def test_request_body_gets_transmitted(http_test_server_fixture):
-  """Test request body transmission.
+@pytest.mark.parametrize(
+    'filter_configs',
+    ["{}", "{static_delay: \"0.01s\"}", "{emit_previous_request_delta_in_response_header: \"aa\"}"])
+def test_request_body_gets_transmitted(http_test_server_fixture, filter_configs):
+  """Test request body transmission with.
 
   Ensure that the number of bytes we request for the request body gets reflected in the upstream
   connection transmitted bytes counter for h1 and h2.
@@ -434,13 +437,17 @@ def test_request_body_gets_transmitted(http_test_server_fixture):
         expected_received_bytes)
 
   upload_bytes = 1024 * 1024 * 3
+  # TODO(#531): The dynamic-delay extension hangs unless we lower the request entity body size.
+  if "static_delay" in filter_configs:
+    upload_bytes = int(upload_bytes / 3)
   requests = 10
   args = [
       http_test_server_fixture.getTestServerRootUri(), "--duration", "100", "--rps", "100",
       "--request-body-size",
       str(upload_bytes), "--termination-predicate",
       "benchmark.http_2xx:%s" % str(requests), "--connections", "1", "--request-method", "POST",
-      "--max-active-requests", "1"
+      "--max-active-requests", "1", "--request-header",
+      "x-nighthawk-test-server-config:%s" % filter_configs
   ]
   # Test we transmit the expected amount of bytes with H1
   parsed_json, _ = http_test_server_fixture.runNighthawkClient(args)


### PR DESCRIPTION
Make the end-to-end test for POST handling cover all extensions.

Split out from #512 

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>