### PR TITLE
Signal handler: don't fire on destruction

### DIFF
--- a/source/common/signal_handler.cc
+++ b/source/common/signal_handler.cc
@@ -23,7 +23,9 @@ SignalHandler::SignalHandler(const std::function<void()>& signal_callback) {
     RELEASE_ASSERT(close(pipe_fds_[0]) == 0, "read side close failed");
     RELEASE_ASSERT(close(pipe_fds_[1]) == 0, "write side close failed");
     pipe_fds_.clear();
-    signal_callback();
+    if (!destructing_) {
+      signal_callback();
+    }
   });
 
   signal_handler_delegate = [this](int) { onSignal(); };
@@ -32,6 +34,7 @@ SignalHandler::SignalHandler(const std::function<void()>& signal_callback) {
 }
 
 SignalHandler::~SignalHandler() {
+  destructing_ = true;
   initiateShutdown();
   if (shutdown_thread_.joinable()) {
     shutdown_thread_.join();

--- a/source/common/signal_handler.h
+++ b/source/common/signal_handler.h
@@ -69,6 +69,7 @@ private:
   // the read side will handle the actual shut down of the gRPC service without having to worry
   // about signal-safety.
   std::vector<int> pipe_fds_;
+  bool destructing_{false};
 };
 
 using SignalHandlerPtr = std::unique_ptr<SignalHandler>;

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -38,3 +38,12 @@ envoy_cc_test(
         "@com_github_grpc_grpc//:grpc++_test",
     ],
 )
+
+envoy_cc_test(
+    name = "signal_handler_test",
+    srcs = ["signal_handler_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/common:nighthawk_common_lib",
+    ],
+)

--- a/test/common/signal_handler_test.cc
+++ b/test/common/signal_handler_test.cc
@@ -1,0 +1,35 @@
+#include <csignal>
+#include <future>
+
+#include "common/signal_handler.h"
+
+#include "gtest/gtest.h"
+
+namespace Nighthawk {
+namespace {
+
+TEST(SignalHandlerTest, SignalGetsHandled) {
+  for (const auto signal : {SIGTERM, SIGINT}) {
+    bool signal_handled = false;
+    std::promise<void> signal_all_threads_running;
+
+    SignalHandler signal_handler([&signal_handled, &signal_all_threads_running]() {
+      signal_handled = true;
+      signal_all_threads_running.set_value();
+    });
+    std::raise(signal);
+    signal_all_threads_running.get_future().wait();
+    EXPECT_TRUE(signal_handled);
+  }
+}
+
+TEST(SignalHandlerTest, DeststructDoesNotFireHandler) {
+  bool signal_handled = false;
+  {
+    SignalHandler signal_handler([&signal_handled]() { signal_handled = true; });
+  }
+  EXPECT_FALSE(signal_handled);
+}
+
+} // namespace
+} // namespace Nighthawk

--- a/test/common/signal_handler_test.cc
+++ b/test/common/signal_handler_test.cc
@@ -23,7 +23,7 @@ TEST(SignalHandlerTest, SignalGetsHandled) {
   }
 }
 
-TEST(SignalHandlerTest, DeststructDoesNotFireHandler) {
+TEST(SignalHandlerTest, DestructDoesNotFireHandler) {
   bool signal_handled = false;
   {
     SignalHandler signal_handler([&signal_handled]() { signal_handled = true; });


### PR DESCRIPTION
Fixes a bug observed while working on horizontal scaling support:
SignalHandler would fire on destruction.
Fix & add tests.

Note: pre-emptive, I don't think this is  an issue in the current
state of master. But some of the CI errors in #600 seemed familiar
and hopefully merging this in there helps.

(Split out from https://github.com/oschaaf/nighthawk/tree/horizontal-scaling)

/cc @eric846

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>