### PR TITLE
Documenting more details of the "Update Envoy" process.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,11 +1,12 @@
-# The following .bazelrc content is forked from the main Envoy repository. This is necessary since	
-# this needs to be available before we can access the Envoy repository contents via Bazel.
-
-build:clang-asan --test_timeout=900
-build:clang-tsan --test_timeout=900
-# See https://github.com/envoyproxy/nighthawk/issues/405
-build:macos --copt -UDEBUG
-
+# The following .bazelrc content is forked from the main Envoy repository.                  # unique
+# This is  necessary since this needs to be available before we can access                  # unique
+# the Envoy repository contents via Bazel.                                                  # unique
+                                                                                            # unique
+build:clang-asan --test_timeout=900                                                         # unique
+build:clang-tsan --test_timeout=900                                                         # unique
+# See https://github.com/envoyproxy/nighthawk/issues/405                                    # unique
+build:macos --copt -UDEBUG                                                                  # unique
+                                                                                            # unique
 # Envoy specific Bazel build/test options.
 
 # Bazel doesn't need more than 200MB of memory for local build based on memory profiling:
@@ -60,10 +61,10 @@ build:asan --config=sanitizer
 # ASAN install its signal handler, disable ours so the stacktrace will be printed by ASAN
 build:asan --define signal_trace=disabled
 build:asan --define ENVOY_CONFIG_ASAN=1
-# The following two lines were manually edited due to #593.
-# Flag undefined was dropped from both the lines to allow CI/ASAN to pass.
-build:asan --copt -fsanitize=address
-build:asan --linkopt -fsanitize=address
+# The following two lines were manually edited due to #593.                                 # unique
+# Flag undefined was dropped from both the lines to allow CI/ASAN to pass.                  # unique
+build:asan --copt -fsanitize=address                                                        # unique
+build:asan --linkopt -fsanitize=address                                                     # unique
 # vptr and function sanitizer are enabled in clang-asan if it is set up via bazel/setup_clang.sh.
 build:asan --copt -fno-sanitize=vptr,function
 build:asan --linkopt -fno-sanitize=vptr,function

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,49 +4,72 @@ This document aims to assist [maintainers](OWNERS.md).
 
 ## Envoy domain expertise
 
-As a guideline, concepts in Nighthawk that are derived from Envoy
-require someone with Envoy domain expertise in review. Notable examples
-are the way Nighthawk internally computes cluster configuration, its
-connection pool derivations, the `StreamDecoder` class, as well as anything related to the Nighthawk test server.
+As a guideline, concepts in Nighthawk that are derived from Envoy require
+someone with Envoy domain expertise in review. Notable examples are the way
+Nighthawk internally computes cluster configuration, its connection pool
+derivations, the `StreamDecoder` class, as well as anything related to the
+Nighthawk test server.
 
-See [OWNERS.md](OWNERS.md) to find maintainers with expertise of
-Envoy internals.
+See [OWNERS.md](OWNERS.md) to find maintainers with expertise of Envoy
+internals.
 
 ## Pre-merge checklist
 
-- Does the PR have breaking changes? Then that should be explicitly mentioned in the [version history](docs/root/version_history.md).
-- New features should be added to the [version history](docs/root/version_history.md).
+- Does the PR have breaking changes? Then that should be explicitly mentioned in
+  the [version history](docs/root/version_history.md).
+- New features should be added to the
+  [version history](docs/root/version_history.md).
 - Breaking changes to the [protobuf APIs](api/) are not allowed.
-- When merging, clean up the commit message so we get a nice history. By default,
-  github will compile a message from all the commits that are squashed.
-  The PR title and description should be a good starting point for the final commit message. 
-  (If it is not, it may be worth asking the PR author to update the description).
+- When merging, clean up the commit message so we get a nice history. By
+  default, github will compile a message from all the commits that are squashed.
+  The PR title and description should be a good starting point for the final
+  commit message.  (If it is not, it may be worth asking the PR author to update
+  the description).
 - Make sure that the DCO signoff is included in the final commit message.
-  - As a convention, it is appropriate to exclude content in the PR description that occurs after the signoff.
+  - As a convention, it is appropriate to exclude content in the PR description
+    that occurs after the signoff.
 
 ## Updates to the Envoy dependency
 
-We aim to [synchronize our Envoy dependency](https://github.com/envoyproxy/nighthawk/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+%22update+envoy%22+) with the latest revision weekly. Nighthawk reuses large parts of Envoy's build system and codebase, so keeping Nighthawk up to date with Envoy's changes is an important maintenance task. When performing the update, follow this procedure:
+We aim to
+[synchronize our Envoy dependency](https://github.com/envoyproxy/nighthawk/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+%22update+envoy%22+)
+with the latest revision weekly. Nighthawk reuses large parts of Envoy's build
+system and codebase, so keeping Nighthawk up to date with Envoy's changes is an
+important maintenance task. When performing the update, follow this procedure:
 
-1. Create a fork of Nighthawk, or fetch upstream and merge changes into your fork if you already have one.
+1. Create a fork of Nighthawk, or fetch upstream and merge changes into your
+   fork if you already have one.
 1. Create a new branch from `main`, e.g. `envoy-update`.
 1. Edit [bazel/repositories.bzl](bazel/repositories.bzl).
-   1. Update `ENVOY_COMMIT` to the latest Envoy's commit from [this page](https://github.com/envoyproxy/envoy/commits/main). (Clicking on the short commit id opens a page that contains the fully expanded commit id).
-   1. Set `ENVOY_SHA` to an empty string initially, we will get the correct sha256 after the first bazel execution.
+   1. Update `ENVOY_COMMIT` to the latest Envoy's commit from 
+      [this page](https://github.com/envoyproxy/envoy/commits/main). (Clicking on the
+      short commit id opens a page that contains the fully expanded commit id).
+   1. Set `ENVOY_SHA` to an empty string initially, we will get the correct
+      sha256 after the first bazel execution.
    Example content of `bazel/repositories.bzl` after the edits:
    ```
    ENVOY_COMMIT = "9753819331d1547c4b8294546a6461a3777958f5"  # Jan 24th, 2021
    ENVOY_SHA = ""
    ```
-  1. Run `ci/do_ci.sh build`, notice the sha256 value at the top of the output, example:
+  1. Run `ci/do_ci.sh build`, notice the sha256 value at the top of the output,
+     example:
   ```
   INFO: SHA256 (https://github.com/envoyproxy/envoy/archive/9753819331d1547c4b8294546a6461a3777958f5.tar.gz) = f4d26c7e78c0a478d959ea8bc877f260d4658a8b44e294e3a400f20ad44d41a3
   ```
-  1. Update `ENVOY_SHA` in [bazel/repositories.bzl](bazel/repositories.bzl) to this value.
-1. Sync (copy) [.bazelrc](.bazelrc) from [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelrc) to update our build configurations. Be sure to retain our local modifications, all lines that are unique to Nighthawk are marked with comment `# unique`.
-1. Sync (copy) [.bazelversion](.bazelversion) from [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelversion) to ensure we are using the same build system version.
-1. Run `ci/do_ci.sh test`. Sometimes the dependency update comes with changes that break our build. Include any changes required to Nighthawk to fix that in the same PR.
-1. Create a PR with a title like `Update Envoy to 9753819 (Jan 24th 2021)`, describe all performed changes in the PR's descriotion.
+  1. Update `ENVOY_SHA` in [bazel/repositories.bzl](bazel/repositories.bzl) to
+     this value.
+1. Sync (copy) [.bazelrc](.bazelrc) from
+   [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelrc) to
+   update our build configurations. Be sure to retain our local modifications,
+   all lines that are unique to Nighthawk are marked with comment `# unique`.
+1. Sync (copy) [.bazelversion](.bazelversion) from
+   [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelversion)
+   to ensure we are using the same build system version.
+1. Run `ci/do_ci.sh test`. Sometimes the dependency update comes with changes
+   that break our build. Include any changes required to Nighthawk to fix that
+   in the same PR.
+1. Create a PR with a title like `Update Envoy to 9753819 (Jan 24th 2021)`,
+   describe all performed changes in the PR's descriotion.
 1. (optional) If the PR ends up modifying any c++ files, execute `ci/do_ci.sh
    fix_format` to reformat the files and avoid a CI failure.
 1. (optional) If the PR ends up modifying any CLI arguments, you may need to

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,7 +23,7 @@ internals.
 - When merging, clean up the commit message so we get a nice history. By
   default, github will compile a message from all the commits that are squashed.
   The PR title and description should be a good starting point for the final
-  commit message.  (If it is not, it may be worth asking the PR author to update
+  commit message. (If it is not, it may be worth asking the PR author to update
   the description).
 - Make sure that the DCO signoff is included in the final commit message.
   - As a convention, it is appropriate to exclude content in the PR description

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,9 +26,24 @@ Envoy internals.
 
 ## Updates to the Envoy dependency
 
-We try to [regularly synchronize our Envoy dependency](https://github.com/envoyproxy/nighthawk/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+%22update+envoy%22+) with the latest revision. Nighthawk reuses large parts of Envoy's build system and CI infrastructure. When we update, that looks like:
+We aim to [synchronize our Envoy dependency](https://github.com/envoyproxy/nighthawk/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+%22update+envoy%22+) with the latest revision weekly. Nighthawk reuses large parts of Envoy's build system and codebase, so keeping Nighthawk up to date with Envoy's changes is an important maintenance task. When performing the update, follow this procedure:
 
-- A change to [repositories.bzl](bazel/repositories.bzl) to update the commit and SHA.
-- A sync of [.bazelrc](.bazelrc) with [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelrc) to update our build configurations.
-- A sync of the build image sha used in the [ci configuration](.circleci/config.yml) with [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.circleci/config.yml) to sync our CI testing environment.
-- Sometimes the dependency update comes with changes that break our build. We include any changes required to Nighthawk to fix that.
+1. Create a fork of Nighthawk, or fetch upstream and merge changes into your fork if you already have one.
+1. Create a new branch from `main`, e.g. `envoy-update`.
+1. Edit [bazel/repositories.bzl](bazel/repositories.bzl).
+   1. Update `ENVOY_COMMIT` to the latest Envoy's commit from [this page](https://github.com/envoyproxy/envoy/commits/main). (Clicking on the short commit id opens a page that contains the fully expanded commit id).
+   1. Set `ENVOY_SHA` to an empty string initially, we will get the correct sha256 after the first bazel execution.
+   Example content of `bazel/repositories.bzl` after the edits:
+   ```
+   ENVOY_COMMIT = "9753819331d1547c4b8294546a6461a3777958f5"  # Jan 24th, 2021
+   ENVOY_SHA = ""
+   ```
+  1. Run `ci/do_ci.sh build`, notice the sha256 value at the top of the output, example:
+  ```
+  INFO: SHA256 (https://github.com/envoyproxy/envoy/archive/9753819331d1547c4b8294546a6461a3777958f5.tar.gz) = f4d26c7e78c0a478d959ea8bc877f260d4658a8b44e294e3a400f20ad44d41a3
+  ```
+  1. Update `ENVOY_SHA` in [bazel/repositories.bzl](bazel/repositories.bzl) to this value.
+1. Sync (copy) [.bazelrc](.bazelrc) from [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelrc) to update our build configurations. Be sure to retain our local modifications, all lines that are unique to Nighthawk are marked with comment `# unique`.
+1. Sync (copy) [.bazelversion](.bazelversion) from [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelversion) to ensure we are using the same build system version.
+1. Run `ci/do_ci.sh test`. Sometimes the dependency update comes with changes that break our build. Include any changes required to Nighthawk to fix that in the same PR.
+1. Create a PR with title like `Update Envoy to 9753819 (Jan 24th 2021)`, describe all performed changes in the PR's descriotion.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -70,9 +70,9 @@ important maintenance task. When performing the update, follow this procedure:
    in the same PR.
 1. Create a PR with a title like `Update Envoy to 9753819 (Jan 24th 2021)`,
    describe all performed changes in the PR's descriotion.
-1. (optional) If the PR ends up modifying any c++ files, execute `ci/do_ci.sh
-   fix_format` to reformat the files and avoid a CI failure.
-1. (optional) If the PR ends up modifying any CLI arguments, you may need to
-   execute `tools/update_cli_readme_documentation.sh --mode fix` to regenerate
-   the portion of our documentation that captures the CLI help output. This will
+1. If the PR ends up modifying any c++ files, execute `ci/do_ci.sh fix_format`
+   to reformat the files and avoid a CI failure.
+1. If the PR ends up modifying any CLI arguments, execute
+   `tools/update_cli_readme_documentation.sh --mode fix` to regenerate the
+   portion of our documentation that captures the CLI help output. This will
    prevent a CI failure.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -46,4 +46,10 @@ We aim to [synchronize our Envoy dependency](https://github.com/envoyproxy/night
 1. Sync (copy) [.bazelrc](.bazelrc) from [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelrc) to update our build configurations. Be sure to retain our local modifications, all lines that are unique to Nighthawk are marked with comment `# unique`.
 1. Sync (copy) [.bazelversion](.bazelversion) from [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelversion) to ensure we are using the same build system version.
 1. Run `ci/do_ci.sh test`. Sometimes the dependency update comes with changes that break our build. Include any changes required to Nighthawk to fix that in the same PR.
-1. Create a PR with title like `Update Envoy to 9753819 (Jan 24th 2021)`, describe all performed changes in the PR's descriotion.
+1. Create a PR with a title like `Update Envoy to 9753819 (Jan 24th 2021)`, describe all performed changes in the PR's descriotion.
+1. (optional) If the PR ends up modifying any c++ files, execute `ci/do_ci.sh
+   fix_format` to reformat the files and avoid a CI failure.
+1. (optional) If the PR ends up modifying any CLI arguments, you may need to
+   execute `tools/update_cli_readme_documentation.sh --mode fix` to regenerate
+   the portion of our documentation that captures the CLI help output. This will
+   prevent a CI failure.


### PR DESCRIPTION
- Step by step guide on how to perform the update.
- Marking our local changes in `.bazelrc` with `#unique`. To make it easier to spot them.
- Reformatting `MAINTAINERS.md`, adding line breaks at 80 char where appropriate.