### PR TITLE
Update Envoy to 867b9e23d2e48350bd1b0d1fbc392a8355f20e35

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "424909395c90d7d68f1afeb3427c26c7c85f2672"  # December 11th, 2020
-ENVOY_SHA = "d80514bcb2ea0f124681d7a05535f724846d5cef2a455f9b2d1d9a29c3ab5740"
+ENVOY_COMMIT = "867b9e23d2e48350bd1b0d1fbc392a8355f20e35"  # December 20th, 2020
+ENVOY_SHA = "b98a88bbff0c64ff08f88d2a4379dd708d1df012424d6b65c7e32773ce249a53"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/test/mocks/client/mock_benchmark_client.h
+++ b/test/mocks/client/mock_benchmark_client.h
@@ -11,13 +11,13 @@ class MockBenchmarkClient : public BenchmarkClient {
 public:
   MockBenchmarkClient();
 
-  MOCK_METHOD0(terminate, void());
-  MOCK_METHOD1(setShouldMeasureLatencies, void(bool));
-  MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
-  MOCK_METHOD1(tryStartRequest, bool(Client::CompletionCallback));
-  MOCK_CONST_METHOD0(scope, Envoy::Stats::Scope&());
-  MOCK_CONST_METHOD0(shouldMeasureLatencies, bool());
-  MOCK_CONST_METHOD0(requestHeaders, const Envoy::Http::RequestHeaderMap&());
+  MOCK_METHOD(void, terminate, ());
+  MOCK_METHOD(void, setShouldMeasureLatencies, (bool));
+  MOCK_METHOD(StatisticPtrMap, statistics, (), (const));
+  MOCK_METHOD(bool, tryStartRequest, (Client::CompletionCallback));
+  MOCK_METHOD(Envoy::Stats::Scope&, scope, (), (const));
+  MOCK_METHOD(bool, shouldMeasureLatencies, (), (const));
+  MOCK_METHOD(const Envoy::Http::RequestHeaderMap&, requestHeaders, (), (const));
 };
 
 } // namespace Client

--- a/test/mocks/common/mock_rate_limiter.h
+++ b/test/mocks/common/mock_rate_limiter.h
@@ -10,19 +10,19 @@ class MockRateLimiter : public RateLimiter {
 public:
   MockRateLimiter();
 
-  MOCK_METHOD0(tryAcquireOne, bool());
-  MOCK_METHOD0(releaseOne, void());
-  MOCK_METHOD0(timeSource, Envoy::TimeSource&());
-  MOCK_METHOD0(elapsed, std::chrono::nanoseconds());
-  MOCK_CONST_METHOD0(firstAcquisitionTime, absl::optional<Envoy::SystemTime>());
+  MOCK_METHOD(bool, tryAcquireOne, ());
+  MOCK_METHOD(void, releaseOne, ());
+  MOCK_METHOD(Envoy::TimeSource&, timeSource, ());
+  MOCK_METHOD(std::chrono::nanoseconds, elapsed, ());
+  MOCK_METHOD(absl::optional<Envoy::SystemTime>, firstAcquisitionTime, (), (const));
 };
 
 class MockDiscreteNumericDistributionSampler : public DiscreteNumericDistributionSampler {
 public:
   MockDiscreteNumericDistributionSampler();
-  MOCK_METHOD0(getValue, uint64_t());
-  MOCK_CONST_METHOD0(min, uint64_t());
-  MOCK_CONST_METHOD0(max, uint64_t());
+  MOCK_METHOD(uint64_t, getValue, ());
+  MOCK_METHOD(uint64_t, min, (), (const));
+  MOCK_METHOD(uint64_t, max, (), (const));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_request_source.h
+++ b/test/mocks/common/mock_request_source.h
@@ -9,8 +9,8 @@ namespace Nighthawk {
 class MockRequestSource : public RequestSource {
 public:
   MockRequestSource();
-  MOCK_METHOD0(get, RequestGenerator());
-  MOCK_METHOD0(initOnThread, void());
+  MOCK_METHOD(RequestGenerator, get, ());
+  MOCK_METHOD(void, initOnThread, ());
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_sequencer.h
+++ b/test/mocks/common/mock_sequencer.h
@@ -11,13 +11,13 @@ class MockSequencer : public Sequencer {
 public:
   MockSequencer();
 
-  MOCK_METHOD0(start, void());
-  MOCK_METHOD0(waitForCompletion, void());
-  MOCK_CONST_METHOD0(completionsPerSecond, double());
-  MOCK_CONST_METHOD0(executionDuration, std::chrono::nanoseconds());
-  MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
-  MOCK_METHOD0(cancel, void());
-  MOCK_CONST_METHOD0(rate_limiter, RateLimiter&());
+  MOCK_METHOD(void, start, ());
+  MOCK_METHOD(void, waitForCompletion, ());
+  MOCK_METHOD(double, completionsPerSecond, (), (const));
+  MOCK_METHOD(std::chrono::nanoseconds, executionDuration, (), (const));
+  MOCK_METHOD(StatisticPtrMap, statistics, (), (const));
+  MOCK_METHOD(void, cancel, ());
+  MOCK_METHOD(RateLimiter&, rate_limiter, (), (const));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -9,10 +9,10 @@ namespace Nighthawk {
 class MockTerminationPredicate : public TerminationPredicate {
 public:
   MockTerminationPredicate();
-  MOCK_METHOD1(link, TerminationPredicate&(TerminationPredicatePtr&&));
-  MOCK_METHOD1(appendToChain, TerminationPredicate&(TerminationPredicatePtr&&));
-  MOCK_METHOD0(evaluateChain, TerminationPredicate::Status());
-  MOCK_METHOD0(evaluate, TerminationPredicate::Status());
+  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr && p));
+  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr && p));
+  MOCK_METHOD(TerminationPredicate::Status, evaluateChain, ());
+  MOCK_METHOD(TerminationPredicate::Status, evaluate, ());
 };
 
 } // namespace Nighthawk

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -34,7 +34,7 @@ public:
 
 class MockSequencerTarget : public FakeSequencerTarget {
 public:
-  MOCK_METHOD1(callback, bool(OperationCallback));
+  MOCK_METHOD(bool, callback, (OperationCallback));
 };
 
 class SequencerTestBase : public testing::Test {


### PR DESCRIPTION
- Unbreak changed allocateConnPool() method usage: changes
  with respect to ALPN allow negotiation of a protocol,
  which is backed in Envoy by a pool which supports >1
  protocols. This update leaves a code-level comment plus
  a RELEASE_ASSERT when a multi-protocol pool is allocated.
- Avoid MOCK_METHODn as per new check_format objections:
  Change our mocks to use MOCK_METHOD instead.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>