### PR TITLE
Optimize calls to std::string::find() and friends for a single char.

### DIFF
--- a/source/common/utility.cc
+++ b/source/common/utility.cc
@@ -38,9 +38,9 @@ Utility::mapCountersFromStore(const Envoy::Stats::Store& store,
 
 size_t Utility::findPortSeparator(absl::string_view hostname) {
   if (hostname.size() > 0 && hostname[0] == '[') {
-    return hostname.find(":", hostname.find(']'));
+    return hostname.find(':', hostname.find(']'));
   }
-  return hostname.rfind(":");
+  return hostname.rfind(':');
 }
 
 Envoy::Network::DnsLookupFamily


### PR DESCRIPTION
The character literal overload is more efficient.

Signed-off-by: Yan Avlasov <yavlasov@google.com>