### PR TITLE
Update Envoy to 424909395c90d7d68f1afeb3427c26c7c85f2672

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "8188e232a9e0b15111d30f4724cbc7bf77d3964a"  # December 8th, 2020
-ENVOY_SHA = "35478b1c133197a7dd1ea1349cd3e8a09ad0169614fa5de1e2336b37ea563c67"
+ENVOY_COMMIT = "424909395c90d7d68f1afeb3427c26c7c85f2672"  # December 11th, 2020
+ENVOY_SHA = "d80514bcb2ea0f124681d7a05535f724846d5cef2a455f9b2d1d9a29c3ab5740"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -137,8 +137,9 @@ public:
   // Helpers
   Envoy::Http::ConnectionPool::Instance* pool() {
     auto proto = use_h2_ ? Envoy::Http::Protocol::Http2 : Envoy::Http::Protocol::Http11;
-    return cluster_manager_->httpConnPoolForCluster(
-        cluster_name_, Envoy::Upstream::ResourcePriority::Default, proto, nullptr);
+    const auto thread_local_cluster = cluster_manager_->getThreadLocalCluster(cluster_name_);
+    return thread_local_cluster->httpConnPool(Envoy::Upstream::ResourcePriority::Default, proto,
+                                              nullptr);
   }
 
 private:

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -67,9 +67,10 @@ public:
         {":scheme", "http"}, {":method", "GET"}, {":path", "/"}, {":host", "localhost"}};
     default_header_map_ =
         (std::make_shared<Envoy::Http::TestRequestHeaderMapImpl>(header_map_param));
-    EXPECT_CALL(cluster_manager(), httpConnPoolForCluster(_, _, _, _))
-        .WillRepeatedly(Return(&pool_));
+    EXPECT_CALL(cluster_manager(), getThreadLocalCluster(_))
+        .WillRepeatedly(Return(&thread_local_cluster_));
     EXPECT_CALL(thread_local_cluster_, info()).WillRepeatedly(Return(cluster_info_));
+    EXPECT_CALL(thread_local_cluster_, httpConnPool(_, _, _)).WillRepeatedly(Return(&pool_));
 
     auto& tracer = static_cast<Envoy::Tracing::MockHttpTracer&>(*http_tracer_);
     EXPECT_CALL(tracer, startSpan_(_, _, _, _))
@@ -357,7 +358,7 @@ TEST_F(BenchmarkClientHttpTest, RequestMethodPost) {
     return std::make_unique<RequestImpl>(header);
   };
 
-  EXPECT_CALL(stream_encoder_, encodeData(_, _)).Times(1);
+  EXPECT_CALL(stream_encoder_, encodeData(_, _));
   auto client_setup_parameters = ClientSetupParameters(1, 1, 1, request_generator);
   verifyBenchmarkClientProcessesExpectedInflightRequests(client_setup_parameters);
   EXPECT_EQ(1, getCounter("http_2xx"));

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -54,7 +54,7 @@ public:
     EXPECT_CALL(request_generator_factory_, create(_, _, _, _))
         .Times(1)
         .WillOnce(Return(ByMove(std::unique_ptr<RequestSource>(request_generator_))));
-    EXPECT_CALL(*request_generator_, initOnThread()).Times(1);
+    EXPECT_CALL(*request_generator_, initOnThread());
 
     EXPECT_CALL(termination_predicate_factory_, create(_, _, _))
         .WillOnce(Return(ByMove(createMockTerminationPredicate())));
@@ -105,13 +105,13 @@ TEST_F(ClientWorkerTest, BasicTest) {
 
   {
     InSequence dummy;
-    EXPECT_CALL(*benchmark_client_, setShouldMeasureLatencies(false)).Times(1);
+    EXPECT_CALL(*benchmark_client_, setShouldMeasureLatencies(false));
     EXPECT_CALL(*benchmark_client_, tryStartRequest(_))
         .WillOnce(Invoke(this, &ClientWorkerTest::CheckThreadChanged));
-    EXPECT_CALL(*benchmark_client_, setShouldMeasureLatencies(true)).Times(1);
-    EXPECT_CALL(*sequencer_, start).Times(1);
-    EXPECT_CALL(*sequencer_, waitForCompletion).Times(1);
-    EXPECT_CALL(*benchmark_client_, terminate()).Times(1);
+    EXPECT_CALL(*benchmark_client_, setShouldMeasureLatencies(true));
+    EXPECT_CALL(*sequencer_, start);
+    EXPECT_CALL(*sequencer_, waitForCompletion);
+    EXPECT_CALL(*benchmark_client_, terminate());
   }
   int worker_number = 12345;
 
@@ -123,8 +123,8 @@ TEST_F(ClientWorkerTest, BasicTest) {
   worker->start();
   worker->waitForCompletion();
 
-  EXPECT_CALL(*benchmark_client_, statistics()).Times(1).WillOnce(Return(createStatisticPtrMap()));
-  EXPECT_CALL(*sequencer_, statistics()).Times(1).WillOnce(Return(createStatisticPtrMap()));
+  EXPECT_CALL(*benchmark_client_, statistics()).WillOnce(Return(createStatisticPtrMap()));
+  EXPECT_CALL(*sequencer_, statistics()).WillOnce(Return(createStatisticPtrMap()));
 
   auto statistics = worker->statistics();
   EXPECT_EQ(2, statistics.size());

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -36,15 +36,15 @@ public:
 TEST_F(FactoriesTest, CreateBenchmarkClient) {
   BenchmarkClientFactoryImpl factory(options_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
-  EXPECT_CALL(options_, connections()).Times(1);
-  EXPECT_CALL(options_, h2()).Times(1);
-  EXPECT_CALL(options_, maxPendingRequests()).Times(1);
-  EXPECT_CALL(options_, maxActiveRequests()).Times(1);
-  EXPECT_CALL(options_, maxRequestsPerConnection()).Times(1);
-  EXPECT_CALL(options_, openLoop()).Times(1);
-  EXPECT_CALL(options_, responseHeaderWithLatencyInput()).Times(1);
+  EXPECT_CALL(options_, connections());
+  EXPECT_CALL(options_, h2());
+  EXPECT_CALL(options_, maxPendingRequests());
+  EXPECT_CALL(options_, maxActiveRequests());
+  EXPECT_CALL(options_, maxRequestsPerConnection());
+  EXPECT_CALL(options_, openLoop());
+  EXPECT_CALL(options_, responseHeaderWithLatencyInput());
   auto cmd = std::make_unique<nighthawk::client::CommandLineOptions>();
-  EXPECT_CALL(options_, toCommandLineOptions()).Times(1).WillOnce(Return(ByMove(std::move(cmd))));
+  EXPECT_CALL(options_, toCommandLineOptions()).WillOnce(Return(ByMove(std::move(cmd))));
   StaticRequestSourceImpl request_generator(
       std::make_unique<Envoy::Http::TestRequestHeaderMapImpl>());
   auto benchmark_client =
@@ -71,10 +71,10 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithWorkingJsonReturnsWorkingRequ
   Envoy::MessageUtil::loadFromJson(request_source_plugin_config_json,
                                    request_source_plugin_config.value(),
                                    Envoy::ProtobufMessage::getStrictValidationVisitor());
-  EXPECT_CALL(options_, requestMethod()).Times(1);
-  EXPECT_CALL(options_, requestBodySize()).Times(1);
+  EXPECT_CALL(options_, requestMethod());
+  EXPECT_CALL(options_, requestBodySize());
   EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/"));
-  EXPECT_CALL(options_, requestSource()).Times(1);
+  EXPECT_CALL(options_, requestSource());
   EXPECT_CALL(options_, requestSourcePluginConfig())
       .Times(2)
       .WillRepeatedly(ReturnRef(request_source_plugin_config));
@@ -83,7 +83,7 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithWorkingJsonReturnsWorkingRequ
       cmd->mutable_request_options()->add_request_headers();
   request_headers->mutable_header()->set_key("foo");
   request_headers->mutable_header()->set_value("bar");
-  EXPECT_CALL(options_, toCommandLineOptions()).Times(1).WillOnce(Return(ByMove(std::move(cmd))));
+  EXPECT_CALL(options_, toCommandLineOptions()).WillOnce(Return(ByMove(std::move(cmd))));
   RequestSourceFactoryImpl factory(options_, *api_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   Nighthawk::RequestSourcePtr request_source = factory.create(
@@ -111,10 +111,10 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithNonWorkingJsonThrowsError) {
   Envoy::MessageUtil::loadFromJson(request_source_plugin_config_json,
                                    request_source_plugin_config.value(),
                                    Envoy::ProtobufMessage::getStrictValidationVisitor());
-  EXPECT_CALL(options_, requestMethod()).Times(1);
-  EXPECT_CALL(options_, requestBodySize()).Times(1);
+  EXPECT_CALL(options_, requestMethod());
+  EXPECT_CALL(options_, requestBodySize());
   EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/"));
-  EXPECT_CALL(options_, requestSource()).Times(1);
+  EXPECT_CALL(options_, requestSource());
   EXPECT_CALL(options_, requestSourcePluginConfig())
       .Times(2)
       .WillRepeatedly(ReturnRef(request_source_plugin_config));
@@ -123,7 +123,7 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithNonWorkingJsonThrowsError) {
       cmd->mutable_request_options()->add_request_headers();
   request_headers->mutable_header()->set_key("foo");
   request_headers->mutable_header()->set_value("bar");
-  EXPECT_CALL(options_, toCommandLineOptions()).Times(1).WillOnce(Return(ByMove(std::move(cmd))));
+  EXPECT_CALL(options_, toCommandLineOptions()).WillOnce(Return(ByMove(std::move(cmd))));
   RequestSourceFactoryImpl factory(options_, *api_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   EXPECT_THROW_WITH_REGEX(
@@ -135,10 +135,10 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithNonWorkingJsonThrowsError) {
 
 TEST_F(FactoriesTest, CreateRequestSource) {
   absl::optional<envoy::config::core::v3::TypedExtensionConfig> request_source_plugin_config;
-  EXPECT_CALL(options_, requestMethod()).Times(1);
-  EXPECT_CALL(options_, requestBodySize()).Times(1);
+  EXPECT_CALL(options_, requestMethod());
+  EXPECT_CALL(options_, requestBodySize());
   EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/"));
-  EXPECT_CALL(options_, requestSource()).Times(1);
+  EXPECT_CALL(options_, requestSource());
   EXPECT_CALL(options_, requestSourcePluginConfig())
       .Times(1)
       .WillRepeatedly(ReturnRef(request_source_plugin_config));
@@ -147,7 +147,7 @@ TEST_F(FactoriesTest, CreateRequestSource) {
       cmd->mutable_request_options()->add_request_headers();
   request_headers->mutable_header()->set_key("foo");
   request_headers->mutable_header()->set_value("bar");
-  EXPECT_CALL(options_, toCommandLineOptions()).Times(1).WillOnce(Return(ByMove(std::move(cmd))));
+  EXPECT_CALL(options_, toCommandLineOptions()).WillOnce(Return(ByMove(std::move(cmd))));
   RequestSourceFactoryImpl factory(options_, *api_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   RequestSourcePtr request_generator = factory.create(
@@ -157,17 +157,17 @@ TEST_F(FactoriesTest, CreateRequestSource) {
 
 TEST_F(FactoriesTest, CreateRemoteRequestSource) {
   absl::optional<envoy::config::core::v3::TypedExtensionConfig> request_source_plugin_config;
-  EXPECT_CALL(options_, requestMethod()).Times(1);
-  EXPECT_CALL(options_, requestBodySize()).Times(1);
+  EXPECT_CALL(options_, requestMethod());
+  EXPECT_CALL(options_, requestBodySize());
   EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/"));
-  EXPECT_CALL(options_, requestSource()).Times(1).WillRepeatedly(Return("http://bar/"));
-  EXPECT_CALL(options_, requestsPerSecond()).Times(1).WillRepeatedly(Return(5));
+  EXPECT_CALL(options_, requestSource()).WillOnce(Return("http://bar/"));
+  EXPECT_CALL(options_, requestsPerSecond()).WillOnce(Return(5));
   auto cmd = std::make_unique<nighthawk::client::CommandLineOptions>();
   envoy::config::core::v3::HeaderValueOption* request_headers =
       cmd->mutable_request_options()->add_request_headers();
   request_headers->mutable_header()->set_key("foo");
   request_headers->mutable_header()->set_value("bar");
-  EXPECT_CALL(options_, toCommandLineOptions()).Times(1).WillOnce(Return(ByMove(std::move(cmd))));
+  EXPECT_CALL(options_, toCommandLineOptions()).WillOnce(Return(ByMove(std::move(cmd))));
   RequestSourceFactoryImpl factory(options_, *api_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   RequestSourcePtr request_generator = factory.create(
@@ -185,13 +185,13 @@ public:
                                  sequencer_idle_strategy) {
     SequencerFactoryImpl factory(options_);
     MockBenchmarkClient benchmark_client;
-    EXPECT_CALL(options_, requestsPerSecond()).Times(1).WillOnce(Return(1));
-    EXPECT_CALL(options_, burstSize()).Times(1).WillOnce(Return(2));
+    EXPECT_CALL(options_, requestsPerSecond()).WillOnce(Return(1));
+    EXPECT_CALL(options_, burstSize()).WillOnce(Return(2));
     EXPECT_CALL(options_, sequencerIdleStrategy())
         .Times(1)
         .WillOnce(Return(sequencer_idle_strategy));
     EXPECT_CALL(dispatcher_, createTimer_(_)).Times(2);
-    EXPECT_CALL(options_, jitterUniform()).Times(1).WillOnce(Return(1ns));
+    EXPECT_CALL(options_, jitterUniform()).WillOnce(Return(1ns));
     Envoy::Event::SimulatedTimeSystem time_system;
     const SequencerTarget dummy_sequencer_target = [](const CompletionCallback&) -> bool {
       return true;

--- a/test/flush_worker_test.cc
+++ b/test/flush_worker_test.cc
@@ -132,7 +132,7 @@ TEST_F(FlushWorkerTest, WorkerFlushStatsPeriodically) {
   thread.join();
   // Stats flush should happen exactly once as the final flush is done in
   // FlushWorkerImpl::shutdownThread().
-  EXPECT_CALL(*sink_, flush(_)).Times(1);
+  EXPECT_CALL(*sink_, flush(_));
   worker.shutdown();
 }
 
@@ -147,7 +147,7 @@ TEST_F(FlushWorkerTest, FinalFlush) {
   worker.waitForCompletion();
   // Stats flush should happen exactly once as the final flush is done in
   // FlushWorkerImpl::shutdownThread().
-  EXPECT_CALL(*sink_, flush(_)).Times(1);
+  EXPECT_CALL(*sink_, flush(_));
   worker.shutdown();
 }
 

--- a/test/rate_limiter_test.cc
+++ b/test/rate_limiter_test.cc
@@ -65,7 +65,7 @@ TEST_F(RateLimiterTest, BurstingRateLimiterTest) {
   rate_limiter->releaseOne();
   EXPECT_TRUE(rate_limiter->tryAcquireOne());
   EXPECT_TRUE(rate_limiter->tryAcquireOne());
-  EXPECT_CALL(unsafe_mock_rate_limiter, tryAcquireOne).Times(1).WillOnce(Return(false));
+  EXPECT_CALL(unsafe_mock_rate_limiter, tryAcquireOne).WillOnce(Return(false));
   EXPECT_FALSE(rate_limiter->tryAcquireOne());
 }
 
@@ -260,7 +260,7 @@ TEST_F(DistributionSamplingRateLimiterTest, ReleaseOneFunctionsWhenAcquired) {
   EXPECT_CALL(mock_inner_rate_limiter_, tryAcquireOne).WillOnce(Return(true));
   EXPECT_CALL(mock_discrete_numeric_distribution_sampler_, getValue).WillOnce(Return(0));
   EXPECT_TRUE(rate_limiter_->tryAcquireOne());
-  EXPECT_CALL(mock_inner_rate_limiter_, releaseOne).Times(1);
+  EXPECT_CALL(mock_inner_rate_limiter_, releaseOne);
   rate_limiter_->releaseOne();
 }
 
@@ -421,7 +421,7 @@ TEST_F(RateLimiterTest, GraduallyOpeningRateLimiterFilterInvalidArgumentTest) {
 
   // Pass in a badly configured distribution sampler.
   auto bad_distribution_sampler = std::make_unique<MockDiscreteNumericDistributionSampler>();
-  EXPECT_CALL(*bad_distribution_sampler, min).Times(1).WillOnce(Return(0));
+  EXPECT_CALL(*bad_distribution_sampler, min).WillOnce(Return(0));
   EXPECT_THROW(
       GraduallyOpeningRateLimiterFilter gorl(1s, std::move(bad_distribution_sampler),
                                              std::make_unique<NiceMock<MockRateLimiter>>());
@@ -429,8 +429,8 @@ TEST_F(RateLimiterTest, GraduallyOpeningRateLimiterFilterInvalidArgumentTest) {
 
   bad_distribution_sampler = std::make_unique<MockDiscreteNumericDistributionSampler>();
   // Correct min, but now introduce a bad max.
-  EXPECT_CALL(*bad_distribution_sampler, min).Times(1).WillOnce(Return(1));
-  EXPECT_CALL(*bad_distribution_sampler, max).Times(1).WillOnce(Return(99));
+  EXPECT_CALL(*bad_distribution_sampler, min).WillOnce(Return(1));
+  EXPECT_CALL(*bad_distribution_sampler, max).WillOnce(Return(99));
   EXPECT_THROW(
       GraduallyOpeningRateLimiterFilter gorl(1s, std::move(bad_distribution_sampler),
                                              std::make_unique<NiceMock<MockRateLimiter>>());

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -201,7 +201,7 @@ TEST_F(SequencerTestWithTimerEmulation, RateLimiterSaturatedTargetInteraction) {
   EXPECT_CALL(*target(), callback(_)).Times(2).WillOnce(Return(true)).WillOnce(Return(false));
 
   // The sequencer should call RateLimiter::releaseOne() when the target returns false.
-  EXPECT_CALL(rate_limiter_unsafe_ref_, releaseOne()).Times(1);
+  EXPECT_CALL(rate_limiter_unsafe_ref_, releaseOne());
   expectDispatcherRun();
 
   EXPECT_CALL(platform_util_, sleep(_)).Times(AtLeast(1));

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -136,9 +136,9 @@ TEST_F(StreamDecoderTest, LatencyIsMeasured) {
                      const Envoy::Tracing::Decision) -> Envoy::Tracing::Span* {
             EXPECT_EQ(Envoy::Tracing::OperationName::Egress, config.operationName());
             auto* span = new Envoy::Tracing::MockSpan();
-            EXPECT_CALL(*span, injectContext(_)).Times(1);
+            EXPECT_CALL(*span, injectContext(_));
             EXPECT_CALL(*span, setTag(_, _)).Times(12);
-            EXPECT_CALL(*span, finishSpan()).Times(1);
+            EXPECT_CALL(*span, finishSpan());
             return span;
           }));
 

--- a/test/worker_test.cc
+++ b/test/worker_test.cc
@@ -45,8 +45,8 @@ public:
 TEST_F(WorkerTest, WorkerExecutesOnThread) {
   InSequence in_sequence;
 
-  EXPECT_CALL(tls_, registerThread(_, false)).Times(1);
-  EXPECT_CALL(tls_, allocateSlot()).Times(1);
+  EXPECT_CALL(tls_, registerThread(_, false));
+  EXPECT_CALL(tls_, allocateSlot());
 
   TestWorker worker(*api_, tls_);
   NiceMock<Envoy::Event::MockDispatcher> dispatcher;
@@ -57,7 +57,7 @@ TEST_F(WorkerTest, WorkerExecutesOnThread) {
   worker.start();
   worker.waitForCompletion();
 
-  EXPECT_CALL(tls_, shutdownThread()).Times(1);
+  EXPECT_CALL(tls_, shutdownThread());
   ASSERT_TRUE(worker.ran_);
   worker.shutdown();
 }


### PR DESCRIPTION
- The way we can obtain a http connection pool changed. Amend.
- Cleanup by fix_format: strip superfluous .Times(1) in tests.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>