### PR TITLE
Update Envoy to 9753819 (Jan 24th 2021).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -256,7 +256,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:11efa5680d987fff33fde4af3cc5ece105015d04
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:c8fa4235714003ba0896287ee2f91cae06e0e407
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "17e815122ff53d0ac6cb2d64cdbf1bfc547bb7e8"  # Jan 16th, 2021
-ENVOY_SHA = "9c5f6a2d01796f3aed25796d47a7e5d800db7633baf627e77cf6c7f1b45a965f"
+ENVOY_COMMIT = "9753819331d1547c4b8294546a6461a3777958f5"  # Jan 24th, 2021
+ENVOY_SHA = "f4d26c7e78c0a478d959ea8bc877f260d4658a8b44e294e3a400f20ad44d41a3"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -59,7 +59,8 @@ Http1PoolImpl::newStream(Envoy::Http::ResponseDecoder& response_decoder,
     while (host_->cluster().resourceManager(priority_).connections().canCreate()) {
       // We pass in a high prefetch ratio, because we don't want to throttle the prefetched
       // connection amount like Envoy does out of the box.
-      if (!tryCreateNewConnection(10000.0)) {
+      ConnPoolImplBase::ConnectionResult result = tryCreateNewConnection(10000.0);
+      if (result != ConnectionResult::CreatedNewConnection) {
         break;
       }
     }


### PR DESCRIPTION
- sync `.bazelrc` from envoy.
- `tryCreateNewConnection` now returns a `ConnPoolImplBase::ConnectionResult` instead of a `bool`.

Signed-off-by: Jakub Sobon <mumak@google.com>