### PR TITLE
Fix python dependency version for NightHawk Benchmark image

### DIFF
--- a/ci/docker/Dockerfile-nighthawk-benchmark
+++ b/ci/docker/Dockerfile-nighthawk-benchmark
@@ -8,7 +8,7 @@ WORKDIR /usr/local/bin/benchmarks
 
 COPY benchmarks /usr/local/bin/benchmarks/
 
-RUN apk add --no-cache docker=20.10.3-r0 openrc=0.42.1-r19 python3=3.8.7-r0
+RUN apk add --no-cache docker=20.10.3-r0 openrc=0.42.1-r19 python3>=3.8.7-r0
 RUN rc-update add docker boot
 
 RUN if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python; fi && \


### PR DESCRIPTION
When invoking `ci/docker/benchmark_build.sh`, the image build fails for me with:

```
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  python3-3.8.7-r1:
    breaks: world[python3=3.8.7-r0]
The command '/bin/sh -c apk add --no-cache docker=20.10.3-r0 openrc=0.42.1-r19 python3=3.8.7-r0' returned a non-zero code: 1
```

The change in this PR updates the Dockerfile to ensure that the python version listed is the minimum required version.

With this change in place, the docker image build script completes successfully:

```bash
$ ci/docker/benchmark_build.sh
...
Step 8/11 : RUN apk add --no-cache docker=20.10.3-r0 openrc=0.42.1-r19 python3>=3.8.7-r0
 ---> Running in 88d67905ec33
...
 ---> 10194209eab7
Successfully built 10194209eab7
Successfully tagged envoyproxy/nighthawk-benchmark-dev:latest
docker build finished
```

cc: @oschaaf 



Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>