### PR TITLE
Update Envoy to 17e8151 (Jan 16th 2021)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -255,7 +255,7 @@ build:remote-clang-cl --config=clang-cl
 build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
-# NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
+# NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
 build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:11efa5680d987fff33fde4af3cc5ece105015d04
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "c2522c69f69b318e30927995468c7f440ad2cb5c"  # Jan 11th, 2021
-ENVOY_SHA = "2d9b674e8bf249b38d338efe30c0b4e8c8b892f8c5d7f11d1654af0962002cf5"
+ENVOY_COMMIT = "17e815122ff53d0ac6cb2d64cdbf1bfc547bb7e8"  # Jan 16th, 2021
+ENVOY_SHA = "9c5f6a2d01796f3aed25796d47a7e5d800db7633baf627e77cf6c7f1b45a965f"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -127,7 +127,7 @@ ProcessImpl::ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_
       request_generator_factory_(options, *api_), options_(options),
       init_manager_("nh_init_manager"),
       local_info_(new Envoy::LocalInfo::LocalInfoImpl(
-          store_root_.symbolTable(), {},
+          store_root_.symbolTable(), node_, node_context_params_,
           Envoy::Network::Utility::getLocalAddress(Envoy::Network::Address::IpVersion::v4),
           "nighthawk_service_zone", "nighthawk_service_cluster", "nighthawk_service_node")),
       secret_manager_(config_tracker_), http_context_(store_root_.symbolTable()),

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -167,6 +167,8 @@ private:
   static std::chrono::nanoseconds computeInterWorkerDelay(const uint32_t concurrency,
                                                           const uint32_t rps);
 
+  const envoy::config::core::v3::Node node_;
+  const Envoy::Protobuf::RepeatedPtrField<std::string> node_context_params_;
   std::shared_ptr<Envoy::ProcessWide> process_wide_;
   Envoy::PlatformImpl platform_impl_;
   Envoy::Event::TimeSystem& time_system_;


### PR DESCRIPTION
Updates the Envoy dependency to revision:
17e815122ff53d0ac6cb2d64cdbf1bfc547bb7e8

Non mechanical change:
- LocalinfoImpl constructor changed

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>