### PR TITLE
Update Envoy to 937f013 (Jan 5th 2021)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "867b9e23d2e48350bd1b0d1fbc392a8355f20e35"  # December 20th, 2020
-ENVOY_SHA = "b98a88bbff0c64ff08f88d2a4379dd708d1df012424d6b65c7e32773ce249a53"
+ENVOY_COMMIT = "937f0133355cf2d8eb9e75d3f09e296bb63951be"  # Jan 5th, 2021
+ENVOY_SHA = "5bdb98e2f2bad83ac672862e399e4ae2d0ca28c31740a3af16d154fc37401ca7"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -127,7 +127,8 @@ ProcessImpl::ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_
       request_generator_factory_(options, *api_), options_(options),
       init_manager_("nh_init_manager"),
       local_info_(new Envoy::LocalInfo::LocalInfoImpl(
-          {}, Envoy::Network::Utility::getLocalAddress(Envoy::Network::Address::IpVersion::v4),
+          store_root_.symbolTable(), {},
+          Envoy::Network::Utility::getLocalAddress(Envoy::Network::Address::IpVersion::v4),
           "nighthawk_service_zone", "nighthawk_service_cluster", "nighthawk_service_node")),
       secret_manager_(config_tracker_), http_context_(store_root_.symbolTable()),
       grpc_context_(store_root_.symbolTable()),

--- a/test/common/nighthawk_service_client_test.cc
+++ b/test/common/nighthawk_service_client_test.cc
@@ -33,7 +33,7 @@ TEST(PerformNighthawkBenchmark, UsesSpecifiedCommandLineOptions) {
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw)
-      .WillOnce([&request](grpc_impl::ClientContext*) {
+      .WillOnce([&request](grpc::ClientContext*) {
         auto* mock_reader_writer =
             new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
         // PerformNighthawkBenchmark currently expects Read to return true exactly once.
@@ -61,7 +61,7 @@ TEST(PerformNighthawkBenchmark, ReturnsNighthawkResponseSuccessfully) {
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw)
-      .WillOnce([&expected_response](grpc_impl::ClientContext*) {
+      .WillOnce([&expected_response](grpc::ClientContext*) {
         auto* mock_reader_writer =
             new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
         // PerformNighthawkBenchmark currently expects Read to return true exactly once.
@@ -88,15 +88,14 @@ TEST(PerformNighthawkBenchmark, ReturnsErrorIfNighthawkServiceDoesNotSendRespons
   nighthawk::client::MockNighthawkServiceStub mock_nighthawk_service_stub;
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
-  EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw)
-      .WillOnce([](grpc_impl::ClientContext*) {
-        auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
-        EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(false));
-        EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
-        EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(true));
-        return mock_reader_writer;
-      });
+  EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw).WillOnce([](grpc::ClientContext*) {
+    auto* mock_reader_writer =
+        new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+    EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(true));
+    return mock_reader_writer;
+  });
 
   NighthawkServiceClientImpl client;
   absl::StatusOr<ExecutionResponse> response_or =
@@ -111,13 +110,12 @@ TEST(PerformNighthawkBenchmark, ReturnsErrorIfNighthawkServiceWriteFails) {
   nighthawk::client::MockNighthawkServiceStub mock_nighthawk_service_stub;
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
-  EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw)
-      .WillOnce([](grpc_impl::ClientContext*) {
-        auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
-        EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(false));
-        return mock_reader_writer;
-      });
+  EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw).WillOnce([](grpc::ClientContext*) {
+    auto* mock_reader_writer =
+        new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+    EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(false));
+    return mock_reader_writer;
+  });
 
   NighthawkServiceClientImpl client;
   absl::StatusOr<ExecutionResponse> response_or =
@@ -131,14 +129,13 @@ TEST(PerformNighthawkBenchmark, ReturnsErrorIfNighthawkServiceWritesDoneFails) {
   nighthawk::client::MockNighthawkServiceStub mock_nighthawk_service_stub;
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
-  EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw)
-      .WillOnce([](grpc_impl::ClientContext*) {
-        auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
-        EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
-        EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(false));
-        return mock_reader_writer;
-      });
+  EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw).WillOnce([](grpc::ClientContext*) {
+    auto* mock_reader_writer =
+        new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+    EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(false));
+    return mock_reader_writer;
+  });
 
   NighthawkServiceClientImpl client;
   absl::StatusOr<ExecutionResponse> response_or =
@@ -152,19 +149,18 @@ TEST(PerformNighthawkBenchmark, PropagatesErrorIfNighthawkServiceGrpcStreamClose
   nighthawk::client::MockNighthawkServiceStub mock_nighthawk_service_stub;
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
-  EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw)
-      .WillOnce([](grpc_impl::ClientContext*) {
-        auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
-        // PerformNighthawkBenchmark currently expects Read to return true exactly once.
-        EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(true)).WillOnce(Return(false));
-        EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
-        EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(true));
-        EXPECT_CALL(*mock_reader_writer, Finish())
-            .WillOnce(
-                Return(::grpc::Status(::grpc::PERMISSION_DENIED, "Finish failure status message")));
-        return mock_reader_writer;
-      });
+  EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw).WillOnce([](grpc::ClientContext*) {
+    auto* mock_reader_writer =
+        new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+    // PerformNighthawkBenchmark currently expects Read to return true exactly once.
+    EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(true)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(true));
+    EXPECT_CALL(*mock_reader_writer, Finish())
+        .WillOnce(
+            Return(::grpc::Status(::grpc::PERMISSION_DENIED, "Finish failure status message")));
+    return mock_reader_writer;
+  });
 
   NighthawkServiceClientImpl client;
   absl::StatusOr<ExecutionResponse> response_or =


### PR DESCRIPTION
- Transitively updates the grpc dependency, which eliminated
the grpc_impl namespace. s/grpc_impl::/grpc::/
- Envoy::LocalInfo::LocalInfoImpl constructor now requires passing
a symbol table. Pass that in.

Signed-off-by: Otto van der Schaaf <oschaaf@gmail.com>