### PR TITLE
Stats: Hdr histogram serialization/deserialization

### DIFF
--- a/include/nighthawk/common/BUILD
+++ b/include/nighthawk/common/BUILD
@@ -32,6 +32,7 @@ envoy_basic_cc_library(
         "@envoy//include/envoy/upstream:cluster_manager_interface_with_external_headers",
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/common/common:non_copyable_with_external_headers",
+        "@envoy//source/common/common:statusor_lib_with_external_headers",
         "@envoy//source/common/event:dispatcher_lib_with_external_headers",
         "@envoy//source/common/network:utility_lib_with_external_headers",
     ],

--- a/include/nighthawk/common/statistic.h
+++ b/include/nighthawk/common/statistic.h
@@ -11,6 +11,7 @@
 
 #include "api/client/output.pb.h"
 
+#include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 
 namespace Nighthawk {
@@ -115,6 +116,23 @@ public:
    * @param id The id that should be set for the Statistic instance.
    */
   virtual void setId(absl::string_view id) PURE;
+
+  /**
+   * Build a string representation of this Statistic instance.
+   *
+   * @return absl::StatusOr<std::unique_ptr<std::istream>> Status or a stream that will yield
+   * a serialized representation of this Statistic instance.
+   */
+  virtual absl::StatusOr<std::unique_ptr<std::istream>> serializeNative() const PURE;
+
+  /**
+   *  Reconstruct this Statistic instance using the serialization delivered by the input stream.
+   *
+   * @param input_stream Stream that will deliver a serialized representation.
+   * @return absl::Status Status indicating success or failure. Upon success the statistic
+   * instance this was called for will now represent what the stream contained.
+   */
+  virtual absl::Status deserializeNative(std::istream& input_stream) PURE;
 };
 
 } // namespace Nighthawk

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -26,6 +26,8 @@ public:
   uint64_t count() const override;
   uint64_t max() const override;
   uint64_t min() const override;
+  absl::StatusOr<std::unique_ptr<std::istream>> serializeNative() const override;
+  absl::Status deserializeNative(std::istream&) override;
 
 protected:
   std::string id_;
@@ -145,6 +147,9 @@ public:
   StatisticPtr createNewInstanceOfSameType() const override {
     return std::make_unique<HdrStatistic>();
   };
+
+  absl::StatusOr<std::unique_ptr<std::istream>> serializeNative() const override;
+  absl::Status deserializeNative(std::istream&) override;
 
 private:
   static const int SignificantDigits;

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -209,6 +209,42 @@ TYPED_TEST(TypedStatisticTest, ProtoOutputEmptyStats) {
   EXPECT_EQ(proto.pstdev().nanos(), 0);
 }
 
+TYPED_TEST(TypedStatisticTest, NativeRoundtrip) {
+  TypeParam a;
+
+  a.setId("bar");
+  a.addValue(6543456);
+  a.addValue(342335);
+  a.addValue(543);
+
+  const absl::StatusOr<std::unique_ptr<std::istream>> status_or_stream = a.serializeNative();
+  if (status_or_stream.ok()) {
+    // If the histogram states it implements native serialization/deserialization, put it through
+    // a round trip test.
+    TypeParam b;
+    absl::Status status = b.deserializeNative(*status_or_stream.value());
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(3, b.count());
+    EXPECT_EQ(a.count(), b.count());
+    EXPECT_EQ(a.mean(), b.mean());
+    EXPECT_EQ(a.pstdev(), b.pstdev());
+  } else {
+    EXPECT_EQ(status_or_stream.status().code(), absl::StatusCode::kUnimplemented);
+  }
+}
+
+TYPED_TEST(TypedStatisticTest, AttemptsToDeserializeBogusBehaveWell) {
+  // Deserializing corrupted data should either result in the statistic reporting
+  // it didn't implement deserialization, or having it report an internal failure.
+  const std::vector<absl::StatusCode> expected_status_list{absl::StatusCode::kInternal,
+                                                           absl::StatusCode::kUnimplemented};
+  TypeParam a;
+  std::istringstream bogus_input(std::string("BOGUS"));
+  const absl::Status status = a.deserializeNative(bogus_input);
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(expected_status_list, Contains(status.code()));
+}
+
 TYPED_TEST(TypedStatisticTest, StringOutput) {
   TypeParam a;
 


### PR DESCRIPTION
Being able to serialize and deserialize statistics serves several goals:
- Allow over-the-wire transportation in horizontally scaled setups.
- Facilitate storage of high res data.
- Could be used as a means to decouple our workers from the main thread,
  by avoiding reliance on a shared process namespace to merge statistics.
  (not a goal right now)

This adds an abstraction to Statistic, implements it for HdrHistogram, and
adds some tests.

Part of horizontal scaling effort, split out from:
Split out from https://github.com/oschaaf/nighthawk/tree/horizontal-scaling

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>