### PR TITLE
Migrating configs of integration tests to Envoy API v3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ any other value will allow client-side queuing of requests).
 Transport socket configuration in json or compact yaml. Mutually
 exclusive with --tls-context. Example (json):
 {name:"envoy.transport_sockets.tls"
-,typed_config:{"@type":"type.googleapis.com/envoy.extensions.transpor
-t_sockets.tls.v3.UpstreamTlsContext"
+,typed_config:{"@type":"type.googleapis.com/envoy.extensions.transport
+_sockets.tls.v3.UpstreamTlsContext"
 ,common_tls_context:{tls_params:{cipher_suites:["-ALL:ECDHE-RSA-AES128
 -SHA"]}}}}
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ any other value will allow client-side queuing of requests).
 Transport socket configuration in json or compact yaml. Mutually
 exclusive with --tls-context. Example (json):
 {name:"envoy.transport_sockets.tls"
-,typed_config:{"@type":"type.googleapis.com/envoy.api.v2.auth.Upstream
-TlsContext"
+,typed_config:{"@type":"type.googleapis.com/envoy.extensions.transpor
+t_sockets.tls.v3.UpstreamTlsContext"
 ,common_tls_context:{tls_params:{cipher_suites:["-ALL:ECDHE-RSA-AES128
 -SHA"]}}}}
 

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -144,7 +144,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "Transport socket configuration in json or compact yaml. "
       "Mutually exclusive with --tls-context. Example (json): "
       "{name:\"envoy.transport_sockets.tls\",typed_config:{"
-      "\"@type\":\"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext\","
+      "\"@type\":\"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\","
       "common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}}",
       false, "", "string", cmd);
 

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -144,7 +144,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "Transport socket configuration in json or compact yaml. "
       "Mutually exclusive with --tls-context. Example (json): "
       "{name:\"envoy.transport_sockets.tls\",typed_config:{"
-      "\"@type\":\"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\","
+      "\"@type\":\"type.googleapis.com/"
+      "envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\","
       "common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}}",
       false, "", "string", cmd);
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -106,6 +106,12 @@ py_library(
     deps = [":integration_test_base"],
 )
 
+py_library(
+    name = "test_request_source_plugin_lib",
+    srcs = ["test_request_source_plugin.py"],
+    deps = [":integration_test_base"],
+)
+
 py_binary(
     name = "integration_test",
     srcs = ["integration_test.py"],
@@ -122,5 +128,6 @@ py_binary(
         ":test_integration_zipkin_lib",
         ":test_output_transform_lib",
         ":test_remote_execution_lib",
+        ":test_request_source_plugin_lib",
     ],
 )

--- a/test/integration/configurations/nighthawk_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_http_origin.yaml
@@ -11,10 +11,11 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
-        config:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: false
-          codec_type: auto
+          codec_type: AUTO
           stat_prefix: ingress_http
           route_config:
             name: local_route
@@ -26,10 +27,12 @@ static_resources:
           - name: time-tracking
           - name: dynamic-delay
           - name: test-server
-            config:
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
               response_body_size: 10
               response_headers:
               - { header: { key: "x-nh", value: "1"}}
-          - name: envoy.router
-            config:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false

--- a/test/integration/configurations/nighthawk_https_origin.yaml
+++ b/test/integration/configurations/nighthawk_https_origin.yaml
@@ -11,10 +11,11 @@ static_resources:
           port_value: 0
       filter_chains:
         - filters:
-            - name: envoy.http_connection_manager
-              config:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                 generate_request_id: false
-                codec_type: auto
+                codec_type: AUTO
                 stat_prefix: ingress_http
                 route_config:
                   name: local_route
@@ -24,19 +25,24 @@ static_resources:
                         - "*"
                 http_filters:
                   - name: test-server
-                    config:
+                    typed_config:
+                      "@type": type.googleapis.com/nighthawk.server.ResponseOptions
                       response_body_size: 10
                       response_headers:
                         - { header: { key: "x-nh", value: "1" } }
-                  - name: envoy.router
-                    config:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                       dynamic_stats: false
-          tls_context:
-            common_tls_context:
-              tls_certificates:
-                - certificate_chain:
-                    inline_string: |
-                      @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/servercert.pem
-                  private_key:
-                    inline_string: |
-                      @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem
+          transport_socket:
+            name: tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              common_tls_context:
+                tls_certificates:
+                  - certificate_chain:
+                      inline_string: |
+                        @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/servercert.pem
+                    private_key:
+                      inline_string: |
+                        @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem

--- a/test/integration/configurations/nighthawk_track_timings.yaml
+++ b/test/integration/configurations/nighthawk_track_timings.yaml
@@ -14,10 +14,11 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
-        config:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: false
-          codec_type: auto
+          codec_type: AUTO
           stat_prefix: ingress_http
           route_config:
             name: local_route
@@ -28,11 +29,14 @@ static_resources:
           http_filters:
             # Here we set up the time-tracking extension to emit request-arrival delta timings in a response header.
           - name: time-tracking
-            config:
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
               emit_previous_request_delta_in_response_header: x-origin-request-receipt-delta
           - name: test-server
-            config:
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
               response_body_size: 10
-          - name: envoy.router
-            config:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false

--- a/test/integration/configurations/sni_origin.yaml
+++ b/test/integration/configurations/sni_origin.yaml
@@ -18,7 +18,7 @@ static_resources:
       transport_socket:
         name: envoy.transport_sockets.tls
         typed_config:
-          "@type": type.googleapis.com/envoy.api.v2.auth.DownstreamTlsContext
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           common_tls_context:
             tls_certificates:
               - certificate_chain:
@@ -36,7 +36,7 @@ static_resources:
       transport_socket:
         name: envoy.transport_sockets.tls
         typed_config:
-          "@type": type.googleapis.com/envoy.api.v2.auth.DownstreamTlsContext
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           common_tls_context:
             tls_certificates:
               - certificate_chain: 
@@ -46,10 +46,11 @@ static_resources:
                   inline_string: |
                     @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem
       filters:
-      - name: envoy.http_connection_manager
-        config:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: false
-          codec_type: auto
+          codec_type: AUTO
           stat_prefix: ingress_http
           route_config:
             name: local_route
@@ -59,18 +60,21 @@ static_resources:
               - "sni.com"
           http_filters:
           - name: test-server
-            config:
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
               response_body_size: 10
               response_headers:
               - { header: { key: "x-nh", value: "1"}}
-          - name: envoy.router
-            config:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
     - filters:
-      - name: envoy.http_connection_manager
-        config:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: false
-          codec_type: auto
+          codec_type: AUTO
           stat_prefix: ingress_http
           route_config:
             name: local_route
@@ -80,10 +84,12 @@ static_resources:
               - "*"
           http_filters:
           - name: test-server
-            config:
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
               response_body_size: 10
               response_headers:
               - { header: { key: "x-nh", value: "1"}}
-          - name: envoy.router
-            config:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -311,7 +311,7 @@ def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2)
   else:
     json_template = "%s%s%s" % (
         "{name:\"envoy.transport_sockets.tls\",typed_config:{",
-        "\"@type\":\"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext\",",
+        "\"@type\":\"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\",",
         "common_tls_context:{tls_params:{cipher_suites:[\"-ALL:%s\"]}}}}")
 
   for cipher in [

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -121,7 +121,8 @@ TEST_F(OptionsImplTest, AlmostAll) {
       "--latency-response-header-name zz",
       client_name_,
       "{name:\"envoy.transport_sockets.tls\","
-      "typed_config:{\"@type\":\"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\","
+      "typed_config:{\"@type\":\"type.googleapis.com/"
+      "envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\","
       "common_tls_context:{tls_params:{"
       "cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}}",
       good_test_uri_, sink_json_1, sink_json_2));
@@ -142,18 +143,19 @@ TEST_F(OptionsImplTest, AlmostAll) {
   const std::vector<std::string> expected_headers = {"f1:b1", "f2:b2", "f3:b3:b4"};
   EXPECT_EQ(expected_headers, options->requestHeaders());
   EXPECT_EQ(1234, options->requestBodySize());
-  EXPECT_EQ("name: \"envoy.transport_sockets.tls\"\n"
-            "typed_config {\n"
-            "  [type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext] {\n"
-            "    common_tls_context {\n"
-            "      tls_params {\n"
-            "        cipher_suites: \"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"\n"
-            "      }\n"
-            "    }\n"
-            "  }\n"
-            "}\n"
-            "183412668: \"envoy.api.v2.core.TransportSocket\"\n",
-            options->transportSocket().value().DebugString());
+  EXPECT_EQ(
+      "name: \"envoy.transport_sockets.tls\"\n"
+      "typed_config {\n"
+      "  [type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext] {\n"
+      "    common_tls_context {\n"
+      "      tls_params {\n"
+      "        cipher_suites: \"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"\n"
+      "      }\n"
+      "    }\n"
+      "  }\n"
+      "}\n"
+      "183412668: \"envoy.api.v2.core.TransportSocket\"\n",
+      options->transportSocket().value().DebugString());
   EXPECT_EQ(10, options->maxPendingRequests());
   EXPECT_EQ(11, options->maxActiveRequests());
   EXPECT_EQ(12, options->maxRequestsPerConnection());

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -121,7 +121,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
       "--latency-response-header-name zz",
       client_name_,
       "{name:\"envoy.transport_sockets.tls\","
-      "typed_config:{\"@type\":\"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext\","
+      "typed_config:{\"@type\":\"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\","
       "common_tls_context:{tls_params:{"
       "cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}}",
       good_test_uri_, sink_json_1, sink_json_2));
@@ -144,7 +144,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
   EXPECT_EQ(1234, options->requestBodySize());
   EXPECT_EQ("name: \"envoy.transport_sockets.tls\"\n"
             "typed_config {\n"
-            "  [type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext] {\n"
+            "  [type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext] {\n"
             "    common_tls_context {\n"
             "      tls_params {\n"
             "        cipher_suites: \"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"\n"


### PR DESCRIPTION
Verified that all integration tests pass after updating Envoy to commit `588d9344b31e6544869547c4bcd359b3b0f1d4cf`, so this PR unblocks #575. Our next steps will be adding a good warning and a compatibility flag for users of Nighthawk. If they do send configs with Envoy API v2, we will break by default, but allow them to continue with the compatibility flag.

Summary of performed changes:
- changing `config` to `typed_config` and listing the correct type.
- migrating from deprecated field `tls_context` to `transport_socket`.
- changing filter names to ones that match extension names in [extensions_build_config.bzl](https://github.com/envoyproxy/nighthawk/blob/master/extensions_build_config.bzl).
- cosmetic changes of enum value from `auto` to `AUTO`.

Also:
- updating README and help displayed by the CLI in regards to passing in the `--tls-context` flag since this behavior is mirrored by one of the edited integration tests.
- Adding the `test_request_source_plugin.py` integration test as a dependency of the `integration_test` py_binary which was forgotten before.

Works on #580

Signed-off-by: Jakub Sobon <mumak@google.com>