### PR TITLE
Update Envoy & HdrHistogram_c

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,7 +27,8 @@ build --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --enable_platform_specific_config
 
-# Enable position independent code, this option is not supported on Windows and default on on macOS.
+# Enable position independent code (this is the default on macOS and Windows)
+# (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
 build:linux --copt=-fPIC
 build:linux --cxxopt=-std=c++17
 build:linux --conlyopt=-fexceptions
@@ -117,7 +118,8 @@ build:libc++ --config=clang
 build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:libc++ --action_env=LDFLAGS=-stdlib=libc++
 build:libc++ --action_env=BAZEL_CXXOPTS=-stdlib=libc++
-build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a:-lm
+build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
+build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-pthread
 build:libc++ --define force_libcpp=enabled
 
 # Optimize build for binary size reduction.
@@ -199,6 +201,8 @@ build:remote --spawn_strategy=remote,sandboxed,local
 build:remote --strategy=Javac=remote,sandboxed,local
 build:remote --strategy=Closure=remote,sandboxed,local
 build:remote --strategy=Genrule=remote,sandboxed,local
+# rules_rust is not remote runnable (yet)
+build:remote --strategy=Rustc=sandboxed,local
 build:remote --remote_timeout=7200
 build:remote --auth_enabled=true
 build:remote --remote_download_toplevel
@@ -235,7 +239,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:1526786b8f5cfce7a40829a0c527b5a27570889c
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:b480535e8423b5fd7c102fd30c92f4785519e33a
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
@@ -292,27 +296,27 @@ build:windows --define signal_trace=disabled
 build:windows --define hot_restart=disabled
 build:windows --define tcmalloc=disabled
 build:windows --define manual_stamp=manual_stamp
+build:windows --cxxopt="/std:c++17"
 
-# Should not be required after upstream fix to bazel,
-# and already a no-op to linux/macos builds
-# see issue https://github.com/bazelbuild/rules_foreign_cc/issues/301
+# TODO(wrowe,sunjayBhatia): Resolve bugs upstream in curl and rules_foreign_cc
+# See issue https://github.com/bazelbuild/rules_foreign_cc/issues/301
 build:windows --copt="-DCARES_STATICLIB"
 build:windows --copt="-DNGHTTP2_STATICLIB"
 build:windows --copt="-DCURL_STATICLIB"
-build:windows --cxxopt="/std:c++17"
 
-# Required to work around build defects on Windows MSVC cl
-# Unguarded gcc pragmas in quiche are not recognized by MSVC
-build:msvc-cl --copt="/wd4068"
-# Allows 'nodiscard' function return values to be discarded
-build:msvc-cl --copt="/wd4834"
-# Allows inline functions to be undefined
-build:msvc-cl --copt="/wd4506"
-build:msvc-cl --copt="-D_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING"
+# Override any clang preference if building msvc-cl
+# Drop the determinism feature (-DDATE etc are a no-op in msvc-cl)
+build:msvc-cl --action_env=USE_CLANG_CL=""
+build:msvc-cl --define clang_cl=0
+build:msvc-cl --features=-determinism
+
+# Windows build behaviors when using clang-cl
+build:clang-cl --action_env=USE_CLANG_CL=1
+build:clang-cl --define clang_cl=1
 
 # Required to work around Windows clang-cl build defects
 # Ignore conflicting definitions of _WIN32_WINNT
-# Overriding __TIME__ etc is problematic (and is actually an invalid no-op)
+# Override determinism flags (DATE etc) is valid on clang-cl compiler
 build:clang-cl --copt="-Wno-macro-redefined"
 build:clang-cl --copt="-Wno-builtin-macro-redefined"
 build:clang-cl --action_env=USE_CLANG_CL=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
-  envoy-build-image: &envoy-build-image # October 2nd, 2020
-    envoyproxy/envoy-build-ubuntu:1526786b8f5cfce7a40829a0c527b5a27570889c
+  envoy-build-image: &envoy-build-image # October 12th, 2020
+    envoyproxy/envoy-build-ubuntu:b480535e8423b5fd7c102fd30c92f4785519e33a
 version: 2
 jobs:
   build:

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,10 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "c318156496edc46c844822a3d1f107ee496fa449"  # October 2nd, 2020
-ENVOY_SHA = "dc4ee70d317f0310b96cb803a5c02b42589f5d1dfbfb2989f4bf72800aaa799a"
+ENVOY_COMMIT = "2097fe908f2abb718757dbd4087d793c861d7c5a"  # October 12th, 2020
+ENVOY_SHA = "323360544ee355f0eddea742b31a80a94899090db1d64029cd22880083b311c0"
 
-HDR_HISTOGRAM_C_VERSION = "0.11.1"  # September 17th, 2020
-HDR_HISTOGRAM_C_SHA = "8550071d4ae5c8229448f9b68469d6d42c620cd25111b49c696d00185e5f8329"
+HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
+HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"
 
 def nighthawk_dependencies():
     http_archive(

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -67,6 +67,7 @@ bazel test \
   --compilation_mode=opt \
   --cxxopt=-g \
   --cxxopt=-ggdb3 \
+  --define tcmalloc=gperftools \
   //benchmarks:*
 ```
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -127,6 +127,7 @@ function do_benchmark_with_own_binaries() {
         --compilation_mode=opt \
         --cxxopt=-g \
         --cxxopt=-ggdb3 \
+        --define tcmalloc=gperftools \
         //benchmarks:*
 }
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -24,8 +24,8 @@ function do_build () {
 }
 
 function do_opt_build () {
-    bazel build $BAZEL_BUILD_OPTIONS -c opt //:nighthawk
-    bazel build $BAZEL_BUILD_OPTIONS -c opt //benchmarks:benchmarks
+    bazel build $BAZEL_BUILD_OPTIONS -c opt --define tcmalloc=gperftools //:nighthawk
+    bazel build $BAZEL_BUILD_OPTIONS -c opt --define tcmalloc=gperftools //benchmarks:benchmarks
 }
 
 function do_test() {

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -36,12 +36,23 @@ function exclude_win32_impl() {
 # Do not run clang-tidy against macOS impl
 # TODO: We should run clang-tidy against macOS impl for completeness
 function exclude_macos_impl() {
-  grep -v source/common/filesystem/kqueue/
+  grep -v source/common/filesystem/kqueue/ | grep -v source/common/network/apple_dns_impl | grep -v test/common/network/apple_dns_impl_test
 }
 
 # Do not run incremental clang-tidy on check_format testdata files.
-function exclude_testdata() {
+function exclude_check_format_testdata() {
   grep -v tools/testdata/check_format/
+}
+
+# Do not run clang-tidy on envoy_headersplit testdata files.
+function exclude_headersplit_testdata() {
+  grep -v tools/envoy_headersplit/
+}
+
+# Do not run clang-tidy against Chromium URL import, this needs to largely
+# reflect the upstream structure.
+function exclude_chromium_url() {
+  grep -v source/common/chromium_url/
 }
 
 # Exclude files in third_party which are temporary forks from other OSS projects.
@@ -49,28 +60,48 @@ function exclude_third_party() {
   grep -v third_party/
 }
 
+# Exclude files which are part of the Wasm emscripten environment
+function exclude_wasm_emscripten() {
+  grep -v source/extensions/common/wasm/ext
+}
+
+# Exclude files which are part of the Wasm SDK
+function exclude_wasm_sdk() {
+  grep -v proxy_wasm_cpp_sdk
+}
+
+# Exclude files which are part of the Wasm Host environment
+function exclude_wasm_host() {
+  grep -v proxy_wasm_cpp_host
+}
+
+# Exclude proxy-wasm test_data.
+function exclude_wasm_test_data() {
+  grep -v wasm/test_data
+}
+
 function filter_excludes() {
-  exclude_testdata | exclude_win32_impl | exclude_macos_impl | exclude_third_party
+  exclude_check_format_testdata | exclude_headersplit_testdata | exclude_chromium_url | exclude_win32_impl | exclude_macos_impl | exclude_third_party | exclude_wasm_emscripten | exclude_wasm_sdk | exclude_wasm_host | exclude_wasm_test_data
 }
 
 function run_clang_tidy() {
   python3 "${LLVM_PREFIX}/share/clang/run-clang-tidy.py" \
-    -clang-tidy-binary=${CLANG_TIDY} -header-filter='-external' \
-    -clang-apply-replacements-binary=${CLANG_APPLY_REPLACEMENTS} \
-    -export-fixes=${FIX_YAML} -j ${NUM_CPUS:-0} -p ${SRCDIR} -quiet \
-    ${APPLY_CLANG_TIDY_FIXES:+-fix} $@
+    -clang-tidy-binary="${CLANG_TIDY}" \
+    -clang-apply-replacements-binary="${CLANG_APPLY_REPLACEMENTS}" \
+    -export-fixes=${FIX_YAML} -j "${NUM_CPUS:-0}" -p "${SRCDIR}" -quiet \
+    ${APPLY_CLANG_TIDY_FIXES:+-fix} "$@"
 }
 
 function run_clang_tidy_diff() {
-  git diff $1 | filter_excludes | \
+  git diff "$1" | filter_excludes | \
     python3 "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
-      -clang-tidy-binary=${CLANG_TIDY} \
-      -export-fixes=${FIX_YAML} -j ${NUM_CPUS:-0} -p 1 -quiet
+      -clang-tidy-binary="${CLANG_TIDY}" \
+      -export-fixes="${FIX_YAML}" -j "${NUM_CPUS:-0}" -p 1 -quiet
 }
 
 if [[ $# -gt 0 ]]; then
-  echo "Running clang-tidy on: $@"
-  run_clang_tidy $@
+  echo "Running clang-tidy on: $*"
+  run_clang_tidy "$@"
 elif [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
   echo "Running a full clang-tidy"
   run_clang_tidy
@@ -81,12 +112,13 @@ else
     elif [[ "${BUILD_REASON}" == *CI ]]; then
       DIFF_REF="HEAD^"
     else
-      DIFF_REF=$(${ENVOY_SRCDIR}/tools/git/last_github_commit.sh)
+      DIFF_REF=$("${ENVOY_SRCDIR}"/tools/git/last_github_commit.sh)
     fi
   fi
-  echo "Running clang-tidy-diff against ${DIFF_REF} ($(git rev-parse ${DIFF_REF})), current HEAD ($(git rev-parse HEAD))"
-  run_clang_tidy_diff ${DIFF_REF}
+  echo "Running clang-tidy-diff against ${DIFF_REF} ($(git rev-parse "${DIFF_REF}")), current HEAD ($(git rev-parse HEAD))"
+  run_clang_tidy_diff "${DIFF_REF}"
 fi
+
 
 if [[ -s "${FIX_YAML}" ]]; then
   echo "clang-tidy check failed, potentially fixed by clang-apply-replacements:"

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eo pipefail
+
 # ENVOY_SRCDIR should point to where Envoy source lives, while SRCDIR could be a downstream build
 # (for example envoy-filter-example).
 [[ -z "${ENVOY_SRCDIR}" ]] && ENVOY_SRCDIR="${PWD}"
@@ -119,9 +120,8 @@ else
   run_clang_tidy_diff "${DIFF_REF}"
 fi
 
-
 if [[ -s "${FIX_YAML}" ]]; then
   echo "clang-tidy check failed, potentially fixed by clang-apply-replacements:"
-  cat ${FIX_YAML}
+  cat "${FIX_YAML}"
   exit 1
 fi

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -71,8 +71,8 @@ public:
       const Envoy::Network::ConnectionSocket::OptionsSharedPtr& options,
       const Envoy::Network::TransportSocketOptionsSharedPtr& transport_socket_options) override {
     if (protocol == Envoy::Http::Protocol::Http11 || protocol == Envoy::Http::Protocol::Http10) {
-      auto* h1_pool =
-          new Http1PoolImpl(dispatcher, random_, host, priority, options, transport_socket_options);
+      auto* h1_pool = new Http1PoolImpl(dispatcher, api_.randomGenerator(), host, priority, options,
+                                        transport_socket_options);
       h1_pool->setConnectionReuseStrategy(connection_reuse_strategy_);
       h1_pool->setPrefetchConnections(prefetch_connections_);
       return Envoy::Http::ConnectionPool::InstancePtr{h1_pool};
@@ -471,7 +471,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
         std::make_unique<Envoy::Extensions::TransportSockets::Tls::ContextManagerImpl>(
             time_system_);
     cluster_manager_factory_ = std::make_unique<ClusterManagerFactory>(
-        admin_, Envoy::Runtime::LoaderSingleton::get(), store_root_, tls_, generator_,
+        admin_, Envoy::Runtime::LoaderSingleton::get(), store_root_, tls_,
         dispatcher_->createDnsResolver({}, false), *ssl_context_manager_, *dispatcher_,
         *local_info_, secret_manager_, validation_context_, *api_, http_context_, grpc_context_,
         access_log_manager_, *singleton_manager_);

--- a/test/rate_limiter_test.cc
+++ b/test/rate_limiter_test.cc
@@ -108,7 +108,7 @@ TEST_F(RateLimiterTest, ScheduledStartingRateLimiterTest) {
 TEST_F(RateLimiterTest, ScheduledStartingRateLimiterTestBadArgs) {
   Envoy::Event::SimulatedTimeSystem time_system;
   // Verify we enforce future-only scheduling.
-  for (const auto timing :
+  for (const auto& timing :
        std::vector<Envoy::SystemTime>{time_system.systemTime(), time_system.systemTime() - 10ms}) {
     std::unique_ptr<MockRateLimiter> mock_rate_limiter = std::make_unique<MockRateLimiter>();
     MockRateLimiter& unsafe_mock_rate_limiter = *mock_rate_limiter;


### PR DESCRIPTION
- Update Envoy to 2097fe908f2abb718757dbd4087d793c861d7c5a
- Update HdrHistogram_c to 0.11.2

Adds `--define tcmalloc=gperftools` to the opt build we use to push images,
to (continue to) allow cpu profiling. We need this because of https://github.com/envoyproxy/envoy/commit/4c0d2d2a36996f2ec7d00b519ea90068629a2c55

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>