### PR TITLE
Implement RemoteProcessImpl in terms of PerformNighthawkBenchmark()

### DIFF
--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
         "//include/nighthawk/common:base_includes",
         "//source/common:request_source_impl_lib",
         "//source/common:nighthawk_common_lib",
+        "//source/common:nighthawk_service_client_impl",
         "@envoy//source/common/common:random_generator_lib_with_external_headers",
         "@envoy//source/common/access_log:access_log_manager_lib_with_external_headers",
         "@envoy//source/common/api:api_lib_with_external_headers",

--- a/source/client/remote_process_impl.cc
+++ b/source/client/remote_process_impl.cc
@@ -9,6 +9,7 @@
 #include "api/client/options.pb.h"
 #include "api/client/output.pb.h"
 
+#include "common/nighthawk_service_client_impl.h"
 #include "common/uri_impl.h"
 
 #include "client/options_impl.h"
@@ -18,39 +19,23 @@ namespace Client {
 
 RemoteProcessImpl::RemoteProcessImpl(const Options& options,
                                      nighthawk::client::NighthawkService::Stub& stub)
-    : options_(options), stub_(stub) {}
+    : options_(options), service_client_(std::make_unique<NighthawkServiceClientImpl>()),
+      stub_(stub) {}
 
 bool RemoteProcessImpl::run(OutputCollector& collector) {
-  nighthawk::client::ExecutionRequest request;
-  nighthawk::client::ExecutionResponse response;
-  grpc::ClientContext context;
-  auto execution_stream = stub_.ExecutionStream(&context);
-
-  *request.mutable_start_request()->mutable_options() = *options_.toCommandLineOptions();
+  Nighthawk::Client::CommandLineOptionsPtr options = options_.toCommandLineOptions();
   // We don't forward the option that requests remote execution. Today,
   // nighthawk_service will ignore the option, but if someone ever changes that this
   // is probably desireable.
-  request.mutable_start_request()->mutable_options()->mutable_nighthawk_service()->Clear();
+  options->mutable_nighthawk_service()->Clear();
 
-  if (execution_stream->Write(request, {}) && execution_stream->Read(&response)) {
-    if (response.has_output()) {
-      collector.setOutput(response.output());
-    } else {
-      ENVOY_LOG(error, "Remote execution failed");
-    }
-    if (response.has_error_detail()) {
-      ENVOY_LOG(error, "have error detail: {}", response.error_detail().DebugString());
-    }
-    if (!execution_stream->WritesDone()) {
-      ENVOY_LOG(warn, "writeDone() failed");
-    } else {
-      auto status = execution_stream->Finish();
-      return status.ok();
-    }
-  } else {
-    ENVOY_LOG(error, "Failure while communicating with the remote service");
+  const absl::StatusOr<const nighthawk::client::ExecutionResponse> result =
+      service_client_->PerformNighthawkBenchmark(&stub_, *options);
+  if (result.ok()) {
+    collector.setOutput(result.value().output());
+    return true;
   }
-
+  ENVOY_LOG(error, "Remote execution failure: {}", result.status().message());
   return false;
 }
 

--- a/source/client/remote_process_impl.h
+++ b/source/client/remote_process_impl.h
@@ -3,6 +3,7 @@
 #include "nighthawk/client/options.h"
 #include "nighthawk/client/output_collector.h"
 #include "nighthawk/client/process.h"
+#include "nighthawk/common/nighthawk_service_client.h"
 
 #include "external/envoy/source/common/common/logger.h"
 
@@ -38,6 +39,7 @@ public:
 
 private:
   const Options& options_;
+  const std::unique_ptr<NighthawkServiceClient> service_client_;
   nighthawk::client::NighthawkService::Stub& stub_;
 };
 


### PR DESCRIPTION
Drop duplicated code, use the newer code that has better test
coverage plus handling for when multiple results would be received.
This also makes the newer code run with the pre-existing end-to-end testing
for this.

Fixes #496

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>