### PR TITLE
Update Envoy to 23a43b2 (March 1st, 2021)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 ENVOY_COMMIT = "23a43b2eaf37f0a44a8953f076a0d055575b2a62"  # March 1st, 2021
-ENVOY_SHA = ""
+ENVOY_SHA = "6c0714e6cdea537217b86900a86e3606299bd54e2502a29202407533c124c160"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "f9301ff57f64fd49918a61f6ac305638f065ecfb"  # Feb 26th, 2021
-ENVOY_SHA = "0aa2a2baf99d5c6a0c98ab8011aac4d28594deb5419fd92d368424324f9e1779"
+ENVOY_COMMIT = "23a43b2eaf37f0a44a8953f076a0d055575b2a62"  # March 1st, 2021
+ENVOY_SHA = ""
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
Following instructions from https://github.com/envoyproxy/nighthawk/blob/main/MAINTAINERS.md#updates-to-the-envoy-dependency 

- Updated Envoy Commit and Envoy_sha in repositories.bzl.
- bazelrc, bazelversion, docker.sh remain unchanged.