### PR TITLE
Test benchmark docker image build in CI

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -25,6 +25,7 @@ function do_build () {
 
 function do_opt_build () {
     bazel build $BAZEL_BUILD_OPTIONS -c opt //:nighthawk
+    bazel build $BAZEL_BUILD_OPTIONS -c opt //benchmarks:benchmarks
 }
 
 function do_test() {
@@ -143,6 +144,7 @@ function do_docker() {
     do_opt_build
     ./ci/docker/docker_build.sh
     ./ci/docker/docker_push.sh
+    ./ci/docker/benchmark_build.sh
 }
 
 function do_fix_format() {


### PR DESCRIPTION
Now that we have a benchmark docker image build, it would be
good to make sure that keeps working in CI.

This also makes it easy to start pushing this image in CI in a
follow-up.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>