### PR TITLE
Add a flag to allow for continued use of the deprecated v2 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Where:
 
 --allow-envoy-deprecated-v2-api
 Set to allow usage of the v2 api. (Not recommended, support will stop
-soon). Default: false
+in Q1 2021). Default: false
 
 --latency-response-header-name <string>
 Set an optional header name that will be returned in responses, whose

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ bazel build -c opt //:nighthawk
 ```
 USAGE:
 
-bazel-bin/nighthawk_client  [--allow-v2-api]
+bazel-bin/nighthawk_client  [--allow-envoy-deprecated-v2-api]
 [--latency-response-header-name <string>]
 [--stats-flush-interval <uint32_t>]
 [--stats-sinks <string>] ...
@@ -84,8 +84,9 @@ format>
 
 Where:
 
---allow-v2-api
-Set to allow usage of the v2 api. (Not recommended). Default: false
+--allow-envoy-deprecated-v2-api
+Set to allow usage of the v2 api. (Not recommended, support will stop
+soon). Default: false
 
 --latency-response-header-name <string>
 Set an optional header name that will be returned in responses, whose

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ bazel build -c opt //:nighthawk
 ```
 USAGE:
 
-bazel-bin/nighthawk_client  [--latency-response-header-name <string>]
+bazel-bin/nighthawk_client  [--allow-v2-api]
+[--latency-response-header-name <string>]
 [--stats-flush-interval <uint32_t>]
 [--stats-sinks <string>] ...
 [--no-duration] [--simple-warmup]
@@ -82,6 +83,9 @@ format>
 
 
 Where:
+
+--allow-v2-api
+Set to allow usage of the v2 api. (Not recommended). Default: false
 
 --latency-response-header-name <string>
 Set an optional header name that will be returned in responses, whose

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -220,5 +220,5 @@ message CommandLineOptions {
   // arrivals.
   google.protobuf.StringValue latency_response_header_name = 36;
   // Set to allow usage of the v2 api (not recommended). Default is false.
-  google.protobuf.BoolValue allow_api_v2 = 38 [deprecated = true];
+  google.protobuf.BoolValue allow_envoy_deprecated_v2_api = 38 [deprecated = true];
 }

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -105,7 +105,7 @@ message H1ConnectionReuseStrategy {
 
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
-// highest unused number is 38
+// highest unused number is 39
 message CommandLineOptions {
   // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
@@ -219,4 +219,6 @@ message CommandLineOptions {
   // "emit_previous_request_delta_in_response_header" to record elapsed time between request
   // arrivals.
   google.protobuf.StringValue latency_response_header_name = 36;
+  // Set to allow usage of the v2 api (not recommended). Default is false.
+  google.protobuf.BoolValue allow_api_v2 = 38 [deprecated = true];
 }

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -219,6 +219,6 @@ message CommandLineOptions {
   // "emit_previous_request_delta_in_response_header" to record elapsed time between request
   // arrivals.
   google.protobuf.StringValue latency_response_header_name = 36;
-  // Set to allow usage of the v2 api (not recommended). Default is false.
+  // Set to allow usage of the v2 api. (Not recommended, support will stop in Q1 2021).
   google.protobuf.BoolValue allow_envoy_deprecated_v2_api = 38 [deprecated = true];
 }

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -74,6 +74,7 @@ public:
   virtual std::vector<envoy::config::metrics::v3::StatsSink> statsSinks() const PURE;
   virtual uint32_t statsFlushInterval() const PURE;
   virtual std::string responseHeaderWithLatencyInput() const PURE;
+  virtual bool allowApiV2() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -74,7 +74,7 @@ public:
   virtual std::vector<envoy::config::metrics::v3::StatsSink> statsSinks() const PURE;
   virtual uint32_t statsFlushInterval() const PURE;
   virtual std::string responseHeaderWithLatencyInput() const PURE;
-  virtual bool allowApiV2() const PURE;
+  virtual bool allowEnvoyDeprecatedV2Api() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -315,8 +315,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "Default: \"\"",
       false, "", "string", cmd);
 
-  TCLAP::SwitchArg allow_api_v2(
-      "", "allow-v2-api", "Set to allow usage of the v2 api. (Not recommended). Default: false",
+  TCLAP::SwitchArg allow_envoy_deprecated_v2_api(
+      "", "allow-envoy-deprecated-v2-api",
+      "Set to allow usage of the v2 api. (Not recommended, support will stop soon). Default: false",
       cmd);
 
   Utility::parseCommand(cmd, argc, argv);
@@ -451,7 +452,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   }
   TCLAP_SET_IF_SPECIFIED(stats_flush_interval, stats_flush_interval_);
   TCLAP_SET_IF_SPECIFIED(latency_response_header_name, latency_response_header_name_);
-  TCLAP_SET_IF_SPECIFIED(allow_api_v2, allow_api_v2_);
+  TCLAP_SET_IF_SPECIFIED(allow_envoy_deprecated_v2_api, allow_envoy_deprecated_v2_api_);
 
   // CLI-specific tests.
   // TODO(oschaaf): as per mergconflicts's remark, it would be nice to aggregate
@@ -657,7 +658,8 @@ OptionsImpl::OptionsImpl(const nighthawk::client::CommandLineOptions& options) {
   std::copy(options.labels().begin(), options.labels().end(), std::back_inserter(labels_));
   latency_response_header_name_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
       options, latency_response_header_name, latency_response_header_name_);
-  allow_api_v2_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(options, allow_api_v2, allow_api_v2_);
+  allow_envoy_deprecated_v2_api_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+      options, allow_envoy_deprecated_v2_api, allow_envoy_deprecated_v2_api_);
   validate();
 }
 
@@ -834,7 +836,8 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
   command_line_options->mutable_stats_flush_interval()->set_value(stats_flush_interval_);
   command_line_options->mutable_latency_response_header_name()->set_value(
       latency_response_header_name_);
-  command_line_options->mutable_allow_api_v2()->set_value(allow_api_v2_);
+  command_line_options->mutable_allow_envoy_deprecated_v2_api()->set_value(
+      allow_envoy_deprecated_v2_api_);
   return command_line_options;
 }
 

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -317,7 +317,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
 
   TCLAP::SwitchArg allow_envoy_deprecated_v2_api(
       "", "allow-envoy-deprecated-v2-api",
-      "Set to allow usage of the v2 api. (Not recommended, support will stop soon). Default: false",
+      "Set to allow usage of the v2 api. (Not recommended, support will stop in Q1 2021). Default: "
+      "false",
       cmd);
 
   Utility::parseCommand(cmd, argc, argv);

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -314,6 +314,10 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "Default: \"\"",
       false, "", "string", cmd);
 
+  TCLAP::SwitchArg allow_api_v2(
+      "", "allow-v2-api", "Set to allow usage of the v2 api. (Not recommended). Default: false",
+      cmd);
+
   Utility::parseCommand(cmd, argc, argv);
 
   // --duration and --no-duration are mutually exclusive
@@ -446,6 +450,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   }
   TCLAP_SET_IF_SPECIFIED(stats_flush_interval, stats_flush_interval_);
   TCLAP_SET_IF_SPECIFIED(latency_response_header_name, latency_response_header_name_);
+  TCLAP_SET_IF_SPECIFIED(allow_api_v2, allow_api_v2_);
 
   // CLI-specific tests.
   // TODO(oschaaf): as per mergconflicts's remark, it would be nice to aggregate
@@ -651,7 +656,7 @@ OptionsImpl::OptionsImpl(const nighthawk::client::CommandLineOptions& options) {
   std::copy(options.labels().begin(), options.labels().end(), std::back_inserter(labels_));
   latency_response_header_name_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
       options, latency_response_header_name, latency_response_header_name_);
-
+  allow_api_v2_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(options, allow_api_v2, allow_api_v2_);
   validate();
 }
 
@@ -828,6 +833,7 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
   command_line_options->mutable_stats_flush_interval()->set_value(stats_flush_interval_);
   command_line_options->mutable_latency_response_header_name()->set_value(
       latency_response_header_name_);
+  command_line_options->mutable_allow_api_v2()->set_value(allow_api_v2_);
   return command_line_options;
 }
 

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -93,6 +93,7 @@ public:
   std::string responseHeaderWithLatencyInput() const override {
     return latency_response_header_name_;
   };
+  bool allowApiV2() const override { return allow_api_v2_; }
 
 private:
   void parsePredicates(const TCLAP::MultiArg<std::string>& arg,
@@ -149,6 +150,7 @@ private:
   std::vector<envoy::config::metrics::v3::StatsSink> stats_sinks_;
   uint32_t stats_flush_interval_{5};
   std::string latency_response_header_name_;
+  bool allow_api_v2_{false};
 };
 
 } // namespace Client

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -93,7 +93,7 @@ public:
   std::string responseHeaderWithLatencyInput() const override {
     return latency_response_header_name_;
   };
-  bool allowApiV2() const override { return allow_api_v2_; }
+  bool allowEnvoyDeprecatedV2Api() const override { return allow_envoy_deprecated_v2_api_; }
 
 private:
   void parsePredicates(const TCLAP::MultiArg<std::string>& arg,
@@ -150,7 +150,7 @@ private:
   std::vector<envoy::config::metrics::v3::StatsSink> stats_sinks_;
   uint32_t stats_flush_interval_{5};
   std::string latency_response_header_name_;
-  bool allow_api_v2_{false};
+  bool allow_envoy_deprecated_v2_api_{false};
 };
 
 } // namespace Client

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -270,7 +270,7 @@ ProcessImpl::mergeWorkerStatistics(const std::vector<ClientWorkerPtr>& workers) 
   return merged_statistics;
 }
 
-void ProcessImpl::allowApiV2(envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+void ProcessImpl::allowEnvoyDeprecatedV2Api(envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
   auto* admin_layer = bootstrap.mutable_layered_runtime()->add_layers();
   admin_layer->set_name("admin layer");
   admin_layer->mutable_admin_layer();
@@ -286,9 +286,10 @@ void ProcessImpl::allowApiV2(envoy::config::bootstrap::v3::Bootstrap& bootstrap)
 void ProcessImpl::createBootstrapConfiguration(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                                                const std::vector<UriPtr>& uris,
                                                const UriPtr& request_source_uri,
-                                               int number_of_clusters, bool allow_api_v2) const {
-  if (allow_api_v2) {
-    allowApiV2(bootstrap);
+                                               int number_of_clusters,
+                                               bool allow_envoy_deprecated_v2_api) const {
+  if (allow_envoy_deprecated_v2_api) {
+    allowEnvoyDeprecatedV2Api(bootstrap);
   }
 
   for (int i = 0; i < number_of_clusters; i++) {
@@ -472,7 +473,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
     shutdown_ = false;
     envoy::config::bootstrap::v3::Bootstrap bootstrap;
     createBootstrapConfiguration(bootstrap, uris, request_source_uri, number_of_workers,
-                                 options_.allowApiV2());
+                                 options_.allowEnvoyDeprecatedV2Api());
     // Needs to happen as early as possible (before createWorkers()) in the instantiation to preempt
     // the objects that require stats.
     if (!options_.statsSinks().empty()) {

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -278,13 +278,9 @@ void ProcessImpl::allowApiV2(envoy::config::bootstrap::v3::Bootstrap& bootstrap)
       bootstrap.mutable_layered_runtime()->add_layers();
   runtime_layer->set_name("static_layer");
   Envoy::ProtobufWkt::Value proto_true;
-  proto_true.set_string_value(std::string("true"));
+  proto_true.set_string_value("true");
   (*runtime_layer->mutable_static_layer()
-        ->mutable_fields())[std::string("envoy.reloadable_features.enable_deprecated_v2_api")] =
-      proto_true;
-  (*runtime_layer->mutable_static_layer()
-        ->mutable_fields())[std::string("envoy.features.enable_all_deprecated_features")] =
-      proto_true;
+        ->mutable_fields())["envoy.reloadable_features.enable_deprecated_v2_api"] = proto_true;
 }
 
 void ProcessImpl::createBootstrapConfiguration(envoy::config::bootstrap::v3::Bootstrap& bootstrap,

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -270,10 +270,31 @@ ProcessImpl::mergeWorkerStatistics(const std::vector<ClientWorkerPtr>& workers) 
   return merged_statistics;
 }
 
+void ProcessImpl::allowApiV2(envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+  auto* admin_layer = bootstrap.mutable_layered_runtime()->add_layers();
+  admin_layer->set_name("admin layer");
+  admin_layer->mutable_admin_layer();
+  envoy::config::bootstrap::v3::RuntimeLayer* runtime_layer =
+      bootstrap.mutable_layered_runtime()->add_layers();
+  runtime_layer->set_name("static_layer");
+  Envoy::ProtobufWkt::Value proto_true;
+  proto_true.set_string_value(std::string("true"));
+  (*runtime_layer->mutable_static_layer()
+        ->mutable_fields())[std::string("envoy.reloadable_features.enable_deprecated_v2_api")] =
+      proto_true;
+  (*runtime_layer->mutable_static_layer()
+        ->mutable_fields())[std::string("envoy.features.enable_all_deprecated_features")] =
+      proto_true;
+}
+
 void ProcessImpl::createBootstrapConfiguration(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                                                const std::vector<UriPtr>& uris,
                                                const UriPtr& request_source_uri,
-                                               int number_of_clusters) const {
+                                               int number_of_clusters, bool allow_api_v2) const {
+  if (allow_api_v2) {
+    allowApiV2(bootstrap);
+  }
+
   for (int i = 0; i < number_of_clusters; i++) {
     auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
     RELEASE_ASSERT(!uris.empty(), "illegal configuration with zero endpoints");
@@ -454,7 +475,8 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
     int number_of_workers = determineConcurrency();
     shutdown_ = false;
     envoy::config::bootstrap::v3::Bootstrap bootstrap;
-    createBootstrapConfiguration(bootstrap, uris, request_source_uri, number_of_workers);
+    createBootstrapConfiguration(bootstrap, uris, request_source_uri, number_of_workers,
+                                 options_.allowApiV2());
     // Needs to happen as early as possible (before createWorkers()) in the instantiation to preempt
     // the objects that require stats.
     if (!options_.statsSinks().empty()) {
@@ -466,7 +488,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
     store_root_.initializeThreading(*dispatcher_, tls_);
     runtime_singleton_ = std::make_unique<Envoy::Runtime::ScopedLoaderSingleton>(
         Envoy::Runtime::LoaderPtr{new Envoy::Runtime::LoaderImpl(
-            *dispatcher_, tls_, {}, *local_info_, store_root_, generator_,
+            *dispatcher_, tls_, bootstrap.layered_runtime(), *local_info_, store_root_, generator_,
             Envoy::ProtobufMessage::getStrictValidationVisitor(), *api_)});
     ssl_context_manager_ =
         std::make_unique<Envoy::Extensions::TransportSockets::Tls::ContextManagerImpl>(

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -89,7 +89,7 @@ public:
    * @param bootstrap The bootstrap that should have it's runtime configuration
    * modified to allow for api v2 usage.
    */
-  static void allowApiV2(envoy::config::bootstrap::v3::Bootstrap& bootstrap);
+  static void allowEnvoyDeprecatedV2Api(envoy::config::bootstrap::v3::Bootstrap& bootstrap);
 
 private:
   /**
@@ -107,7 +107,7 @@ private:
   void createBootstrapConfiguration(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                                     const std::vector<UriPtr>& uris,
                                     const UriPtr& request_source_uri, int number_of_workers,
-                                    bool allow_api_v2) const;
+                                    bool allow_envoy_deprecated_v2_api) const;
   void maybeCreateTracingDriver(const envoy::config::trace::v3::Tracing& configuration);
   void configureComponentLogLevels(spdlog::level::level_enum level);
   /**

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -30,6 +30,7 @@
 #include "external/envoy/source/exe/process_wide.h"
 #include "external/envoy/source/extensions/transport_sockets/tls/context_manager_impl.h"
 #include "external/envoy/source/server/config_validation/admin.h"
+#include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
 
 #include "client/benchmark_client_impl.h"
 #include "client/factories_impl.h"
@@ -84,6 +85,12 @@ public:
 
   bool requestExecutionCancellation() override;
 
+  /**
+   * @param bootstrap The bootstrap that should have it's runtime configuration
+   * modified to allow for api v2 usage.
+   */
+  static void allowApiV2(envoy::config::bootstrap::v3::Bootstrap& bootstrap);
+
 private:
   /**
    * @brief Creates a cluster for usage by a remote request source.
@@ -99,9 +106,9 @@ private:
                                   const Uri& uri) const;
   void createBootstrapConfiguration(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                                     const std::vector<UriPtr>& uris,
-                                    const UriPtr& request_source_uri, int number_of_workers) const;
+                                    const UriPtr& request_source_uri, int number_of_workers,
+                                    bool allow_api_v2) const;
   void maybeCreateTracingDriver(const envoy::config::trace::v3::Tracing& configuration);
-
   void configureComponentLogLevels(spdlog::level::level_enum level);
   /**
    * Prepare the ProcessImpl instance by creating and configuring the workers it needs for execution

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -13,6 +13,7 @@ py_library(
     name = "integration_test_base",
     data = [
         "configurations/nighthawk_http_origin.yaml",
+        "configurations/nighthawk_http_origin_v2_api.yaml",
         "configurations/nighthawk_https_origin.yaml",
         "configurations/nighthawk_track_timings.yaml",
         "configurations/sni_origin.yaml",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -13,7 +13,7 @@ py_library(
     name = "integration_test_base",
     data = [
         "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_http_origin_v2_api.yaml",
+        "configurations/nighthawk_http_origin_envoy_deprecated_v2_api.yaml",
         "configurations/nighthawk_https_origin.yaml",
         "configurations/nighthawk_track_timings.yaml",
         "configurations/sni_origin.yaml",

--- a/test/integration/configurations/nighthawk_http_origin_envoy_deprecated_v2_api.yaml
+++ b/test/integration/configurations/nighthawk_http_origin_envoy_deprecated_v2_api.yaml
@@ -1,3 +1,4 @@
+# This file is intentionally using the v2 api: it is used to test support for that.
 admin:
   access_log_path: $tmpdir/nighthawk-test-server-admin-access.log
   profile_path: $tmpdir/nighthawk-test-server.prof

--- a/test/integration/configurations/nighthawk_http_origin_v2_api.yaml
+++ b/test/integration/configurations/nighthawk_http_origin_v2_api.yaml
@@ -36,4 +36,3 @@ layered_runtime:
     - name: static_layer
       static_layer:
         envoy.reloadable_features.enable_deprecated_v2_api: true
-        envoy.features.enable_all_deprecated_features: true

--- a/test/integration/configurations/nighthawk_http_origin_v2_api.yaml
+++ b/test/integration/configurations/nighthawk_http_origin_v2_api.yaml
@@ -1,0 +1,39 @@
+admin:
+  access_log_path: $tmpdir/nighthawk-test-server-admin-access.log
+  profile_path: $tmpdir/nighthawk-test-server.prof
+  address:
+    socket_address: { address: $server_ip, port_value: 0 }
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          generate_request_id: false
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: test-server
+            config:
+              response_body_size: 10
+              response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.router
+            config:
+              dynamic_stats: false
+layered_runtime:
+  layers:
+    - name: static_layer
+      static_layer:
+        envoy.reloadable_features.enable_deprecated_v2_api: true
+        envoy.features.enable_all_deprecated_features: true

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -301,7 +301,7 @@ class HttpIntegrationTestBase(IntegrationTestBase):
     return super(HttpIntegrationTestBase, self).getTestServerRootUri(False)
 
 
-class HttpIntegrationTestBaseWithV2Bootstrap(IntegrationTestBase):
+class HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap(IntegrationTestBase):
   """Base for running plain http tests against the Nighthawk test server.
 
   NOTE: any script that consumes derivations of this, needs to also explicitly
@@ -311,13 +311,13 @@ class HttpIntegrationTestBaseWithV2Bootstrap(IntegrationTestBase):
 
   def __init__(self, ip_version, server_config):
     """See base class."""
-    super(HttpIntegrationTestBaseWithV2Bootstrap, self).__init__(ip_version,
-                                                                 server_config,
-                                                                 bootstrap_version_arg="2")
+    super(HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap,
+          self).__init__(ip_version, server_config, bootstrap_version_arg="2")
 
   def getTestServerRootUri(self):
     """See base class."""
-    return super(HttpIntegrationTestBaseWithV2Bootstrap, self).getTestServerRootUri(False)
+    return super(HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap,
+                 self).getTestServerRootUri(False)
 
 
 class MultiServerHttpIntegrationTestBase(IntegrationTestBase):
@@ -402,13 +402,13 @@ def http_test_server_fixture(request, server_config):
 
 
 @pytest.fixture(params=determineIpVersionsFromEnvironment())
-def http_test_server_fixture_v2_api(request, server_config):
+def http_test_server_fixture_envoy_deprecated_v2_api(request, server_config):
   """Fixture for setting up a test environment with http server configuration that uses v2 configuration.
 
   Yields:
-      HttpIntegrationTestBaseWithV2Bootstrap: A fully set up instance. Tear down will happen automatically.
+      HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap: A fully set up instance. Tear down will happen automatically.
   """
-  f = HttpIntegrationTestBaseWithV2Bootstrap(request.param, server_config)
+  f = HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap(request.param, server_config)
   f.setUp()
   yield f
   f.tearDown()

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -63,7 +63,7 @@ class IntegrationTestBase():
       ip_version: a single IP mode that this instance will test: IpVersion.IPV4 or IpVersion.IPV6
       server_config: path to the server configuration
       backend_count: number of Nighthawk Test Server backends to run, to allow testing MultiTarget mode
-      bootstrap_version_arg: number of Nighthawk Test Server backends to run, to allow testing MultiTarget mode
+      bootstrap_version_arg: specify a bootstrap cli argument value for the test server binary.
     Attributes:
       ip_version: IP version that the proxy should use when listening.
       server_ip: string containing the server ip that will be used to listen

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -56,7 +56,7 @@ class IntegrationTestBase():
   This class will be refactored (https://github.com/envoyproxy/nighthawk/issues/258).
   """
 
-  def __init__(self, ip_version, server_config, backend_count=1, bootstrap_version_arg=0):
+  def __init__(self, ip_version, server_config, backend_count=1, bootstrap_version_arg=None):
     """Initialize the IntegrationTestBase instance.
 
     Args:

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -64,6 +64,7 @@ class IntegrationTestBase():
       server_config: path to the server configuration
       backend_count: number of Nighthawk Test Server backends to run, to allow testing MultiTarget mode
       bootstrap_version_arg: specify a bootstrap cli argument value for the test server binary.
+
     Attributes:
       ip_version: IP version that the proxy should use when listening.
       server_ip: string containing the server ip that will be used to listen

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -286,7 +286,7 @@ class IntegrationTestBase():
 class HttpIntegrationTestBase(IntegrationTestBase):
   """Base for running plain http tests against the Nighthawk test server.
 
-  NOTE: any script that consumes derivations of this, needs to needs also explictly
+  NOTE: any script that consumes derivations of this, needs to also explicitly
   import server_config, to avoid errors caused by the server_config not being found
   by pytest.
   """
@@ -303,7 +303,7 @@ class HttpIntegrationTestBase(IntegrationTestBase):
 class HttpIntegrationTestBaseWithV2Bootstrap(IntegrationTestBase):
   """Base for running plain http tests against the Nighthawk test server.
 
-  NOTE: any script that consumes derivations of this, needs to needs also explictly
+  NOTE: any script that consumes derivations of this, needs to also explicitly
   import server_config, to avoid errors caused by the server_config not being found
   by pytest.
   """

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -56,14 +56,14 @@ class IntegrationTestBase():
   This class will be refactored (https://github.com/envoyproxy/nighthawk/issues/258).
   """
 
-  def __init__(self, ip_version, server_config, backend_count=1, bootstrap_version_arg=None):
+  def __init__(self, ip_version, server_config, backend_count=1, bootstrap_version_arg=0):
     """Initialize the IntegrationTestBase instance.
 
     Args:
       ip_version: a single IP mode that this instance will test: IpVersion.IPV4 or IpVersion.IPV6
       server_config: path to the server configuration
       backend_count: number of Nighthawk Test Server backends to run, to allow testing MultiTarget mode
-      bootstrap_version_arg: specify a bootstrap cli argument value for the test server binary.
+      bootstrap_version_arg: An optional int, specify a bootstrap cli argument value for the test server binary. If None is specified, no bootstrap cli argment will be passed.
 
     Attributes:
       ip_version: IP version that the proxy should use when listening.
@@ -312,7 +312,7 @@ class HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap(IntegrationTestBase)
   def __init__(self, ip_version, server_config):
     """See base class."""
     super(HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap,
-          self).__init__(ip_version, server_config, bootstrap_version_arg="2")
+          self).__init__(ip_version, server_config, bootstrap_version_arg=2)
 
   def getTestServerRootUri(self):
     """See base class."""

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -133,7 +133,7 @@ class TestServerBase(object):
     if self._bootstrap_version_arg is not None:
       args = args + ["--bootstrap-version", self._bootstrap_version_arg]
 
-    logging.error("Test server popen() args: %s" % str.join(" ", args))
+    logging.info("Test server popen() args: %s" % str.join(" ", args))
     self._server_process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = self._server_process.communicate()
     logging.info("Process stdout: %s", stdout.decode("utf-8"))

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -59,7 +59,7 @@ class TestServerBase(object):
                server_binary_config_path_arg,
                parameters,
                tag,
-               bootstrap_version_arg=0):
+               bootstrap_version_arg=None):
     """Initialize a TestServerBase instance.
 
     Args:

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -59,7 +59,7 @@ class TestServerBase(object):
                server_binary_config_path_arg,
                parameters,
                tag,
-               bootstrap_version_arg=None):
+               bootstrap_version_arg=0):
     """Initialize a TestServerBase instance.
 
     Args:
@@ -70,7 +70,7 @@ class TestServerBase(object):
         server_binary_config_path_arg (str): Specify the name of the CLI argument the test server binary uses to accept a configuration path.
         parameters (dict): Supply to provide configuration template parameter replacement values.
         tag (str): Supply to get recognizeable output locations.
-        bootstrap_version_arg (str, optional): specify a bootstrap cli argument value for the test server binary.
+        bootstrap_version_arg (int, optional): specify a bootstrap cli argument value for the test server binary.
     """
     assert ip_version != IpVersion.UNKNOWN
     self.ip_version = ip_version
@@ -131,7 +131,7 @@ class TestServerBase(object):
         "--admin-address-path", self._admin_address_path, "--concurrency", "1"
     ]
     if self._bootstrap_version_arg is not None:
-      args = args + ["--bootstrap-version", self._bootstrap_version_arg]
+      args = args + ["--bootstrap-version", str(self._bootstrap_version_arg)]
 
     logging.info("Test server popen() args: %s" % str.join(" ", args))
     self._server_process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -130,7 +130,7 @@ class TestServerBase(object):
         self._parameterized_config_path, "-l", "debug", "--base-id", self._instance_id,
         "--admin-address-path", self._admin_address_path, "--concurrency", "1"
     ]
-    if not self._bootstrap_version_arg is None:
+    if self._bootstrap_version_arg is not None:
       args = args + ["--bootstrap-version", self._bootstrap_version_arg]
 
     logging.error("Test server popen() args: %s" % str.join(" ", args))

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -86,23 +86,26 @@ def test_nighthawk_client_v2_api_explicitly_set(http_test_server_fixture):
   """Test that the v2 api works when requested to."""
   parsed_json, _ = http_test_server_fixture.runNighthawkClient([
       http_test_server_fixture.getTestServerRootUri(), "--duration", "100",
-      "--termination-predicate", "benchmark.http_2xx:24", "--allow-v2-api", "--transport-socket",
-      "{name:\"envoy.transport_sockets.tls\",typed_config:{\"@type\":\"type.googleapis.com/envoy.config.transport_socket.raw_buffer.v2.RawBuffer\"}}"
+      "--termination-predicate", "benchmark.pool_connection_failure:0", "--failure-predicate",
+      "foo:1", "--allow-v2-api", "--transport-socket",
+      "{name:\"envoy.transport_sockets.tls\",typed_config:{\"@type\":\"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext\",\"common_tls_context\":{}}}"
   ])
 
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
+  asserts.assertCounterEqual(counters, "benchmark.pool_connection_failure", 1)
 
 
 # TODO(oschaaf): This ought to work after the Envoy update.
 def DISABLED_test_nighthawk_client_v2_api_breaks_by_default(http_test_server_fixture):
   """Test that the v2 api breaks us when it's not explicitly requested."""
-  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+  _, _ = http_test_server_fixture.runNighthawkClient([
       http_test_server_fixture.getTestServerRootUri(), "--duration", "100",
-      "--termination-predicate", "benchmark.http_2xx:24", "--transport-socket",
-      "{name:\"envoy.transport_sockets.tls\", typed_config:{\"@type\":\"type.googleapis.com/envoy.config.transport_socket.raw_buffer.v2.RawBuffer\"}}"
+      "--termination-predicate", "benchmark.pool_connection_failure:0", "--failure-predicate",
+      "foo:1", "--transport-socket",
+      "{name:\"envoy.transport_sockets.tls\",typed_config:{\"@type\":\"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext\",\"common_tls_context\":{}}}"
   ],
-                                                               expect_failure=True)
+                                                     expect_failure=True,
+                                                     as_json=False)
 
 
 def _mini_stress_test(fixture, args):

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -10,11 +10,10 @@ import time
 from threading import Thread
 
 from test.integration.common import IpVersion
-from test.integration.integration_test_fixtures import (http_test_server_fixture,
-                                                        https_test_server_fixture,
-                                                        multi_http_test_server_fixture,
-                                                        multi_https_test_server_fixture,
-                                                        server_config)
+from test.integration.integration_test_fixtures import (
+    http_test_server_fixture, http_test_server_fixture_v2_api, https_test_server_fixture,
+    https_test_server_fixture, multi_http_test_server_fixture, multi_https_test_server_fixture,
+    server_config)
 from test.integration import asserts
 from test.integration import utility
 
@@ -67,6 +66,43 @@ def test_http_h1(http_test_server_fixture):
       int(global_histograms["benchmark_http_client.response_header_size"]["raw_pstdev"]), 0)
 
   asserts.assertEqual(len(counters), 12)
+
+
+@pytest.mark.parametrize(
+    'server_config',
+    ["nighthawk/test/integration/configurations/nighthawk_http_origin_v2_api.yaml"])
+def test_nighthawk_test_server_v2_api(http_test_server_fixture_v2_api):
+  """Test that the v2 configuration works for the test server."""
+  parsed_json, _ = http_test_server_fixture_v2_api.runNighthawkClient([
+      http_test_server_fixture_v2_api.getTestServerRootUri(), "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:24"
+  ])
+
+  counters = http_test_server_fixture_v2_api.getNighthawkCounterMapFromJson(parsed_json)
+  asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
+
+
+def test_nighthawk_client_v2_api_explicitly_set(http_test_server_fixture):
+  """Test that the v2 api works when requested to."""
+  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+      http_test_server_fixture.getTestServerRootUri(), "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:24", "--allow-v2-api", "--transport-socket",
+      "{name:\"envoy.transport_sockets.tls\",typed_config:{\"@type\":\"type.googleapis.com/envoy.config.transport_socket.raw_buffer.v2.RawBuffer\"}}"
+  ])
+
+  counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
+  asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
+
+
+# TODO(oschaaf): This ought to work after the Envoy update.
+def DISABLED_test_nighthawk_client_v2_api_breaks_by_default(http_test_server_fixture):
+  """Test that the v2 api breaks us when it's not explicitly requested."""
+  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+      http_test_server_fixture.getTestServerRootUri(), "--duration", "100",
+      "--termination-predicate", "benchmark.http_2xx:24", "--transport-socket",
+      "{name:\"envoy.transport_sockets.tls\", typed_config:{\"@type\":\"type.googleapis.com/envoy.config.transport_socket.raw_buffer.v2.RawBuffer\"}}"
+  ],
+                                                               expect_failure=True)
 
 
 def _mini_stress_test(fixture, args):

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -11,9 +11,9 @@ from threading import Thread
 
 from test.integration.common import IpVersion
 from test.integration.integration_test_fixtures import (
-    http_test_server_fixture, http_test_server_fixture_v2_api, https_test_server_fixture,
-    https_test_server_fixture, multi_http_test_server_fixture, multi_https_test_server_fixture,
-    server_config)
+    http_test_server_fixture, http_test_server_fixture_envoy_deprecated_v2_api,
+    https_test_server_fixture, https_test_server_fixture, multi_http_test_server_fixture,
+    multi_https_test_server_fixture, server_config)
 from test.integration import asserts
 from test.integration import utility
 
@@ -68,17 +68,19 @@ def test_http_h1(http_test_server_fixture):
   asserts.assertEqual(len(counters), 12)
 
 
-@pytest.mark.parametrize(
-    'server_config',
-    ["nighthawk/test/integration/configurations/nighthawk_http_origin_v2_api.yaml"])
-def test_nighthawk_test_server_v2_api(http_test_server_fixture_v2_api):
+@pytest.mark.parametrize('server_config', [
+    "nighthawk/test/integration/configurations/nighthawk_http_origin_envoy_deprecated_v2_api.yaml"
+])
+def test_nighthawk_test_server_envoy_deprecated_v2_api(
+    http_test_server_fixture_envoy_deprecated_v2_api):
   """Test that the v2 configuration works for the test server."""
-  parsed_json, _ = http_test_server_fixture_v2_api.runNighthawkClient([
-      http_test_server_fixture_v2_api.getTestServerRootUri(), "--duration", "100",
+  parsed_json, _ = http_test_server_fixture_envoy_deprecated_v2_api.runNighthawkClient([
+      http_test_server_fixture_envoy_deprecated_v2_api.getTestServerRootUri(), "--duration", "100",
       "--termination-predicate", "benchmark.http_2xx:24"
   ])
 
-  counters = http_test_server_fixture_v2_api.getNighthawkCounterMapFromJson(parsed_json)
+  counters = http_test_server_fixture_envoy_deprecated_v2_api.getNighthawkCounterMapFromJson(
+      parsed_json)
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
 
 
@@ -87,7 +89,7 @@ def test_nighthawk_client_v2_api_explicitly_set(http_test_server_fixture):
   parsed_json, _ = http_test_server_fixture.runNighthawkClient([
       http_test_server_fixture.getTestServerRootUri(), "--duration", "100",
       "--termination-predicate", "benchmark.pool_connection_failure:0", "--failure-predicate",
-      "foo:1", "--allow-v2-api", "--transport-socket",
+      "foo:1", "--allow-envoy-deprecated-v2-api", "--transport-socket",
       "{name:\"envoy.transport_sockets.tls\",typed_config:{\"@type\":\"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext\",\"common_tls_context\":{}}}"
   ])
 

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -57,7 +57,7 @@ public:
   MOCK_CONST_METHOD0(statsSinks, std::vector<envoy::config::metrics::v3::StatsSink>());
   MOCK_CONST_METHOD0(statsFlushInterval, uint32_t());
   MOCK_CONST_METHOD0(responseHeaderWithLatencyInput, std::string());
-  MOCK_CONST_METHOD0(allowApiV2, bool());
+  MOCK_CONST_METHOD0(allowEnvoyDeprecatedV2Api, bool());
 };
 
 } // namespace Client

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -57,6 +57,7 @@ public:
   MOCK_CONST_METHOD0(statsSinks, std::vector<envoy::config::metrics::v3::StatsSink>());
   MOCK_CONST_METHOD0(statsFlushInterval, uint32_t());
   MOCK_CONST_METHOD0(responseHeaderWithLatencyInput, std::string());
+  MOCK_CONST_METHOD0(allowApiV2, bool());
 };
 
 } // namespace Client

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -118,7 +118,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
       "--experimental-h2-use-multiple-connections "
       "--experimental-h1-connection-reuse-strategy lru --label label1 --label label2 {} "
       "--simple-warmup --stats-sinks {} --stats-sinks {} --stats-flush-interval 10 "
-      "--latency-response-header-name zz --allow-v2-api",
+      "--latency-response-header-name zz --allow-envoy-deprecated-v2-api",
       client_name_,
       "{name:\"envoy.transport_sockets.tls\","
       "typed_config:{\"@type\":\"type.googleapis.com/"
@@ -193,7 +193,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
             "183412668: \"envoy.config.metrics.v2.StatsSink\"\n",
             options->statsSinks()[1].DebugString());
   EXPECT_EQ("zz", options->responseHeaderWithLatencyInput());
-  EXPECT_TRUE(options->allowApiV2());
+  EXPECT_TRUE(options->allowEnvoyDeprecatedV2Api());
 
   // Check that our conversion to CommandLineOptionsPtr makes sense.
   CommandLineOptionsPtr cmd = options->toCommandLineOptions();
@@ -252,8 +252,8 @@ TEST_F(OptionsImplTest, AlmostAll) {
   EXPECT_TRUE(util(cmd->stats_sinks(0), options->statsSinks()[0]));
   EXPECT_TRUE(util(cmd->stats_sinks(1), options->statsSinks()[1]));
   EXPECT_EQ(cmd->latency_response_header_name().value(), options->responseHeaderWithLatencyInput());
-  ASSERT_TRUE(cmd->has_allow_api_v2());
-  EXPECT_EQ(cmd->allow_api_v2().value(), options->allowApiV2());
+  ASSERT_TRUE(cmd->has_allow_envoy_deprecated_v2_api());
+  EXPECT_EQ(cmd->allow_envoy_deprecated_v2_api().value(), options->allowEnvoyDeprecatedV2Api());
   // TODO(#433) Here and below, replace comparisons once we choose a proto diff.
   OptionsImpl options_from_proto(*cmd);
   std::string s1 = Envoy::MessageUtil::getYamlStringFromMessage(
@@ -597,18 +597,20 @@ TEST_F(OptionsImplTest, PrefetchConnectionsFlag) {
                           MalformedArgvException, "Couldn't find match for argument");
 }
 
-TEST_F(OptionsImplTest, AllowApiV2Flag) {
+TEST_F(OptionsImplTest, AllowEnvoyDeprecatedV2ApiFlag) {
   EXPECT_FALSE(TestUtility::createOptionsImpl(fmt::format("{} {}", client_name_, good_test_uri_))
-                   ->allowApiV2());
-  EXPECT_TRUE(TestUtility::createOptionsImpl(
-                  fmt::format("{} --allow-v2-api {}", client_name_, good_test_uri_))
-                  ->allowApiV2());
-  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
-                              fmt::format("{} --allow-v2-api 0 {}", client_name_, good_test_uri_)),
-                          MalformedArgvException, "Couldn't find match for argument");
-  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format("{} --allow-v2-api true {}",
-                                                                     client_name_, good_test_uri_)),
-                          MalformedArgvException, "Couldn't find match for argument");
+                   ->allowEnvoyDeprecatedV2Api());
+  EXPECT_TRUE(TestUtility::createOptionsImpl(fmt::format("{} --allow-envoy-deprecated-v2-api {}",
+                                                         client_name_, good_test_uri_))
+                  ->allowEnvoyDeprecatedV2Api());
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(
+          fmt::format("{} --allow-envoy-deprecated-v2-api 0 {}", client_name_, good_test_uri_)),
+      MalformedArgvException, "Couldn't find match for argument");
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(
+          fmt::format("{} --allow-envoy-deprecated-v2-api true {}", client_name_, good_test_uri_)),
+      MalformedArgvException, "Couldn't find match for argument");
 }
 
 // Test --concurrency, which is a bit special. It's an int option, which also accepts 'auto' as

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -179,10 +179,10 @@ TEST_P(ProcessTest, NoFlushWhenCancelExecutionBeforeLoadTestBegin) {
   EXPECT_EQ(numFlushes, 0);
 }
 
-TEST(RuntimeConfiguration, allowApiV2) {
+TEST(RuntimeConfiguration, allowEnvoyDeprecatedV2Api) {
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   EXPECT_EQ(bootstrap.DebugString(), "");
-  ProcessImpl::allowApiV2(bootstrap);
+  ProcessImpl::allowEnvoyDeprecatedV2Api(bootstrap);
   std::cerr << bootstrap.DebugString() << std::endl;
   EXPECT_EQ(bootstrap.DebugString(), R"EOF(layered_runtime {
   layers {

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -183,7 +183,26 @@ TEST(RuntimeConfiguration, allowApiV2) {
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   EXPECT_EQ(bootstrap.DebugString(), "");
   ProcessImpl::allowApiV2(bootstrap);
-  EXPECT_NE(bootstrap.DebugString(), "");
+  std::cerr << bootstrap.DebugString() << std::endl;
+  EXPECT_EQ(bootstrap.DebugString(), R"EOF(layered_runtime {
+  layers {
+    name: "admin layer"
+    admin_layer {
+    }
+  }
+  layers {
+    name: "static_layer"
+    static_layer {
+      fields {
+        key: "envoy.reloadable_features.enable_deprecated_v2_api"
+        value {
+          string_value: "true"
+        }
+      }
+    }
+  }
+}
+)EOF");
 }
 
 } // namespace

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -7,6 +7,7 @@
 #include "external/envoy/test/test_common/network_utility.h"
 #include "external/envoy/test/test_common/registry.h"
 #include "external/envoy/test/test_common/utility.h"
+#include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
 
 #include "common/uri_impl.h"
 
@@ -176,6 +177,13 @@ TEST_P(ProcessTest, NoFlushWhenCancelExecutionBeforeLoadTestBegin) {
   numFlushes = 0;
   runProcess(RunExpectation::EXPECT_SUCCESS, true, true);
   EXPECT_EQ(numFlushes, 0);
+}
+
+TEST(RuntimeConfiguration, allowApiV2) {
+  envoy::config::bootstrap::v3::Bootstrap bootstrap;
+  EXPECT_EQ(bootstrap.DebugString(), "");
+  ProcessImpl::allowApiV2(bootstrap);
+  EXPECT_NE(bootstrap.DebugString(), "");
 }
 
 } // namespace


### PR DESCRIPTION
- Adds a new proto/cli option, which allows requesting continued use of the about to be deprecated v2 api's. 
- Adds a new fixture / integration test for the test server, as a sanity check for making sure that when we update Envoy to the 
  revision that deprecated v2 things will keep working as expected, while documenting how to set up the runtime configuration.
