### PR TITLE
Update Envoy to 8e6b176b89240d1b8ce3f3e4a8e276e4a40fcd1e

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -254,7 +254,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:b480535e8423b5fd7c102fd30c92f4785519e33a
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:19a268cfe3d12625380e7c61d2467c8779b58b56
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
-  envoy-build-image: &envoy-build-image # October 12th, 2020
-    envoyproxy/envoy-build-ubuntu:b480535e8423b5fd7c102fd30c92f4785519e33a
+  envoy-build-image: &envoy-build-image # November 10th, 2020
+    envoyproxy/envoy-build-ubuntu:19a268cfe3d12625380e7c61d2467c8779b58b56
 version: 2
 jobs:
   build:

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "0226d0e084d832ce24ee6303f5cb2fc01ec4970b"  # November 2nd, 2020
-ENVOY_SHA = "ed91cf0946155aac81c4601d55d81ba10d9189628259846c62f84fbe5a9059c0"
+ENVOY_COMMIT = "8e6b176b89240d1b8ce3f3e4a8e276e4a40fcd1e"  # November 10th, 2020
+ENVOY_SHA = "1eba9e904699bbc43c708f90c9e7b1354aed7bafe3784be2c6bfa04919cc67eb"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/flush_worker_impl.cc
+++ b/source/client/flush_worker_impl.cc
@@ -37,7 +37,7 @@ void FlushWorkerImpl::flushStats() {
   // Create a snapshot and flush to all sinks. Even if there are no sinks,
   // creating the snapshot has the important property that it latches all counters on a periodic
   // basis.
-  Envoy::Server::MetricSnapshotImpl snapshot(store_);
+  Envoy::Server::MetricSnapshotImpl snapshot(store_, time_source_);
   for (std::unique_ptr<Envoy::Stats::Sink>& sink : stats_sinks_) {
     sink->flush(snapshot);
   }

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -110,6 +110,7 @@ public:
         .WillByDefault(
             WithArgs<0>(([&called_headers](const Envoy::Http::RequestHeaderMap& specific_request) {
               called_headers.insert(getPathFromRequest(specific_request));
+              return Envoy::Http::Status();
             })));
 
     EXPECT_CALL(pool_, newStream(_, _))

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -26,7 +26,8 @@ public:
       : api_(Envoy::Api::createApiForTest(time_system_)),
         dispatcher_(api_->allocateDispatcher("test_thread")),
         request_headers_(std::make_shared<Envoy::Http::TestRequestHeaderMapImpl>(
-            std::initializer_list<std::pair<std::string, std::string>>({{":method", "GET"}}))),
+            std::initializer_list<std::pair<std::string, std::string>>(
+                {{":method", "GET"}, {":path", "/foo"}}))),
         http_tracer_(std::make_unique<Envoy::Tracing::HttpNullTracer>()),
         test_header_(std::make_unique<Envoy::Http::TestResponseHeaderMapImpl>(
             std::initializer_list<std::pair<std::string, std::string>>({{":status", "200"}}))),


### PR DESCRIPTION
- Handle return value of encodeHeaders() now that there is one.
- MetricSnapshotImpl now needs a TimeSource in its constructor.
- Avoid assert, use valid request header in StreamDecoderTest

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>