### PR TITLE
CI: make clang-tidy always pass.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -34,6 +34,7 @@ function do_test() {
 }
 
 function do_clang_tidy() {
+    # TODO(#546): deflake clang tidy runs, and remove '|| true' here.
     ci/run_clang_tidy.sh || true
 }
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -34,7 +34,7 @@ function do_test() {
 }
 
 function do_clang_tidy() {
-    ci/run_clang_tidy.sh
+    ci/run_clang_tidy.sh || true
 }
 
 function do_unit_test_coverage() {


### PR DESCRIPTION
As discussed yesterday, make clang-tidy ignore failures to stop
the excessive flaking from being a blocker to merge.
This is meant as a temporary stop gap to buy us some time to dig
up the root cause.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>