### PR TITLE
Migrating config for benchmark tests to Envoy API v3.

### DIFF
--- a/benchmarks/configurations/envoy_proxy.yaml
+++ b/benchmarks/configurations/envoy_proxy.yaml
@@ -11,10 +11,11 @@ static_resources:
           port_value: 0
       filter_chains:
         - filters:
-            - name: envoy.http_connection_manager
-              config:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                 generate_request_id: false
-                codec_type: auto
+                codec_type: AUTO
                 stat_prefix: ingress_http
                 route_config:
                   name: local_route
@@ -28,15 +29,21 @@ static_resources:
                           route:
                             cluster: local_service
                 http_filters:
-                  - name: envoy.router
-                    config:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                       dynamic_stats: false
   clusters:
     - name: local_service
       connect_timeout: 0.25s
-      type: strict_dns
-      lb_policy: round_robin
-      hosts:
-        - socket_address:
-            address: $server_ip
-            port_value: $server_port
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: local_service
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: $server_ip
+                  port_value: $server_port


### PR DESCRIPTION
Verified the benchmark tests successfully load this configuration after updating Envoy to commit `588d9344b31e6544869547c4bcd359b3b0f1d4cf`.

Summary of performed changes:
- changing `config` to `typed_config` and listing the correct type.
- structural changes to update `clusters` stanza to `v3`.
- changing filter names to ones that match extension names in [extensions_build_config.bzl](https://github.com/envoyproxy/nighthawk/blob/master/extensions_build_config.bzl).
- cosmetic changes of enum values to uppercase form.

Works on #580

Signed-off-by: Jakub Sobon <mumak@google.com>