### PR TITLE
Update Envoy to cfe0391 (Feb 5th 2021).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-# The following .bazelrc content is forked from the main Envoy repository. This is necessary since	
+# The following .bazelrc content is forked from the main Envoy repository. This is necessary since
 # this needs to be available before we can access the Envoy repository contents via Bazel.
 
 build:clang-asan --test_timeout=900
@@ -287,18 +287,41 @@ build:remote-ci --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
 # Fuzz builds
+
+# Shared fuzzing configuration.
+build:fuzzing --define=ENVOY_CONFIG_ASAN=1
+build:fuzzing --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+build:fuzzing --config=libc++
+
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
+build:plain-fuzzer --config=fuzzing
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
-build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1
+# The fuzzing rules provide their own instrumentation, but it is currently
+# disabled due to bazelbuild/bazel#12888. Instead, we provide instrumentation at
+# the top level through these options.
 build:plain-fuzzer --copt=-fsanitize=fuzzer-no-link
 build:plain-fuzzer --linkopt=-fsanitize=fuzzer-no-link
-build:plain-fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
 build:asan-fuzzer --config=plain-fuzzer
 build:asan-fuzzer --config=asan
 build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
+
+build:oss-fuzz --config=fuzzing
+build:oss-fuzz --define=FUZZING_ENGINE=oss-fuzz
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
+build:oss-fuzz --dynamic_mode=off
+build:oss-fuzz --strip=never
+build:oss-fuzz --copt=-fno-sanitize=vptr
+build:oss-fuzz --linkopt=-fno-sanitize=vptr
+build:oss-fuzz --define=tcmalloc=disabled
+build:oss-fuzz --define=signal_trace=disabled
+build:oss-fuzz --copt=-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+build:oss-fuzz --define=force_libcpp=enabled
+build:oss-fuzz --linkopt=-lc++
+build:oss-fuzz --linkopt=-pthread
 
 # Compile database generation config
 build:compdb --build_tag_filters=-nocompdb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - run: ci/do_ci.sh test_gcc
+      - run:
+          command: ci/do_ci.sh test_gcc
+          no_output_timeout: 30m
   coverage:
     docker:
       - image: *envoy-build-image

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "f6679d51cc7b2f0b5e05c883a035ad87d011f454"  # Feb 1st, 2021
-ENVOY_SHA = "77a765b6f1063925ac53d09335dd23b546b4254a392755bddf5d81b4d299cd5f"
+ENVOY_COMMIT = "cfe0391ce24f7d11b3b125078ab77f6f4142e4ac"  # Feb 5th, 2021
+ENVOY_SHA = "5c9fbd5b95837ef409d85b6408bbb616452c164be5016c62e1c5055d3eeee268"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -143,7 +143,7 @@ std::string ConsoleOutputFormatterImpl::statIdtoFriendlyStatName(absl::string_vi
 }
 
 std::string JsonOutputFormatterImpl::formatProto(const nighthawk::client::Output& output) const {
-  return Envoy::MessageUtil::getJsonStringFromMessage(output, true, true);
+  return Envoy::MessageUtil::getJsonStringFromMessageOrDie(output, true, true);
 }
 
 std::string YamlOutputFormatterImpl::formatProto(const nighthawk::client::Output& output) const {
@@ -320,7 +320,7 @@ std::string FortioOutputFormatterImpl::formatProto(const nighthawk::client::Outp
   if (statistic != nullptr) {
     fortio_output.mutable_headersizes()->CopyFrom(renderFortioDurationHistogram(*statistic));
   }
-  return Envoy::MessageUtil::getJsonStringFromMessage(fortio_output, true, true);
+  return Envoy::MessageUtil::getJsonStringFromMessageOrDie(fortio_output, true, true);
 }
 
 const nighthawk::client::DurationHistogram FortioOutputFormatterImpl::renderFortioDurationHistogram(

--- a/test/output_transform_main_test.cc
+++ b/test/output_transform_main_test.cc
@@ -64,7 +64,7 @@ TEST_F(OutputTransformMainTest, HappyFlowForAllOutputFormats) {
       output.add_results()->set_name("global");
     }
     output.mutable_options()->mutable_uri()->set_value("http://127.0.0.1/");
-    stream_ << Envoy::MessageUtil::getJsonStringFromMessage(output, true, true);
+    stream_ << Envoy::MessageUtil::getJsonStringFromMessageOrDie(output, true, true);
     OutputTransformMain main(argv.size(), argv.data(), stream_);
     EXPECT_EQ(main.run(), 0);
   }

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -307,9 +307,9 @@ TEST(StatisticTest, HdrStatisticPercentilesProto) {
   util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
                         TestEnvironment::runfilesPath("test/test_data/hdr_proto_json.gold")),
                     parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
-  const std::string json = util.getJsonStringFromMessage(
+  const std::string json = util.getJsonStringFromMessageOrDie(
       statistic.toProto(Statistic::SerializationDomain::DURATION), true, true);
-  const std::string golden_json = util.getJsonStringFromMessage(parsed_json_proto, true, true);
+  const std::string golden_json = util.getJsonStringFromMessageOrDie(parsed_json_proto, true, true);
   EXPECT_THAT(statistic.toProto(Statistic::SerializationDomain::DURATION),
               Envoy::ProtoEq(parsed_json_proto))
       << json << "\n"
@@ -329,9 +329,9 @@ TEST(StatisticTest, CircllhistStatisticPercentilesProto) {
   util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
                         TestEnvironment::runfilesPath("test/test_data/circllhist_proto_json.gold")),
                     parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
-  const std::string json = util.getJsonStringFromMessage(
+  const std::string json = util.getJsonStringFromMessageOrDie(
       statistic.toProto(Statistic::SerializationDomain::DURATION), true, true);
-  const std::string golden_json = util.getJsonStringFromMessage(parsed_json_proto, true, true);
+  const std::string golden_json = util.getJsonStringFromMessageOrDie(parsed_json_proto, true, true);
   EXPECT_THAT(statistic.toProto(Statistic::SerializationDomain::DURATION),
               Envoy::ProtoEq(parsed_json_proto))
       << json << "\n"


### PR DESCRIPTION
- synchronizing `.bazelrc` from Envoy repository.
- the API of `getJsonStringFromMessage` changed, it now returns `ProtobufUtil::StatusOr` instead of `std::string`. Switching our code over to `getJsonStringFromMessageOrDie` which continues to return `std::string`.
- Increased the `no_output_timeout` parameter to 30m for test_gcc which was timing out.

Signed-off-by: Jakub Sobon <mumak@google.com>