### PR TITLE
Avoid crash with the experimental fortio pedantic formatter

### DIFF
--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -108,6 +108,8 @@ OutputFormatterPtr OutputFormatterFactoryImpl::create(
     return std::make_unique<Client::DottedStringOutputFormatterImpl>();
   case nighthawk::client::OutputFormat::FORTIO:
     return std::make_unique<Client::FortioOutputFormatterImpl>();
+  case nighthawk::client::OutputFormat::EXPERIMENTAL_FORTIO_PEDANTIC:
+    return std::make_unique<Client::FortioPedanticOutputFormatterImpl>();
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }


### PR DESCRIPTION
I forgot the last step, which is to actually teach the output
formatter factory when to construct the new formatter. Sorry!

- Amends a pre-existing test to avoid regression when adding new
output formats in the future
- Fix the issue, add the new proto enum option to the switch
statement.

Fixes #543

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>