### PR TITLE
Fix potential hangs on exit & cap drain wait time

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -40,7 +40,7 @@ function do_clang_tidy() {
 
 function do_unit_test_coverage() {
     export TEST_TARGETS="//test/... -//test:python_test"
-    export COVERAGE_THRESHOLD=94.0
+    export COVERAGE_THRESHOLD=94.3
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
     exit 0

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -115,15 +115,13 @@ void BenchmarkClientHttpImpl::terminate() {
     // disabling latency measurement here.
     setShouldMeasureLatencies(false);
     pool()->addDrainedCallback([this]() -> void {
-      // We no longer need to the drain timer. Today this dispatcher is done for, but in the future
-      // it may get re-used as another phase continues execution for the pool. Therefore disarm it.
       drain_timer_->disableTimer();
       dispatcher_.exit();
     });
     pool()->drainConnections();
     // Set up a timer with a callback which caps the time we wait for the pool to drain.
     drain_timer_ = dispatcher_.createTimer([this]() -> void {
-      ENVOY_LOG(warn, "Connection pool drain timed out.");
+      ENVOY_LOG(info, "Wait for the connection pool drain timed out, proceeding to hard shutdown.");
       dispatcher_.exit();
     });
     drain_timer_->enableTimer(5s);

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -107,9 +107,26 @@ BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(
 }
 
 void BenchmarkClientHttpImpl::terminate() {
-  if (pool() != nullptr) {
-    pool()->addDrainedCallback([this]() -> void { dispatcher_.exit(); });
+  if (pool() != nullptr && pool()->hasActiveConnections()) {
+    // We don't report what happens after this call in the output, but latencies may still be
+    // reported via callbacks. This may happen after a long time (60s), which HdrHistogram can't
+    // track the way we configure it today, as that exceeds the max that it can record.
+    // No harm is done, but it does result in log lines warning about it. Avoid that, by
+    // disabling latency measurement here.
+    setShouldMeasureLatencies(false);
+    pool()->addDrainedCallback([this]() -> void {
+      // We no longer need to the drain timer. Today this dispatcher is done for, but in the future
+      // it may get re-used as another phase continues execution for the pool. Therefore disarm it.
+      drain_timer_->disableTimer();
+      dispatcher_.exit();
+    });
     pool()->drainConnections();
+    // Set up a timer with a callback which caps the time we wait for the pool to drain.
+    drain_timer_ = dispatcher_.createTimer([this]() -> void {
+      ENVOY_LOG(warn, "Connection pool drain timed out.");
+      dispatcher_.exit();
+    });
+    drain_timer_->enableTimer(5s);
     dispatcher_.run(Envoy::Event::Dispatcher::RunType::RunUntilExit);
   }
 }

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -118,7 +118,6 @@ void BenchmarkClientHttpImpl::terminate() {
       drain_timer_->disableTimer();
       dispatcher_.exit();
     });
-    pool()->drainConnections();
     // Set up a timer with a callback which caps the time we wait for the pool to drain.
     drain_timer_ = dispatcher_.createTimer([this]() -> void {
       ENVOY_LOG(info, "Wait for the connection pool drain timed out, proceeding to hard shutdown.");

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -165,6 +165,7 @@ private:
   const RequestGenerator request_generator_;
   const bool provide_resource_backpressure_;
   const std::string latency_response_header_name_;
+  Envoy::Event::TimerPtr drain_timer_;
 };
 
 } // namespace Client

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -424,8 +424,13 @@ TEST_F(BenchmarkClientHttpTest, DrainTimeoutFires) {
   RequestGenerator default_request_generator = getDefaultRequestGenerator();
   setupBenchmarkClient(default_request_generator);
   EXPECT_CALL(pool_, newStream(_, _))
-      .WillOnce([this](Envoy::Http::ResponseDecoder&, Envoy::Http::ConnectionPool::Callbacks&)
+      .WillOnce([this](Envoy::Http::ResponseDecoder& decoder,
+                       Envoy::Http::ConnectionPool::Callbacks& callbacks)
                     -> Envoy::Http::ConnectionPool::Cancellable* {
+        decoders_.push_back(&decoder);
+        NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+        callbacks.onPoolReady(stream_encoder_, Envoy::Upstream::HostDescriptionConstSharedPtr{},
+                              stream_info, {} /*absl::optional<Envoy::Http::Protocol> protocol*/);
         // Now that there's an active stream, terminate the benchmark client. The benchmark client
         // has to rely on the drain timeout to wrap up execution.
         client_->terminate();

--- a/test/integration/configurations/nighthawk_https_origin.yaml
+++ b/test/integration/configurations/nighthawk_https_origin.yaml
@@ -24,6 +24,7 @@ static_resources:
                       domains:
                         - "*"
                 http_filters:
+                  - name: dynamic-delay
                   - name: test-server
                     typed_config:
                       "@type": type.googleapis.com/nighthawk.server.ResponseOptions

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -795,11 +795,12 @@ def test_client_cli_bad_uri(http_test_server_fixture):
                                                        as_json=False)
   assert "Invalid target URI" in err
 
+
 @pytest.mark.parametrize('server_config',
                          ["nighthawk/test/integration/configurations/nighthawk_https_origin.yaml"])
 def test_drain(https_test_server_fixture):
   """Test that the pool drain timeout is effective, and we terminate in a timely fashion.
-  
+
   Sets up the test server to delay replies 100 seconds. Our execution will only last 3 seconds, so we
   expect to observe no replies. Termination should be cut short by the drain timeout, which means
   that we should have results in approximately execution duration + drain timeout = 8 seconds.
@@ -807,12 +808,12 @@ def test_drain(https_test_server_fixture):
   """
   t0 = time.time()
   parsed_json, _ = https_test_server_fixture.runNighthawkClient([
-      https_test_server_fixture.getTestServerRootUri(), "--rps", "100",
-      "--duration", "3", "--request-header", "x-nighthawk-test-server-config: {static_delay: \"100s\"}"
+      https_test_server_fixture.getTestServerRootUri(), "--rps", "100", "--duration", "3",
+      "--request-header", "x-nighthawk-test-server-config: {static_delay: \"100s\"}"
   ])
   t1 = time.time()
   time_delta = t1 - t0
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  assert time_delta < 20 # lots of slack to avoid failure in slow CI executions.
+  assert time_delta < 20  # lots of slack to avoid failure in slow CI executions.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertNotIn("benchmark.http_2xx", counters)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -794,3 +794,25 @@ def test_client_cli_bad_uri(http_test_server_fixture):
                                                        expect_failure=True,
                                                        as_json=False)
   assert "Invalid target URI" in err
+
+@pytest.mark.parametrize('server_config',
+                         ["nighthawk/test/integration/configurations/nighthawk_https_origin.yaml"])
+def test_drain(https_test_server_fixture):
+  """Test that the pool drain timeout is effective, and we terminate in a timely fashion.
+  
+  Sets up the test server to delay replies 100 seconds. Our execution will only last 3 seconds, so we
+  expect to observe no replies. Termination should be cut short by the drain timeout, which means
+  that we should have results in approximately execution duration + drain timeout = 8 seconds.
+  (the pool drain timeout is hard coded to 5 seconds as of writing this).
+  """
+  t0 = time.time()
+  parsed_json, _ = https_test_server_fixture.runNighthawkClient([
+      https_test_server_fixture.getTestServerRootUri(), "--rps", "100",
+      "--duration", "3", "--request-header", "x-nighthawk-test-server-config: {static_delay: \"100s\"}"
+  ])
+  t1 = time.time()
+  time_delta = t1 - t0
+  counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
+  assert time_delta < 20 # lots of slack to avoid failure in slow CI executions.
+  asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
+  asserts.assertNotIn("benchmark.http_2xx", counters)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -814,6 +814,6 @@ def test_drain(https_test_server_fixture):
   t1 = time.time()
   time_delta = t1 - t0
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  assert time_delta < 20  # lots of slack to avoid failure in slow CI executions.
+  assert time_delta < 40  # *lots* of slack to avoid failure in slow CI executions.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertNotIn("benchmark.http_2xx", counters)


### PR DESCRIPTION
- don't set up a drain callback when there are no active connections
- set up a timer that will cap the amount of time we wait for the pool
  to drain.
- disable latency measurement when commencing the drain procedure, as
  by that time we are no longer interested in it, and in particular
  don't want to hear about any warnings issued by the Statistic
  implementation about recorded values being too large. 

Fixes #627

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>