### PR TITLE
Use system time for scheduling.

### DIFF
--- a/include/nighthawk/common/factories.h
+++ b/include/nighthawk/common/factories.h
@@ -24,7 +24,7 @@ public:
                               const SequencerTarget& sequencer_target,
                               TerminationPredicatePtr&& termination_predicate,
                               Envoy::Stats::Scope& scope,
-                              const Envoy::MonotonicTime scheduled_starting_time) const PURE;
+                              const Envoy::SystemTime scheduled_starting_time) const PURE;
 };
 
 class StatisticFactory {
@@ -46,7 +46,7 @@ public:
   virtual ~TerminationPredicateFactory() = default;
   virtual TerminationPredicatePtr
   create(Envoy::TimeSource& time_source, Envoy::Stats::Scope& scope,
-         const Envoy::MonotonicTime scheduled_starting_time) const PURE;
+         const Envoy::SystemTime scheduled_starting_time) const PURE;
 };
 
 /**

--- a/source/client/client_worker_impl.cc
+++ b/source/client/client_worker_impl.cc
@@ -19,7 +19,7 @@ ClientWorkerImpl::ClientWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Ins
                                    const SequencerFactory& sequencer_factory,
                                    const RequestSourceFactory& request_generator_factory,
                                    Envoy::Stats::Store& store, const int worker_number,
-                                   const Envoy::MonotonicTime starting_time,
+                                   const Envoy::SystemTime starting_time,
                                    Envoy::Tracing::HttpTracerSharedPtr& http_tracer,
                                    const HardCodedWarmupStyle hardcoded_warmup_style)
     : WorkerImpl(api, tls, store),

--- a/source/client/client_worker_impl.h
+++ b/source/client/client_worker_impl.h
@@ -33,7 +33,7 @@ public:
                    const SequencerFactory& sequencer_factory,
                    const RequestSourceFactory& request_generator_factory,
                    Envoy::Stats::Store& store, const int worker_number,
-                   const Envoy::MonotonicTime starting_time,
+                   const Envoy::SystemTime starting_time,
                    Envoy::Tracing::HttpTracerSharedPtr& http_tracer,
                    const HardCodedWarmupStyle hardcoded_warmup_style);
   StatisticPtrMap statistics() const override;

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -63,10 +63,12 @@ BenchmarkClientPtr BenchmarkClientFactoryImpl::create(
 SequencerFactoryImpl::SequencerFactoryImpl(const Options& options)
     : OptionBasedFactoryImpl(options) {}
 
-SequencerPtr SequencerFactoryImpl::create(
-    Envoy::TimeSource& time_source, Envoy::Event::Dispatcher& dispatcher,
-    const SequencerTarget& sequencer_target, TerminationPredicatePtr&& termination_predicate,
-    Envoy::Stats::Scope& scope, const Envoy::MonotonicTime scheduled_starting_time) const {
+SequencerPtr SequencerFactoryImpl::create(Envoy::TimeSource& time_source,
+                                          Envoy::Event::Dispatcher& dispatcher,
+                                          const SequencerTarget& sequencer_target,
+                                          TerminationPredicatePtr&& termination_predicate,
+                                          Envoy::Stats::Scope& scope,
+                                          const Envoy::SystemTime scheduled_starting_time) const {
   StatisticFactoryImpl statistic_factory(options_);
   Frequency frequency(options_.requestsPerSecond());
   RateLimiterPtr rate_limiter = std::make_unique<ScheduledStartingRateLimiter>(
@@ -87,7 +89,7 @@ SequencerPtr SequencerFactoryImpl::create(
   return std::make_unique<SequencerImpl>(
       platform_util_, dispatcher, time_source, std::move(rate_limiter), sequencer_target,
       statistic_factory.create(), statistic_factory.create(), options_.sequencerIdleStrategy(),
-      std::move(termination_predicate), scope, scheduled_starting_time);
+      std::move(termination_predicate), scope);
 }
 
 StatisticFactoryImpl::StatisticFactoryImpl(const Options& options)
@@ -184,7 +186,7 @@ TerminationPredicateFactoryImpl::TerminationPredicateFactoryImpl(const Options& 
 
 TerminationPredicatePtr
 TerminationPredicateFactoryImpl::create(Envoy::TimeSource& time_source, Envoy::Stats::Scope& scope,
-                                        const Envoy::MonotonicTime scheduled_starting_time) const {
+                                        const Envoy::SystemTime scheduled_starting_time) const {
   // We'll always link a predicate which checks for requests to cancel.
   TerminationPredicatePtr root_predicate =
       std::make_unique<StatsCounterAbsoluteThresholdTerminationPredicateImpl>(

--- a/source/client/factories_impl.h
+++ b/source/client/factories_impl.h
@@ -41,7 +41,7 @@ public:
   SequencerPtr create(Envoy::TimeSource& time_source, Envoy::Event::Dispatcher& dispatcher,
                       const SequencerTarget& sequencer_target,
                       TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope,
-                      const Envoy::MonotonicTime scheduled_starting_time) const override;
+                      const Envoy::SystemTime scheduled_starting_time) const override;
 };
 
 class StatisticFactoryImpl : public OptionBasedFactoryImpl, public StatisticFactory {
@@ -73,7 +73,7 @@ class TerminationPredicateFactoryImpl : public OptionBasedFactoryImpl,
 public:
   TerminationPredicateFactoryImpl(const Options& options);
   TerminationPredicatePtr create(Envoy::TimeSource& time_source, Envoy::Stats::Scope& scope,
-                                 const Envoy::MonotonicTime scheduled_starting_time) const override;
+                                 const Envoy::SystemTime scheduled_starting_time) const override;
   TerminationPredicate* linkConfiguredPredicates(
       TerminationPredicate& last_predicate, const TerminationPredicateMap& predicates,
       const TerminationPredicate::Status termination_status, Envoy::Stats::Scope& scope) const;

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -177,7 +177,7 @@ void ProcessImpl::createWorkers(const uint32_t concurrency) {
   // TODO(oschaaf): Arguably, this ought to be the job of a rate limiter with awareness of the
   // global status quo, which we do not have right now. This has been noted in the
   // track-for-future issue.
-  const auto first_worker_start = time_system_.monotonicTime() + kMinimalWorkerDelay;
+  const auto first_worker_start = time_system_.systemTime() + kMinimalWorkerDelay;
   const double inter_worker_delay_usec =
       (1. / options_.requestsPerSecond()) * 1000000 / concurrency;
   int worker_number = 0;

--- a/source/common/cached_time_source_impl.h
+++ b/source/common/cached_time_source_impl.h
@@ -21,9 +21,9 @@ public:
   CachedTimeSourceImpl(Envoy::Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
 
   /**
-   * Calling this will trigger an assert.
+   * @return Envoy::SystemTime current system time.
    */
-  Envoy::SystemTime systemTime() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; };
+  Envoy::SystemTime systemTime() override { return dispatcher_.timeSource().systemTime(); };
 
   /**
    * @return Envoy::MonotonicTime cached monotonic time.

--- a/source/common/rate_limiter_impl.cc
+++ b/source/common/rate_limiter_impl.cc
@@ -53,16 +53,16 @@ void BurstingRateLimiter::releaseOne() {
 }
 
 ScheduledStartingRateLimiter::ScheduledStartingRateLimiter(
-    RateLimiterPtr&& rate_limiter, const Envoy::MonotonicTime scheduled_starting_time)
+    RateLimiterPtr&& rate_limiter, const Envoy::SystemTime scheduled_starting_time)
     : ForwardingRateLimiterImpl(std::move(rate_limiter)),
       scheduled_starting_time_(scheduled_starting_time) {
-  if (timeSource().monotonicTime() >= scheduled_starting_time_) {
+  if (timeSource().systemTime() >= scheduled_starting_time_) {
     ENVOY_LOG(error, "Scheduled starting time exceeded. This may cause unintended bursty traffic.");
   }
 }
 
 bool ScheduledStartingRateLimiter::tryAcquireOne() {
-  if (timeSource().monotonicTime() < scheduled_starting_time_) {
+  if (timeSource().systemTime() < scheduled_starting_time_) {
     aquisition_attempted_ = true;
     return false;
   }
@@ -76,7 +76,7 @@ bool ScheduledStartingRateLimiter::tryAcquireOne() {
 }
 
 void ScheduledStartingRateLimiter::releaseOne() {
-  if (timeSource().monotonicTime() < scheduled_starting_time_) {
+  if (timeSource().systemTime() < scheduled_starting_time_) {
     throw NighthawkException("Unexpected call to releaseOne()");
   }
   return rate_limiter_->releaseOne();

--- a/source/common/rate_limiter_impl.h
+++ b/source/common/rate_limiter_impl.h
@@ -124,12 +124,12 @@ public:
    * @param scheduled_starting_time The starting time
    */
   ScheduledStartingRateLimiter(RateLimiterPtr&& rate_limiter,
-                               const Envoy::MonotonicTime scheduled_starting_time);
+                               const Envoy::SystemTime scheduled_starting_time);
   bool tryAcquireOne() override;
   void releaseOne() override;
 
 private:
-  const Envoy::MonotonicTime scheduled_starting_time_;
+  const Envoy::SystemTime scheduled_starting_time_;
   bool aquisition_attempted_{false};
 };
 

--- a/source/common/sequencer_impl.cc
+++ b/source/common/sequencer_impl.cc
@@ -14,13 +14,12 @@ SequencerImpl::SequencerImpl(
     Envoy::TimeSource& time_source, RateLimiterPtr&& rate_limiter, SequencerTarget target,
     StatisticPtr&& latency_statistic, StatisticPtr&& blocked_statistic,
     nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions idle_strategy,
-    TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope,
-    const Envoy::MonotonicTime scheduled_starting_time)
+    TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope)
     : target_(std::move(target)), platform_util_(platform_util), dispatcher_(dispatcher),
       time_source_(time_source), rate_limiter_(std::move(rate_limiter)),
       latency_statistic_(std::move(latency_statistic)),
-      blocked_statistic_(std::move(blocked_statistic)), start_time_(scheduled_starting_time),
-      idle_strategy_(idle_strategy), termination_predicate_(std::move(termination_predicate)),
+      blocked_statistic_(std::move(blocked_statistic)), idle_strategy_(idle_strategy),
+      termination_predicate_(std::move(termination_predicate)),
       last_termination_status_(TerminationPredicate::Status::PROCEED),
       scope_(scope.createScope("sequencer.")),
       sequencer_stats_({ALL_SEQUENCER_STATS(POOL_COUNTER(*scope_))}) {
@@ -57,8 +56,7 @@ void SequencerImpl::stop(bool failed) {
   spin_timer_.reset();
   dispatcher_.exit();
   unblockAndUpdateStatisticIfNeeded(time_source_.monotonicTime());
-  const auto ran_for =
-      std::chrono::duration_cast<std::chrono::milliseconds>(last_event_time_ - start_time_);
+  const auto ran_for = std::chrono::duration_cast<std::chrono::milliseconds>(executionDuration());
   ENVOY_LOG(info,
             "Stopping after {} ms. Initiated: {} / Completed: {}. "
             "(Completion rate was {} per second.)",
@@ -106,6 +104,9 @@ void SequencerImpl::run(bool from_periodic_timer) {
   }
 
   while (rate_limiter_->tryAcquireOne()) {
+    if (!start_time_.has_value()) {
+      start_time_ = now;
+    }
     // The rate limiter says it's OK to proceed and call the target. Let's see if the target is OK
     // with that as well.
     const bool target_could_start = target_([this, now](bool, bool) {

--- a/source/common/sequencer_impl.cc
+++ b/source/common/sequencer_impl.cc
@@ -91,7 +91,7 @@ void SequencerImpl::run(bool from_periodic_timer) {
   // More importantly, it may help avoid a class of bugs that could be more serious, depending on
   // functionality (TOC/TOU).
   dispatcher_.updateApproximateMonotonicTime();
-  const auto now = last_event_time_ = time_source_.monotonicTime();
+  const auto now = time_source_.monotonicTime();
 
   last_termination_status_ = last_termination_status_ == TerminationPredicate::Status::PROCEED
                                  ? termination_predicate_->evaluateChain()
@@ -104,9 +104,6 @@ void SequencerImpl::run(bool from_periodic_timer) {
   }
 
   while (rate_limiter_->tryAcquireOne()) {
-    if (!start_time_.has_value()) {
-      start_time_ = now;
-    }
     // The rate limiter says it's OK to proceed and call the target. Let's see if the target is OK
     // with that as well.
     const bool target_could_start = target_([this, now](bool, bool) {

--- a/source/common/sequencer_impl.h
+++ b/source/common/sequencer_impl.h
@@ -47,8 +47,7 @@ public:
       Envoy::TimeSource& time_source, RateLimiterPtr&& rate_limiter, SequencerTarget target,
       StatisticPtr&& latency_statistic, StatisticPtr&& blocked_statistic,
       nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions idle_strategy,
-      TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope,
-      const Envoy::MonotonicTime scheduled_starting_time);
+      TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope);
 
   /**
    * Starts the Sequencer. Should be followed up with a call to waitForCompletion().
@@ -62,13 +61,12 @@ public:
   void waitForCompletion() override;
 
   std::chrono::nanoseconds executionDuration() const override {
-    return last_event_time_ - start_time_;
+    return last_event_time_ - start_time_.value_or(last_event_time_);
   }
 
   double completionsPerSecond() const override {
     const double usec =
-        std::chrono::duration_cast<std::chrono::microseconds>(last_event_time_ - start_time_)
-            .count();
+        std::chrono::duration_cast<std::chrono::microseconds>(executionDuration()).count();
 
     return usec == 0 ? 0 : ((targets_completed_ / usec) * 1000000);
   }
@@ -120,7 +118,7 @@ private:
   StatisticPtr blocked_statistic_;
   Envoy::Event::TimerPtr periodic_timer_;
   Envoy::Event::TimerPtr spin_timer_;
-  const Envoy::MonotonicTime start_time_;
+  absl::optional<Envoy::MonotonicTime> start_time_;
   Envoy::MonotonicTime last_event_time_;
   uint64_t targets_initiated_{0};
   uint64_t targets_completed_{0};

--- a/source/common/sequencer_impl.h
+++ b/source/common/sequencer_impl.h
@@ -60,9 +60,7 @@ public:
    */
   void waitForCompletion() override;
 
-  std::chrono::nanoseconds executionDuration() const override {
-    return last_event_time_ - start_time_.value_or(last_event_time_);
-  }
+  std::chrono::nanoseconds executionDuration() const override { return rate_limiter_->elapsed(); }
 
   double completionsPerSecond() const override {
     const double usec =
@@ -118,8 +116,6 @@ private:
   StatisticPtr blocked_statistic_;
   Envoy::Event::TimerPtr periodic_timer_;
   Envoy::Event::TimerPtr spin_timer_;
-  absl::optional<Envoy::MonotonicTime> start_time_;
-  Envoy::MonotonicTime last_event_time_;
   uint64_t targets_initiated_{0};
   uint64_t targets_completed_{0};
   bool running_{};

--- a/source/common/termination_predicate_impl.cc
+++ b/source/common/termination_predicate_impl.cc
@@ -16,8 +16,8 @@ TerminationPredicate::Status TerminationPredicateBaseImpl::evaluateChain() {
 }
 
 TerminationPredicate::Status DurationTerminationPredicateImpl::evaluate() {
-  return time_source_.monotonicTime() - start_ > duration_ ? TerminationPredicate::Status::TERMINATE
-                                                           : TerminationPredicate::Status::PROCEED;
+  return time_source_.systemTime() - start_ > duration_ ? TerminationPredicate::Status::TERMINATE
+                                                        : TerminationPredicate::Status::PROCEED;
 }
 
 TerminationPredicate::Status StatsCounterAbsoluteThresholdTerminationPredicateImpl::evaluate() {

--- a/source/common/termination_predicate_impl.h
+++ b/source/common/termination_predicate_impl.h
@@ -35,13 +35,13 @@ class DurationTerminationPredicateImpl : public TerminationPredicateBaseImpl {
 public:
   DurationTerminationPredicateImpl(Envoy::TimeSource& time_source,
                                    std::chrono::microseconds duration,
-                                   const Envoy::MonotonicTime start)
+                                   const Envoy::SystemTime start)
       : time_source_(time_source), start_(start), duration_(duration) {}
   TerminationPredicate::Status evaluate() override;
 
 private:
   Envoy::TimeSource& time_source_;
-  const Envoy::MonotonicTime start_;
+  const Envoy::SystemTime start_;
   std::chrono::microseconds duration_;
 };
 

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -118,7 +118,7 @@ TEST_F(ClientWorkerTest, BasicTest) {
   auto worker = std::make_unique<ClientWorkerImpl>(
       *api_, tls_, cluster_manager_ptr_, benchmark_client_factory_, termination_predicate_factory_,
       sequencer_factory_, request_generator_factory_, store_, worker_number,
-      time_system_.monotonicTime(), http_tracer_, ClientWorkerImpl::HardCodedWarmupStyle::ON);
+      time_system_.systemTime(), http_tracer_, ClientWorkerImpl::HardCodedWarmupStyle::ON);
 
   worker->start();
   worker->waitForCompletion();

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -92,7 +92,7 @@ public:
     };
     auto sequencer = factory.create(api_->timeSource(), dispatcher_, dummy_sequencer_target,
                                     std::make_unique<MockTerminationPredicate>(), stats_store_,
-                                    time_system.monotonicTime() + 10ms);
+                                    time_system.systemTime() + 10ms);
     EXPECT_NE(nullptr, sequencer.get());
   }
 };

--- a/test/mocks/common/mock_sequencer_factory.h
+++ b/test/mocks/common/mock_sequencer_factory.h
@@ -14,7 +14,7 @@ public:
                                           const SequencerTarget& sequencer_target,
                                           TerminationPredicatePtr&& termination_predicate,
                                           Envoy::Stats::Scope& scope,
-                                          const Envoy::MonotonicTime scheduled_starting_time));
+                                          const Envoy::SystemTime scheduled_starting_time));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_termination_predicate_factory.h
+++ b/test/mocks/common/mock_termination_predicate_factory.h
@@ -12,7 +12,7 @@ public:
   MOCK_CONST_METHOD3(create,
                      TerminationPredicatePtr(Envoy::TimeSource& time_source,
                                              Envoy::Stats::Scope& scope,
-                                             const Envoy::MonotonicTime scheduled_starting_time));
+                                             const Envoy::SystemTime scheduled_starting_time));
 };
 
 } // namespace Nighthawk

--- a/test/rate_limiter_test.cc
+++ b/test/rate_limiter_test.cc
@@ -75,8 +75,7 @@ TEST_F(RateLimiterTest, ScheduledStartingRateLimiterTest) {
   // scheduled delay. This should be business as usual from a functional perspective, but internally
   // this rate limiter specializes on this case to log a warning message, and we want to cover that.
   for (const bool starting_late : std::vector<bool>{false, true}) {
-    const Envoy::MonotonicTime scheduled_starting_time =
-        time_system.monotonicTime() + schedule_delay;
+    const Envoy::SystemTime scheduled_starting_time = time_system.systemTime() + schedule_delay;
     std::unique_ptr<MockRateLimiter> mock_rate_limiter = std::make_unique<MockRateLimiter>();
     MockRateLimiter& unsafe_mock_rate_limiter = *mock_rate_limiter;
     InSequence s;
@@ -95,7 +94,7 @@ TEST_F(RateLimiterTest, ScheduledStartingRateLimiterTest) {
     }
 
     // We should expect zero releases until it is time to start.
-    while (time_system.monotonicTime() < scheduled_starting_time) {
+    while (time_system.systemTime() < scheduled_starting_time) {
       EXPECT_FALSE(rate_limiter->tryAcquireOne());
       time_system.advanceTimeWait(1ms);
     }
@@ -108,8 +107,8 @@ TEST_F(RateLimiterTest, ScheduledStartingRateLimiterTest) {
 TEST_F(RateLimiterTest, ScheduledStartingRateLimiterTestBadArgs) {
   Envoy::Event::SimulatedTimeSystem time_system;
   // Verify we enforce future-only scheduling.
-  for (const auto timing : std::vector<Envoy::MonotonicTime>{time_system.monotonicTime(),
-                                                             time_system.monotonicTime() - 10ms}) {
+  for (const auto timing :
+       std::vector<Envoy::SystemTime>{time_system.systemTime(), time_system.systemTime() - 10ms}) {
     std::unique_ptr<MockRateLimiter> mock_rate_limiter = std::make_unique<MockRateLimiter>();
     MockRateLimiter& unsafe_mock_rate_limiter = *mock_rate_limiter;
     EXPECT_CALL(unsafe_mock_rate_limiter, timeSource)

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -165,7 +165,7 @@ TEST_F(SequencerTestWithTimerEmulation, RateLimiterInteraction) {
   SequencerImpl sequencer(platform_util_, *dispatcher_, time_system_, std::move(rate_limiter_),
                           callback, std::make_unique<StreamingStatistic>(),
                           std::make_unique<StreamingStatistic>(), SequencerIdleStrategy::SLEEP,
-                          std::move(termination_predicate_), store_, time_system_.monotonicTime());
+                          std::move(termination_predicate_), store_);
   // Have the mock rate limiter gate two calls, and block everything else.
   EXPECT_CALL(rate_limiter_unsafe_ref_, tryAcquireOne())
       .Times(AtLeast(3))
@@ -186,7 +186,7 @@ TEST_F(SequencerTestWithTimerEmulation, RateLimiterSaturatedTargetInteraction) {
   SequencerImpl sequencer(platform_util_, *dispatcher_, time_system_, std::move(rate_limiter_),
                           callback, std::make_unique<StreamingStatistic>(),
                           std::make_unique<StreamingStatistic>(), SequencerIdleStrategy::SLEEP,
-                          std::move(termination_predicate_), store_, time_system_.monotonicTime());
+                          std::move(termination_predicate_), store_);
 
   EXPECT_CALL(rate_limiter_unsafe_ref_, tryAcquireOne())
       .Times(AtLeast(3))
@@ -224,10 +224,10 @@ public:
   std::unique_ptr<LinearRateLimiter> rate_limiter_;
 
   void testRegularFlow(SequencerIdleStrategy::SequencerIdleStrategyOptions idle_strategy) {
-    SequencerImpl sequencer(
-        platform_util_, *dispatcher_, time_system_, std::move(rate_limiter_), sequencer_target_,
-        std::make_unique<StreamingStatistic>(), std::make_unique<StreamingStatistic>(),
-        idle_strategy, std::move(termination_predicate_), store_, time_system_.monotonicTime());
+    SequencerImpl sequencer(platform_util_, *dispatcher_, time_system_, std::move(rate_limiter_),
+                            sequencer_target_, std::make_unique<StreamingStatistic>(),
+                            std::make_unique<StreamingStatistic>(), idle_strategy,
+                            std::move(termination_predicate_), store_);
     EXPECT_EQ(0, callback_test_count_);
     EXPECT_EQ(0, sequencer.latencyStatistic().count());
     sequencer.start();
@@ -265,7 +265,7 @@ TEST_F(SequencerIntegrationTest, AlwaysSaturatedTargetTest) {
   SequencerImpl sequencer(platform_util_, *dispatcher_, time_system_, std::move(rate_limiter_),
                           callback, std::make_unique<StreamingStatistic>(),
                           std::make_unique<StreamingStatistic>(), SequencerIdleStrategy::SLEEP,
-                          std::move(termination_predicate_), store_, time_system_.monotonicTime());
+                          std::move(termination_predicate_), store_);
   EXPECT_CALL(platform_util_, sleep(_)).Times(AtLeast(1));
   sequencer.start();
   sequencer.waitForCompletion();
@@ -283,7 +283,7 @@ TEST_F(SequencerIntegrationTest, CallbacksDoNotInfluenceTestDuration) {
   SequencerImpl sequencer(platform_util_, *dispatcher_, time_system_, std::move(rate_limiter_),
                           callback, std::make_unique<StreamingStatistic>(),
                           std::make_unique<StreamingStatistic>(), SequencerIdleStrategy::SLEEP,
-                          std::move(termination_predicate_), store_, time_system_.monotonicTime());
+                          std::move(termination_predicate_), store_);
   EXPECT_CALL(platform_util_, sleep(_)).Times(AtLeast(1));
   auto pre_timeout = time_system_.monotonicTime();
   sequencer.start();

--- a/test/termination_predicate_test.cc
+++ b/test/termination_predicate_test.cc
@@ -25,7 +25,7 @@ public:
 
 TEST_F(TerminationPredicateTest, DurationTerminationPredicateImplTest) {
   const auto duration = 100us;
-  DurationTerminationPredicateImpl pred(time_system, duration, time_system.monotonicTime());
+  DurationTerminationPredicateImpl pred(time_system, duration, time_system.systemTime());
   EXPECT_EQ(pred.evaluate(), TerminationPredicate::Status::PROCEED);
   // move to the edge.
   time_system.advanceTimeWait(duration);


### PR DESCRIPTION
Small refactor that makes the client rely on system time instead of monotonic time
for scheduling the start of worker executions. System clocks can be synchronized
across machines, and this may come in handy when we start facilitating horizontal
scaling. 

Note: `SequencerImpl` gets modified to re-use the execution duration that the `RateLimiter`
it uses already tracks, in favour of its own tracking. This is a small clean up.

Apart from the actual switching from monotonic time to wall clock time, this should be a
mechanical change. 

This change will make things easier if we would like to add an option to schedule the time at
which an execution will start. 
This in turn could be useful when directing clients running on multiple machines to start, as a
means to have them start at approximately the same time. 
(the approximation would mostly depend on how well the wall clock time is synchronised across
machines that are involved).

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>