### PR TITLE
Fix integration tests when running with IPv6.

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -9,5 +9,8 @@ import pytest
 
 if __name__ == '__main__':
   path = os.path.dirname(os.path.realpath(__file__))
-  r = pytest.main(["--rootdir=" + path, "-x", path, "-p", "no:cacheprovider", *sys.argv])
+  r = pytest.main([
+      "--rootdir=" + path, "-x", path, "-p", "no:cacheprovider", "--log-level", "INFO",
+      "--log-cli-level", "INFO", *sys.argv
+  ])
   exit(r)

--- a/test/integration/integration_test.py
+++ b/test/integration/integration_test.py
@@ -22,7 +22,11 @@ if __name__ == '__main__':
           "-x",
           path,
           "-n",
-          "4" if utility.isSanitizerRun() else "20"  # Number of tests to run in parallel
+          "4" if utility.isSanitizerRun() else "20",  # Number of tests to run in parallel
+          "--log-level",
+          "INFO",
+          "--log-cli-level",
+          "INFO",
       ],
       plugins=["xdist"])
   exit(r)

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -75,7 +75,7 @@ class IntegrationTestBase():
     super(IntegrationTestBase, self).__init__()
     assert ip_version != IpVersion.UNKNOWN
     self.ip_version = ip_version
-    self.server_ip = "::/0" if ip_version == IpVersion.IPV6 else "0.0.0.0"
+    self.server_ip = "::" if ip_version == IpVersion.IPV6 else "0.0.0.0"
     self.server_ip = os.getenv("TEST_SERVER_EXTERNAL_IP", self.server_ip)
     self.tag = ""
     self.parameters = {}

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -124,8 +124,8 @@ class TestServerBase(object):
     logging.info("Test server popen() args: %s" % str.join(" ", args))
     self._server_process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = self._server_process.communicate()
-    logging.debug(stdout.decode("utf-8"))
-    logging.debug(stderr.decode("utf-8"))
+    logging.info("Process stdout: %s", stdout.decode("utf-8"))
+    logging.info("Process stderr: %s", stderr.decode("utf-8"))
 
   def fetchJsonFromAdminInterface(self, path):
     """Fetch and parse json from the admin interface.
@@ -183,13 +183,13 @@ class TestServerBase(object):
     return r.status_code == 200
 
   def _waitUntilServerListening(self):
-    # we allow 30 seconds for the server to have its listeners up.
+    # we allow some time for the server to have its listeners up.
     # (It seems that in sanitizer-enabled runs this can take a little while)
     timeout = time.time() + 60
     while time.time() < timeout:
       if self._tryUpdateFromAdminInterface():
         return True
-      time.sleep(0.1)
+      time.sleep(1)
     logging.error("Timeout in _waitUntilServerListening()")
     return False
 

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -189,7 +189,7 @@ class TestServerBase(object):
     while time.time() < timeout:
       if self._tryUpdateFromAdminInterface():
         return True
-      time.sleep(1)
+      time.sleep(0.1)
     logging.error("Timeout in _waitUntilServerListening()")
     return False
 

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -39,7 +39,7 @@ def test_http_h1(http_test_server_fixture):
   asserts.assertCounterEqual(counters, "upstream_cx_total", 1)
   asserts.assertCounterEqual(
       counters, "upstream_cx_tx_bytes_total",
-      1400 if http_test_server_fixture.ip_version == IpVersion.IPV6 else 1450)
+      1375 if http_test_server_fixture.ip_version == IpVersion.IPV6 else 1450)
   asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 1)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 1)
@@ -223,7 +223,7 @@ def test_https_h1(https_test_server_fixture):
   asserts.assertCounterEqual(counters, "upstream_cx_total", 1)
   asserts.assertCounterEqual(
       counters, "upstream_cx_tx_bytes_total",
-      1400 if https_test_server_fixture.ip_version == IpVersion.IPV6 else 1450)
+      1375 if https_test_server_fixture.ip_version == IpVersion.IPV6 else 1450)
   asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 1)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "ssl.ciphers.ECDHE-RSA-AES128-GCM-SHA256", 1)


### PR DESCRIPTION
We don't run integration tests in IPv6 mode on CI (See #578). As a result some of the test expectations became invalid.

Also:
- Pytest now displays more logging on test failures including the stderr and stdout of the started nighthawk test server.
- fixing the default IPv6 address, as per `man 3 inet_pton`, the address `::/0` isn't valid, while `::` is.

Signed-off-by: Jakub Sobon <mumak@google.com>