### PR TITLE
Deprecate Envoy API v2 primitives in configuration for our Envoy filters.

### DIFF
--- a/api/server/BUILD
+++ b/api/server/BUILD
@@ -13,5 +13,6 @@ api_cc_py_proto_library(
     srcs = ["response_options.proto"],
     deps = [
         "@envoy_api//envoy/api/v2/core:pkg",
+        "@envoy_api//envoy/config/core/v3:pkg",
     ],
 )

--- a/api/server/response_options.proto
+++ b/api/server/response_options.proto
@@ -2,10 +2,11 @@ syntax = "proto3";
 
 package nighthawk.server;
 
+import "envoy/api/v2/core/base.proto";
+import "envoy/config/core/v3/base.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 import "validate/validate.proto";
-import "envoy/api/v2/core/base.proto";
-import "google/protobuf/duration.proto";
 
 message ConcurrencyBasedLinearDelay {
   // Minimal delay to add to replies.
@@ -20,7 +21,15 @@ message ConcurrencyBasedLinearDelay {
 // configuration will override.
 message ResponseOptions {
   // List of additional response headers.
-  repeated envoy.api.v2.core.HeaderValueOption response_headers = 1;
+  //
+  // Envoy deprecated its v2 API, prefer to use v3_response_headers instead.
+  // Mutually exclusive with v3_response_headers.
+  repeated envoy.api.v2.core.HeaderValueOption response_headers = 1 [deprecated = true];
+
+  // List of additional response headers.
+  // Mutually exclusive with response_headers.
+  repeated envoy.config.core.v3.HeaderValueOption v3_response_headers = 7;
+
   // Number of 'a' characters in the the response body.
   uint32 response_body_size = 2 [(validate.rules).uint32 = {lte: 4194304}];
   // If true, then echo request headers in the response body.

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -37,6 +37,8 @@ envoy_cc_library(
         "@envoy//source/common/protobuf:message_validator_lib_with_external_headers",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//source/common/singleton:const_singleton_with_external_headers",
+        "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/server/configuration.cc
+++ b/source/server/configuration.cc
@@ -33,18 +33,20 @@ bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions&
 
 void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_headers,
                                   const nighthawk::server::ResponseOptions& response_options) {
+
+  // The validation guarantees we only get one of the fields (response_headers, v3_response_headers)
+  // set.
   validateResponseOptions(response_options);
   nighthawk::server::ResponseOptions v3_only_response_options = response_options;
-
-  // Validation above guarantees we only get one of the fields
-  // (response_headers, v3_response_headers) set.
-  for (const auto& header_value_option : v3_only_response_options.response_headers()) {
+  for (const envoy::api::v2::core::HeaderValueOption& header_value_option :
+       v3_only_response_options.response_headers()) {
     *v3_only_response_options.add_v3_response_headers() =
         upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(header_value_option);
   }
 
-  for (const auto& header_value_option : v3_only_response_options.v3_response_headers()) {
-    const auto& header = header_value_option.header();
+  for (const envoy::config::core::v3::HeaderValueOption& header_value_option :
+       v3_only_response_options.v3_response_headers()) {
+    const envoy::config::core::v3::HeaderValue& header = header_value_option.header();
     auto lower_case_key = Envoy::Http::LowerCaseString(header.key());
     if (!header_value_option.append().value()) {
       response_headers.remove(lower_case_key);

--- a/source/server/configuration.cc
+++ b/source/server/configuration.cc
@@ -2,6 +2,9 @@
 
 #include <string>
 
+#include "envoy/api/v2/core/base.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+
 #include "external/envoy/source/common/protobuf/message_validator_impl.h"
 #include "external/envoy/source/common/protobuf/utility.h"
 
@@ -38,6 +41,20 @@ void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_heade
     }
     response_headers.addCopy(lower_case_key, header.value());
   }
+}
+
+envoy::config::core::v3::HeaderValueOption upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(
+    const envoy::api::v2::core::HeaderValueOption& v2_header_value_option) {
+  envoy::config::core::v3::HeaderValueOption v3_header_value_option;
+  if (v2_header_value_option.has_append()) {
+    *v3_header_value_option.mutable_append() = v2_header_value_option.append();
+  }
+  if (v2_header_value_option.has_header()) {
+    envoy::config::core::v3::HeaderValue* v3_header = v3_header_value_option.mutable_header();
+    v3_header->set_key(v2_header_value_option.header().key());
+    v3_header->set_value(v2_header_value_option.header().value());
+  }
+  return v3_header_value_option;
 }
 
 } // namespace Configuration

--- a/source/server/configuration.h
+++ b/source/server/configuration.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "envoy/api/v2/core/base.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
 #include "envoy/http/header_map.h"
 
 #include "api/server/response_options.pb.h"
@@ -30,6 +32,14 @@ bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions&
  */
 void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_headers,
                                   const nighthawk::server::ResponseOptions& response_options);
+
+/**
+ * Upgrades Envoy's HeaderValueOption from the deprecated v2 API version to v3.
+ *
+ * @param v2_header_value_option The HeaderValueOption to be upgraded.
+ */
+envoy::config::core::v3::HeaderValueOption upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(
+    const envoy::api::v2::core::HeaderValueOption& v2_header_value_option);
 
 } // namespace Configuration
 } // namespace Server

--- a/source/server/configuration.h
+++ b/source/server/configuration.h
@@ -39,6 +39,7 @@ void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_heade
  * Upgrades Envoy's HeaderValueOption from the deprecated v2 API version to v3.
  *
  * @param v2_header_value_option The HeaderValueOption to be upgraded.
+ * @return a version of HeaderValueOption upgraded to Envoy API v3.
  */
 envoy::config::core::v3::HeaderValueOption upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(
     const envoy::api::v2::core::HeaderValueOption& v2_header_value_option);

--- a/source/server/configuration.h
+++ b/source/server/configuration.h
@@ -29,6 +29,8 @@ bool mergeJsonConfig(absl::string_view json, nighthawk::server::ResponseOptions&
  * @param response_headers Response headers to transform to reflect the passed in response
  * options.
  * @param response_options Configuration specifying how to transform the header map.
+ *
+ * @throws Envoy::EnvoyException if invalid response_options are provided.
  */
 void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_headers,
                                   const nighthawk::server::ResponseOptions& response_options);
@@ -40,6 +42,13 @@ void applyConfigToResponseHeaders(Envoy::Http::ResponseHeaderMap& response_heade
  */
 envoy::config::core::v3::HeaderValueOption upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(
     const envoy::api::v2::core::HeaderValueOption& v2_header_value_option);
+
+/**
+ * Validates the ResponseOptions.
+ *
+ * @throws Envoy::EnvoyException on validation errors.
+ */
+void validateResponseOptions(const nighthawk::server::ResponseOptions& response_options);
 
 } // namespace Configuration
 } // namespace Server

--- a/source/server/http_dynamic_delay_filter_config.cc
+++ b/source/server/http_dynamic_delay_filter_config.cc
@@ -7,6 +7,7 @@
 #include "api/server/response_options.pb.h"
 #include "api/server/response_options.pb.validate.h"
 
+#include "server/configuration.h"
 #include "server/http_dynamic_delay_filter.h"
 
 namespace Nighthawk {
@@ -22,10 +23,11 @@ public:
                                Envoy::Server::Configuration::FactoryContext& context) override {
 
     auto& validation_visitor = Envoy::ProtobufMessage::getStrictValidationVisitor();
-    return createFilter(
+    const nighthawk::server::ResponseOptions& response_options =
         Envoy::MessageUtil::downcastAndValidate<const nighthawk::server::ResponseOptions&>(
-            proto_config, validation_visitor),
-        context);
+            proto_config, validation_visitor);
+    validateResponseOptions(response_options);
+    return createFilter(response_options, context);
   }
 
   Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/server/http_test_server_filter_config.cc
+++ b/source/server/http_test_server_filter_config.cc
@@ -7,6 +7,7 @@
 #include "api/server/response_options.pb.h"
 #include "api/server/response_options.pb.validate.h"
 
+#include "server/configuration.h"
 #include "server/http_test_server_filter.h"
 
 namespace Nighthawk {
@@ -20,10 +21,11 @@ public:
   createFilterFactoryFromProto(const Envoy::Protobuf::Message& proto_config, const std::string&,
                                Envoy::Server::Configuration::FactoryContext& context) override {
     auto& validation_visitor = Envoy::ProtobufMessage::getStrictValidationVisitor();
-    return createFilter(
+    const nighthawk::server::ResponseOptions& response_options =
         Envoy::MessageUtil::downcastAndValidate<const nighthawk::server::ResponseOptions&>(
-            proto_config, validation_visitor),
-        context);
+            proto_config, validation_visitor);
+    validateResponseOptions(response_options);
+    return createFilter(response_options, context);
   }
 
   Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/server/http_test_server_filter_config.cc
+++ b/source/server/http_test_server_filter_config.cc
@@ -19,7 +19,6 @@ public:
   Envoy::Http::FilterFactoryCb
   createFilterFactoryFromProto(const Envoy::Protobuf::Message& proto_config, const std::string&,
                                Envoy::Server::Configuration::FactoryContext& context) override {
-
     auto& validation_visitor = Envoy::ProtobufMessage::getStrictValidationVisitor();
     return createFilter(
         Envoy::MessageUtil::downcastAndValidate<const nighthawk::server::ResponseOptions&>(

--- a/source/server/http_time_tracking_filter_config.cc
+++ b/source/server/http_time_tracking_filter_config.cc
@@ -7,6 +7,7 @@
 #include "api/server/response_options.pb.h"
 #include "api/server/response_options.pb.validate.h"
 
+#include "server/configuration.h"
 #include "server/http_time_tracking_filter.h"
 
 namespace Nighthawk {
@@ -21,10 +22,11 @@ public:
                                Envoy::Server::Configuration::FactoryContext& context) override {
     Envoy::ProtobufMessage::ValidationVisitor& validation_visitor =
         Envoy::ProtobufMessage::getStrictValidationVisitor();
-    return createFilter(
+    const nighthawk::server::ResponseOptions& response_options =
         Envoy::MessageUtil::downcastAndValidate<const nighthawk::server::ResponseOptions&>(
-            proto_config, validation_visitor),
-        context);
+            proto_config, validation_visitor);
+    validateResponseOptions(response_options);
+    return createFilter(response_options, context);
   }
 
   Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -71,7 +71,9 @@ envoy_cc_test(
     srcs = ["configuration_test.cc"],
     repository = "@envoy",
     deps = [
+        "//api/server:response_options_proto_cc_proto",
         "//source/server:configuration_lib",
+        "@envoy//test/test_common:utility_lib",
         "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -65,3 +65,14 @@ envoy_cc_test(
         "@envoy//test/test_common:simulated_time_system_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "configuration_test",
+    srcs = ["configuration_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/server:configuration_lib",
+        "@envoy_api//envoy/api/v2/core:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)

--- a/test/server/configuration_test.cc
+++ b/test/server/configuration_test.cc
@@ -1,6 +1,10 @@
 #include "envoy/api/v2/core/base.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 
+#include "external/envoy/test/test_common/utility.h"
+
+#include "api/server/response_options.pb.validate.h"
+
 #include "server/configuration.h"
 
 #include "gmock/gmock.h"
@@ -11,7 +15,8 @@ namespace Server {
 namespace Configuration {
 namespace {
 
-using ::testing::HasSubstr;
+using ::Envoy::Http::LowerCaseString;
+using ::Envoy::Http::TestResponseHeaderMapImpl;
 
 TEST(UpgradeDeprecatedEnvoyV2HeaderValueOptionToV3Test, UpgradesEmptyHeaderValue) {
   envoy::api::v2::core::HeaderValueOption v2_header_value_option;
@@ -58,6 +63,135 @@ TEST(UpgradeDeprecatedEnvoyV2HeaderValueOptionToV3Test, UpgradesHeaderValueWithA
 
   EXPECT_TRUE(v3_header_value_option.append().value());
   EXPECT_FALSE(v3_header_value_option.has_header());
+}
+
+// Specifies the Envoy API version to use in the test configuration.
+enum EnvoyApiVersion {
+  EnvoyApiV2,
+  EnvoyApiV3,
+};
+
+// Specifies if headers with duplicate key should be appended or replace the
+// previous header.
+enum HeaderAddMode {
+  ReplaceOnDuplicateKey,
+  AppendOnDuplicateKey,
+};
+
+// Creates a test configuration with three headers, two of which have the same
+// key. The following headers are added:
+//
+//   key1: header1_value
+//   key2: header2_value
+//   key1: header3_value
+//
+// @param api_version determines the version of the Envoy API used in the
+// created configuration.
+// @param add_mode specifies how the header with the duplicate key is added.
+nighthawk::server::ResponseOptions createTestConfiguration(EnvoyApiVersion api_version,
+                                                           HeaderAddMode add_mode) {
+  nighthawk::server::ResponseOptions configuration;
+
+  if (api_version == EnvoyApiV2) {
+    envoy::api::v2::core::HeaderValueOption* header1 = configuration.add_response_headers();
+    header1->mutable_header()->set_key("key1");
+    header1->mutable_header()->set_value("header1_value");
+
+    envoy::api::v2::core::HeaderValueOption* header2 = configuration.add_response_headers();
+    header2->mutable_header()->set_key("key2");
+    header2->mutable_header()->set_value("header2_value");
+
+    envoy::api::v2::core::HeaderValueOption* header3 = configuration.add_response_headers();
+    header3->mutable_header()->set_key("key1");
+    header3->mutable_header()->set_value("header3_value");
+    if (add_mode == AppendOnDuplicateKey) {
+      header3->mutable_append()->set_value("true");
+    }
+  } else if (api_version == EnvoyApiV3) {
+    envoy::config::core::v3::HeaderValueOption* header1 = configuration.add_v3_response_headers();
+    header1->mutable_header()->set_key("key1");
+    header1->mutable_header()->set_value("header1_value");
+
+    envoy::config::core::v3::HeaderValueOption* header2 = configuration.add_v3_response_headers();
+    header2->mutable_header()->set_key("key2");
+    header2->mutable_header()->set_value("header2_value");
+
+    envoy::config::core::v3::HeaderValueOption* header3 = configuration.add_v3_response_headers();
+    header3->mutable_header()->set_key("key1");
+    header3->mutable_header()->set_value("header3_value");
+    if (add_mode == AppendOnDuplicateKey) {
+      header3->mutable_append()->set_value("true");
+    }
+  }
+  return configuration;
+}
+
+// Creates the expected header map for the specified add mode.
+//
+// @param add_mode specifies how the header with the duplicate key is added.
+TestResponseHeaderMapImpl createExpectedHeaderMap(HeaderAddMode add_mode) {
+  TestResponseHeaderMapImpl expected_header_map;
+  if (add_mode == ReplaceOnDuplicateKey) {
+    expected_header_map.addCopy(LowerCaseString("key2"), "header2_value");
+    expected_header_map.addCopy(LowerCaseString("key1"), "header3_value");
+  } else if (add_mode == AppendOnDuplicateKey) {
+    expected_header_map.addCopy(LowerCaseString("key1"), "header1_value");
+    expected_header_map.addCopy(LowerCaseString("key2"), "header2_value");
+    expected_header_map.addCopy(LowerCaseString("key1"), "header3_value");
+  }
+  return expected_header_map;
+}
+
+TEST(ApplyConfigToResponseHeaders, ReplacesHeadersFromEnvoyApiV2Config) {
+  HeaderAddMode add_mode = ReplaceOnDuplicateKey;
+  nighthawk::server::ResponseOptions configuration = createTestConfiguration(EnvoyApiV2, add_mode);
+
+  TestResponseHeaderMapImpl header_map;
+  applyConfigToResponseHeaders(header_map, configuration);
+  TestResponseHeaderMapImpl expected_header_map = createExpectedHeaderMap(add_mode);
+
+  EXPECT_EQ(header_map, expected_header_map) << "got header_map:\n"
+                                             << header_map << "\nexpected_header_map:\n"
+                                             << expected_header_map;
+}
+
+TEST(ApplyConfigToResponseHeaders, AppendsHeadersFromEnvoyApiV2Config) {
+  HeaderAddMode add_mode = AppendOnDuplicateKey;
+  nighthawk::server::ResponseOptions configuration = createTestConfiguration(EnvoyApiV2, add_mode);
+
+  TestResponseHeaderMapImpl header_map;
+  applyConfigToResponseHeaders(header_map, configuration);
+  TestResponseHeaderMapImpl expected_header_map = createExpectedHeaderMap(add_mode);
+
+  EXPECT_EQ(header_map, expected_header_map) << "got header_map:\n"
+                                             << header_map << "\nexpected_header_map:\n"
+                                             << expected_header_map;
+}
+
+TEST(ApplyConfigToResponseHeaders, ReplacesHeadersFromEnvoyApiV3Config) {
+  HeaderAddMode add_mode = ReplaceOnDuplicateKey;
+  nighthawk::server::ResponseOptions configuration = createTestConfiguration(EnvoyApiV3, add_mode);
+
+  TestResponseHeaderMapImpl header_map;
+  applyConfigToResponseHeaders(header_map, configuration);
+  TestResponseHeaderMapImpl expected_header_map = createExpectedHeaderMap(add_mode);
+
+  EXPECT_EQ(header_map, expected_header_map) << "got header_map:\n"
+                                             << header_map << "\nexpected_header_map:\n"
+                                             << expected_header_map;
+}
+
+TEST(ApplyConfigToResponseHeaders, AppendsHeadersFromEnvoyApiV3Config) {
+  HeaderAddMode add_mode = AppendOnDuplicateKey;
+  nighthawk::server::ResponseOptions configuration = createTestConfiguration(EnvoyApiV3, add_mode);
+
+  TestResponseHeaderMapImpl header_map;
+  applyConfigToResponseHeaders(header_map, configuration);
+  TestResponseHeaderMapImpl expected_header_map = createExpectedHeaderMap(add_mode);
+
+  EXPECT_EQ(header_map, expected_header_map) << "got header_map:\n"
+                                             << header_map << "\nexpected_header_map:\n"
+                                             << expected_header_map;
 }
 
 } // namespace

--- a/test/server/configuration_test.cc
+++ b/test/server/configuration_test.cc
@@ -1,0 +1,66 @@
+#include "envoy/api/v2/core/base.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+
+#include "server/configuration.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Nighthawk {
+namespace Server {
+namespace Configuration {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(UpgradeDeprecatedEnvoyV2HeaderValueOptionToV3Test, UpgradesEmptyHeaderValue) {
+  envoy::api::v2::core::HeaderValueOption v2_header_value_option;
+  envoy::config::core::v3::HeaderValueOption v3_header_value_option =
+      upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(v2_header_value_option);
+
+  EXPECT_FALSE(v3_header_value_option.has_append());
+  EXPECT_FALSE(v3_header_value_option.has_header());
+}
+
+TEST(UpgradeDeprecatedEnvoyV2HeaderValueOptionToV3Test, UpgradesHeaderValueWithHeaderAndAppendSet) {
+  envoy::api::v2::core::HeaderValueOption v2_header_value_option;
+  v2_header_value_option.mutable_append()->set_value(true);
+  v2_header_value_option.mutable_header()->set_key("key");
+  v2_header_value_option.mutable_header()->set_value("value");
+
+  envoy::config::core::v3::HeaderValueOption v3_header_value_option =
+      upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(v2_header_value_option);
+
+  EXPECT_TRUE(v3_header_value_option.append().value());
+  EXPECT_EQ(v3_header_value_option.header().key(), "key");
+  EXPECT_EQ(v3_header_value_option.header().value(), "value");
+}
+
+TEST(UpgradeDeprecatedEnvoyV2HeaderValueOptionToV3Test, UpgradesHeaderValueWithHeaderOnly) {
+  envoy::api::v2::core::HeaderValueOption v2_header_value_option;
+  v2_header_value_option.mutable_header()->set_key("key");
+  v2_header_value_option.mutable_header()->set_value("value");
+
+  envoy::config::core::v3::HeaderValueOption v3_header_value_option =
+      upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(v2_header_value_option);
+
+  EXPECT_FALSE(v3_header_value_option.has_append());
+  EXPECT_EQ(v3_header_value_option.header().key(), "key");
+  EXPECT_EQ(v3_header_value_option.header().value(), "value");
+}
+
+TEST(UpgradeDeprecatedEnvoyV2HeaderValueOptionToV3Test, UpgradesHeaderValueWithAppendOnly) {
+  envoy::api::v2::core::HeaderValueOption v2_header_value_option;
+  v2_header_value_option.mutable_append()->set_value(true);
+
+  envoy::config::core::v3::HeaderValueOption v3_header_value_option =
+      upgradeDeprecatedEnvoyV2HeaderValueOptionToV3(v2_header_value_option);
+
+  EXPECT_TRUE(v3_header_value_option.append().value());
+  EXPECT_FALSE(v3_header_value_option.has_header());
+}
+
+} // namespace
+} // namespace Configuration
+} // namespace Server
+} // namespace Nighthawk

--- a/test/server/configuration_test.cc
+++ b/test/server/configuration_test.cc
@@ -88,6 +88,7 @@ enum HeaderAddMode {
 // @param api_version determines the version of the Envoy API used in the
 // created configuration.
 // @param add_mode specifies how the header with the duplicate key is added.
+// @return a configuration for the test.
 nighthawk::server::ResponseOptions createTestConfiguration(EnvoyApiVersion api_version,
                                                            HeaderAddMode add_mode) {
   nighthawk::server::ResponseOptions configuration;
@@ -129,6 +130,7 @@ nighthawk::server::ResponseOptions createTestConfiguration(EnvoyApiVersion api_v
 // Creates the expected header map for the specified add mode.
 //
 // @param add_mode specifies how the header with the duplicate key is added.
+// @return a header map populated with the expected headers.
 TestResponseHeaderMapImpl createExpectedHeaderMap(HeaderAddMode add_mode) {
   TestResponseHeaderMapImpl expected_header_map;
   if (add_mode == ReplaceOnDuplicateKey) {

--- a/test/server/configuration_test.cc
+++ b/test/server/configuration_test.cc
@@ -194,6 +194,39 @@ TEST(ApplyConfigToResponseHeaders, AppendsHeadersFromEnvoyApiV3Config) {
                                              << expected_header_map;
 }
 
+TEST(ApplyConfigToResponseHeaders, ThrowsOnInvalidConfiguration) {
+  nighthawk::server::ResponseOptions configuration;
+  configuration.add_response_headers();
+  configuration.add_v3_response_headers();
+
+  TestResponseHeaderMapImpl header_map;
+  EXPECT_THROW(applyConfigToResponseHeaders(header_map, configuration), Envoy::EnvoyException);
+}
+
+TEST(ValidateResponseOptions, DoesNotThrowOnEmptyConfiguration) {
+  nighthawk::server::ResponseOptions configuration;
+  EXPECT_NO_THROW(validateResponseOptions(configuration));
+}
+
+TEST(ValidateResponseOptions, DoesNotThrowWhenOnlyEnvoyApiV2ResponseHeadersAreSet) {
+  nighthawk::server::ResponseOptions configuration;
+  configuration.add_response_headers();
+  EXPECT_NO_THROW(validateResponseOptions(configuration));
+}
+
+TEST(ValidateResponseOptions, DoesNotThrowWhenOnlyEnvoyApiV3ResponseHeadersAreSet) {
+  nighthawk::server::ResponseOptions configuration;
+  configuration.add_v3_response_headers();
+  EXPECT_NO_THROW(validateResponseOptions(configuration));
+}
+
+TEST(ValidateResponseOptions, ThrowsWhenBothEnvoyApiV2AndV3ResponseHeadersAreSet) {
+  nighthawk::server::ResponseOptions configuration;
+  configuration.add_response_headers();
+  configuration.add_v3_response_headers();
+  EXPECT_THROW(validateResponseOptions(configuration), Envoy::EnvoyException);
+}
+
 } // namespace
 } // namespace Configuration
 } // namespace Server


### PR DESCRIPTION
Adds a new field `v3_response_headers` alongside the old v2 `response_headers` in `api/server/response_options.proto` and marks the old field as deprecated. The old field retains its functionality for backward compatibility.

Since these are repeated fields, we cannot use a oneof. Instead validation is added to ensure the filters report an error on configuration that has both the v2 and the v3 fields set. `Envoy::EnvoyException` is thrown on validation errors to comply with the `Envoy::Server::Configuration::NamedHttpFilterConfigFactory` interface.

Also:
- sorting imports in `response_options.proto ` alphabetically.
- adding missing anonymous namespace in `http_dynamic_delay_filter_integration_test.cc`.

Works on #580.

Signed-off-by: Jakub Sobon <mumak@google.com>