### PR TITLE
CI: Fix broken docker tasks

### DIFF
--- a/ci/docker/Dockerfile-nighthawk
+++ b/ci/docker/Dockerfile-nighthawk
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:alpine-3.13_glibc-2.32
 
 ADD nighthawk_client /usr/local/bin/nighthawk_client
 ADD nighthawk_test_server /usr/local/bin/nighthawk_test_server

--- a/ci/docker/Dockerfile-nighthawk-benchmark
+++ b/ci/docker/Dockerfile-nighthawk-benchmark
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:alpine-3.13_glibc-2.32
 
 CMD ["./benchmarks" "--help"]
 ENV RUNFILES_DIR=/usr/local/bin/benchmarks/benchmarks.runfiles
@@ -8,7 +8,7 @@ WORKDIR /usr/local/bin/benchmarks
 
 COPY benchmarks /usr/local/bin/benchmarks/
 
-RUN apk add --no-cache docker=20.10.2-r0 openrc=0.42.1-r19 python3>=3.8.5
+RUN apk add --no-cache docker=20.10.3-r0 openrc=0.42.1-r19 python3=3.8.7-r0
 RUN rc-update add docker boot
 
 RUN if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python; fi && \


### PR DESCRIPTION
I think the root cause is that the alpine-glibc image updates,
and through that dependency requirements can no longer be met.

This PR
- pins the alpine image at the latest version
- changes the dependency versions so they work again

Note: the `>=` for python was changed to `=` as otherwise we'd
write a file to disk mentioning the version, this seemed contra
intent.

There's a complaint [1] emitted during the image build, so we need to
see if everything is OK when CI finishes.

[1] /usr/glibc-compat/sbin/ldconfig: /usr/glibc-compat/lib/ld-linux-x86-64.so.2 is not a symbolic link

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>