### PR TITLE
Switch dynamic delay and time-tracking to use FilterConfigurationBase.

### DIFF
--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -20,11 +20,20 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "configuration_lib",
-    srcs = ["configuration.cc"],
-    hdrs = ["configuration.h"],
+    srcs = [
+        "configuration.cc",
+        "http_filter_config_base.cc",
+    ],
+    hdrs = [
+        "configuration.h",
+        "http_filter_config_base.h",
+    ],
     repository = "@envoy",
     deps = [
+        ":well_known_headers_lib",
         "//api/server:response_options_proto_cc_proto",
+        "@envoy//include/envoy/server:filter_config_interface_with_external_headers",
+        "@envoy//source/common/common:statusor_lib_with_external_headers",
         "@envoy//source/common/protobuf:message_validator_lib_with_external_headers",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//source/common/singleton:const_singleton_with_external_headers",
@@ -38,7 +47,6 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":configuration_lib",
-        ":well_known_headers_lib",
         "//api/server:response_options_proto_cc_proto",
         "@envoy//source/exe:envoy_common_lib_with_external_headers",
     ],
@@ -51,7 +59,6 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":configuration_lib",
-        ":well_known_headers_lib",
         "//api/server:response_options_proto_cc_proto",
         "//source/common:thread_safe_monotonic_time_stopwatch_lib",
         "@envoy//source/exe:envoy_common_lib_with_external_headers",
@@ -66,7 +73,6 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":configuration_lib",
-        ":well_known_headers_lib",
         "//api/server:response_options_proto_cc_proto",
         "@envoy//source/exe:envoy_common_lib_with_external_headers",
         "@envoy//source/extensions/filters/http/fault:fault_filter_lib_with_external_headers",

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -9,6 +9,8 @@
 
 #include "api/server/response_options.pb.h"
 
+#include "server/http_filter_config_base.h"
+
 namespace Nighthawk {
 namespace Server {
 
@@ -17,7 +19,7 @@ namespace Server {
  * Instances of this class will be shared accross instances of HttpDynamicDelayDecoderFilter.
  * The methods for getting and manipulating (global) active filter instance counts are thread safe.
  */
-class HttpDynamicDelayDecoderFilterConfig {
+class HttpDynamicDelayDecoderFilterConfig : public FilterConfigurationBase {
 
 public:
   /**
@@ -31,17 +33,10 @@ public:
    * @param scope Statistics scope to be used by the filter.
    * @param time_source Time source to be used by the filter.
    */
-  HttpDynamicDelayDecoderFilterConfig(nighthawk::server::ResponseOptions proto_config,
+  HttpDynamicDelayDecoderFilterConfig(const nighthawk::server::ResponseOptions& proto_config,
                                       Envoy::Runtime::Loader& runtime,
                                       const std::string& stats_prefix, Envoy::Stats::Scope& scope,
                                       Envoy::TimeSource& time_source);
-
-  /**
-   * @return const nighthawk::server::ResponseOptions& read-only reference to the proto config
-   * object.
-   */
-  const nighthawk::server::ResponseOptions& server_config() const { return server_config_; }
-
   /**
    * Increments the number of globally active filter instances.
    */
@@ -79,7 +74,6 @@ public:
   std::string stats_prefix() { return stats_prefix_; }
 
 private:
-  const nighthawk::server::ResponseOptions server_config_;
   static std::atomic<uint64_t>& instances() {
     // We lazy-init the atomic to avoid static initialization / a fiasco.
     MUTABLE_CONSTRUCT_ON_FIRST_USE(std::atomic<uint64_t>, 0); // NOLINT
@@ -112,20 +106,8 @@ public:
 
   // Http::StreamDecoderFilter
   Envoy::Http::FilterHeadersStatus decodeHeaders(Envoy::Http::RequestHeaderMap&, bool) override;
+  Envoy::Http::FilterDataStatus decodeData(Envoy::Buffer::Instance&, bool) override;
   void setDecoderFilterCallbacks(Envoy::Http::StreamDecoderFilterCallbacks&) override;
-
-  /**
-   * Compute the response options based on the static configuration and optional configuration
-   * provided via the request headers. After a successfull call the response_options_ field will
-   * have been modified to reflect request-level configuration.
-   *
-   * @param request_headers The request headers set to inspect for configuration.
-   * @param error_message Set to an error message if the request-level configuration couldn't be
-   * interpreted.
-   * @return true iff the configuration was successfully computed.
-   */
-  bool computeResponseOptions(const Envoy::Http::RequestHeaderMap& request_headers,
-                              std::string& error_message);
 
   /**
    * Compute the concurrency based linear delay in milliseconds.
@@ -179,7 +161,6 @@ public:
 private:
   const HttpDynamicDelayDecoderFilterConfigSharedPtr config_;
   Envoy::Http::StreamDecoderFilterCallbacks* decoder_callbacks_;
-  nighthawk::server::ResponseOptions response_options_;
   bool destroyed_{false};
 };
 

--- a/source/server/http_filter_config_base.cc
+++ b/source/server/http_filter_config_base.cc
@@ -1,12 +1,14 @@
 #include "server/http_filter_config_base.h"
 
+#include "server/well_known_headers.h"
+
 namespace Nighthawk {
 namespace Server {
 
 FilterConfigurationBase::FilterConfigurationBase(
     const nighthawk::server::ResponseOptions& proto_config, absl::string_view filter_name)
     : filter_name_(filter_name),
-      server_config_(std::make_shared<nighthawk::server::ResponseOptions>(std::move(proto_config))),
+      server_config_(std::make_shared<nighthawk::server::ResponseOptions>(proto_config)),
       effective_config_(server_config_) {}
 
 void FilterConfigurationBase::computeEffectiveConfiguration(

--- a/source/server/http_filter_config_base.h
+++ b/source/server/http_filter_config_base.h
@@ -9,7 +9,6 @@
 #include "api/server/response_options.pb.h"
 
 #include "server/configuration.h"
-#include "server/well_known_headers.h"
 
 #include "absl/status/status.h"
 

--- a/source/server/http_time_tracking_filter.cc
+++ b/source/server/http_time_tracking_filter.cc
@@ -16,8 +16,8 @@ namespace Nighthawk {
 namespace Server {
 
 HttpTimeTrackingFilterConfig::HttpTimeTrackingFilterConfig(
-    nighthawk::server::ResponseOptions proto_config)
-    : server_config_(std::move(proto_config)),
+    const nighthawk::server::ResponseOptions& proto_config)
+    : FilterConfigurationBase(proto_config, "time-tracking"),
       stopwatch_(std::make_unique<ThreadSafeMontonicTimeStopwatch>()) {}
 
 uint64_t
@@ -29,28 +29,28 @@ HttpTimeTrackingFilter::HttpTimeTrackingFilter(HttpTimeTrackingFilterConfigShare
     : config_(std::move(config)) {}
 
 Envoy::Http::FilterHeadersStatus
-HttpTimeTrackingFilter::decodeHeaders(Envoy::Http::RequestHeaderMap& headers, bool /*end_stream*/) {
-  base_config_ = config_->server_config();
-  const auto* request_config_header = headers.get(TestServer::HeaderNames::get().TestServerConfig);
-  if (request_config_header) {
-    json_merge_error_ = !Configuration::mergeJsonConfig(
-        request_config_header->value().getStringView(), base_config_, error_message_);
-    if (json_merge_error_) {
-      decoder_callbacks_->sendLocalReply(
-          static_cast<Envoy::Http::Code>(500),
-          fmt::format("time-tracking didn't understand the request: {}", error_message_), nullptr,
-          absl::nullopt, "");
-      return Envoy::Http::FilterHeadersStatus::StopIteration;
-    }
+HttpTimeTrackingFilter::decodeHeaders(Envoy::Http::RequestHeaderMap& headers, bool end_stream) {
+  config_->computeEffectiveConfiguration(headers);
+  if (end_stream && config_->maybeSendErrorReply(*decoder_callbacks_)) {
+    return Envoy::Http::FilterHeadersStatus::StopIteration;
   }
   return Envoy::Http::FilterHeadersStatus::Continue;
 }
 
+Envoy::Http::FilterDataStatus HttpTimeTrackingFilter::decodeData(Envoy::Buffer::Instance&,
+                                                                 bool end_stream) {
+  if (end_stream && config_->maybeSendErrorReply(*decoder_callbacks_)) {
+    return Envoy::Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+  return Envoy::Http::FilterDataStatus::Continue;
+}
+
 Envoy::Http::FilterHeadersStatus
 HttpTimeTrackingFilter::encodeHeaders(Envoy::Http::ResponseHeaderMap& response_headers, bool) {
-  if (!json_merge_error_) {
+  const auto effective_config = config_->getEffectiveConfiguration();
+  if (effective_config.ok()) {
     const std::string previous_request_delta_in_response_header =
-        base_config_.emit_previous_request_delta_in_response_header();
+        effective_config.value()->emit_previous_request_delta_in_response_header();
     if (!previous_request_delta_in_response_header.empty() && last_request_delta_ns_ > 0) {
       response_headers.appendCopy(
           Envoy::Http::LowerCaseString(previous_request_delta_in_response_header),


### PR DESCRIPTION
Second step in unifying configuration handling across extensions:
make these two extensions inherit from and use FilterConfigurationBase.
Fix POST handling.

Split out from #512

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>