### PR TITLE
Remove strict equality for error message

### DIFF
--- a/test/server/http_test_server_filter_integration_test.cc
+++ b/test/server/http_test_server_filter_integration_test.cc
@@ -298,7 +298,7 @@ TEST(HttpTestServerDecoderFilterTest, HeaderMerge) {
   EXPECT_FALSE(Server::Configuration::mergeJsonConfig("bad_json", options, error_message));
   EXPECT_THAT(error_message,
               testing::HasSubstr("Error merging json config: Unable to parse JSON as proto "
-                                 "(INVALID_ARGUMENT: Unexpected token.\nbad_json\n^): bad_json"));
+                                 "(INVALID_ARGUMENT:Unexpected token.\nbad_json\n^): bad_json"));
   EXPECT_EQ(3, options.response_headers_size());
 }
 

--- a/test/server/http_test_server_filter_integration_test.cc
+++ b/test/server/http_test_server_filter_integration_test.cc
@@ -296,9 +296,9 @@ TEST(HttpTestServerDecoderFilterTest, HeaderMerge) {
                       {":status", "200"}, {"foo", "bar2"}, {"foo2", "bar3"}}));
 
   EXPECT_FALSE(Server::Configuration::mergeJsonConfig("bad_json", options, error_message));
-  EXPECT_EQ("Error merging json config: Unable to parse JSON as proto (INVALID_ARGUMENT:Unexpected "
-            "token.\nbad_json\n^): bad_json",
-            error_message);
+  EXPECT_THAT(error_message,
+              testing::HasSubstr("Error merging json config: Unable to parse JSON as proto "
+                                 "(INVALID_ARGUMENT: Unexpected token.\nbad_json\n^): bad_json"));
   EXPECT_EQ(3, options.response_headers_size());
 }
 


### PR DESCRIPTION
Recommend not to check for strict equality on error messages. This is aligned with [Google Cloud APIs error model](https://cloud.google.com/apis/design/errors#error_messages).

We are considering adding extra debug information to the underlying JSON parser library. The extra debug information breaks this test if it checks for strict equality.

Signed-off-by: Teju Nareddy <nareddyt@google.com>