### PR TITLE
Update Envoy to 031f75d (Mar 14th 2021)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -63,7 +63,7 @@ important maintenance task. When performing the update, follow this procedure:
    update our build configurations. Be sure to retain our local modifications,
    all lines that are unique to Nighthawk are marked with comment `# unique`.
 1. In the updated [.bazelrc](.bazelrc) search for `experimental_docker_image`.
-   Copy the SHA and update `envoy-build-image:sha` over at the top of [.circleci/config.yml](.circleci/config.yml).
+   Copy the SHA and update `envoyproxy/envoy-build-ubuntu` over at the top of [.circleci/config.yml](.circleci/config.yml).
 1. Sync (copy) [.bazelversion](.bazelversion) from
    [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/.bazelversion)
    to ensure we are using the same build system version.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ format>
 Where:
 
 --allow-envoy-deprecated-v2-api
-Set to allow usage of the v2 api. (Not recommended, support will stop
-in Q1 2021). Default: false
+DEPRECATED, not supported anymore.
 
 --latency-response-header-name <string>
 Set an optional header name that will be returned in responses, whose

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "62bd82d750ed0cbc50e92baa56432ddba68d4025"  # March 8th, 2021
-ENVOY_SHA = "7529e050b82a555ab6a68e0420a30a1cb294ed117bceaa77962f82d86cb7fd60"
+ENVOY_COMMIT = "031f75dd113e2f7be41b94a0365145e7bf1e6c12"  # March 14th, 2021
+ENVOY_SHA = "20f5f98cc9a5c1ddd2c3de434b019273e3dbe02afe52396b90d74fab38dba4ba"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -315,11 +315,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "Default: \"\"",
       false, "", "string", cmd);
 
-  TCLAP::SwitchArg allow_envoy_deprecated_v2_api(
-      "", "allow-envoy-deprecated-v2-api",
-      "Set to allow usage of the v2 api. (Not recommended, support will stop in Q1 2021). Default: "
-      "false",
-      cmd);
+  TCLAP::SwitchArg allow_envoy_deprecated_v2_api("", "allow-envoy-deprecated-v2-api",
+                                                 "DEPRECATED, not supported anymore.", cmd);
 
   Utility::parseCommand(cmd, argc, argv);
 

--- a/source/common/request_source_impl.cc
+++ b/source/common/request_source_impl.cc
@@ -44,7 +44,7 @@ void RemoteRequestSourceImpl::connectToRequestStreamGrpcService() {
   grpc_service.mutable_envoy_grpc()->set_cluster_name(service_cluster_name_);
   Envoy::Grpc::AsyncClientFactoryPtr cluster_manager =
       cluster_manager_->grpcAsyncClientManager().factoryForGrpcService(
-          grpc_service, scope_, Envoy::Grpc::AsyncClientFactoryClusterChecks::Skip);
+          grpc_service, scope_, /*skip_cluster_check=*/true);
   grpc_client_ = std::make_unique<RequestStreamGrpcClientImpl>(
       cluster_manager->create(), dispatcher_, *base_header_, header_buffer_length_);
   grpc_client_->start();

--- a/source/common/request_source_impl.cc
+++ b/source/common/request_source_impl.cc
@@ -43,8 +43,8 @@ void RemoteRequestSourceImpl::connectToRequestStreamGrpcService() {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name(service_cluster_name_);
   Envoy::Grpc::AsyncClientFactoryPtr cluster_manager =
-      cluster_manager_->grpcAsyncClientManager().factoryForGrpcService(
-          grpc_service, scope_, /*skip_cluster_check=*/true);
+      cluster_manager_->grpcAsyncClientManager().factoryForGrpcService(grpc_service, scope_,
+                                                                       /*skip_cluster_check=*/true);
   grpc_client_ = std::make_unique<RequestStreamGrpcClientImpl>(
       cluster_manager->create(), dispatcher_, *base_header_, header_buffer_length_);
   grpc_client_->start();

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -421,19 +421,6 @@ def http_test_server_fixture(request, server_config, caplog):
 
 
 @pytest.fixture(params=determineIpVersionsFromEnvironment())
-def http_test_server_fixture_envoy_deprecated_v2_api(request, server_config, caplog):
-  """Fixture for setting up a test environment with http server configuration that uses v2 configuration.
-
-  Yields:
-      HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap: A fully set up instance. Tear down will happen automatically.
-  """
-  f = HttpIntegrationTestBaseWithEnvoyDeprecatedV2Bootstrap(request, server_config)
-  f.setUp()
-  yield f
-  f.tearDown(caplog)
-
-
-@pytest.fixture(params=determineIpVersionsFromEnvironment())
 def https_test_server_fixture(request, server_config, caplog):
   """Fixture for setting up a test environment with the stock https server configuration.
 

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -11,9 +11,8 @@ from threading import Thread
 
 from test.integration.common import IpVersion
 from test.integration.integration_test_fixtures import (
-    http_test_server_fixture, http_test_server_fixture_envoy_deprecated_v2_api,
-    https_test_server_fixture, https_test_server_fixture, multi_http_test_server_fixture,
-    multi_https_test_server_fixture, server_config)
+    http_test_server_fixture, https_test_server_fixture, https_test_server_fixture,
+    multi_http_test_server_fixture, multi_https_test_server_fixture, server_config)
 from test.integration import asserts
 from test.integration import utility
 
@@ -64,22 +63,6 @@ def test_http_h1(http_test_server_fixture):
       int(global_histograms["benchmark_http_client.response_header_size"]["raw_pstdev"]), 0)
 
   asserts.assertEqual(len(counters), 12)
-
-
-@pytest.mark.parametrize('server_config', [
-    "nighthawk/test/integration/configurations/nighthawk_http_origin_envoy_deprecated_v2_api.yaml"
-])
-def test_nighthawk_test_server_envoy_deprecated_v2_api(
-    http_test_server_fixture_envoy_deprecated_v2_api):
-  """Test that the v2 configuration works for the test server."""
-  parsed_json, _ = http_test_server_fixture_envoy_deprecated_v2_api.runNighthawkClient([
-      http_test_server_fixture_envoy_deprecated_v2_api.getTestServerRootUri(), "--duration", "100",
-      "--termination-predicate", "benchmark.http_2xx:24"
-  ])
-
-  counters = http_test_server_fixture_envoy_deprecated_v2_api.getNighthawkCounterMapFromJson(
-      parsed_json)
-  asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
 
 
 # TODO(oschaaf): This ought to work after the Envoy update.

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -82,19 +82,6 @@ def test_nighthawk_test_server_envoy_deprecated_v2_api(
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
 
 
-def test_nighthawk_client_v2_api_explicitly_set(http_test_server_fixture):
-  """Test that the v2 api works when requested to."""
-  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
-      http_test_server_fixture.getTestServerRootUri(), "--duration", "100",
-      "--termination-predicate", "benchmark.pool_connection_failure:0", "--failure-predicate",
-      "foo:1", "--allow-envoy-deprecated-v2-api", "--transport-socket",
-      "{name:\"envoy.transport_sockets.tls\",typed_config:{\"@type\":\"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext\",\"common_tls_context\":{}}}"
-  ])
-
-  counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  asserts.assertCounterEqual(counters, "benchmark.pool_connection_failure", 1)
-
-
 # TODO(oschaaf): This ought to work after the Envoy update.
 def DISABLED_test_nighthawk_client_v2_api_breaks_by_default(http_test_server_fixture):
   """Test that the v2 api breaks us when it's not explicitly requested."""


### PR DESCRIPTION
- `.bazelrc` was unchanged
- `.circleci/config.yml` was unchanged
- `.bazelversion` was unchanged
- `ci/run_envoy_docker.sh` was unchanged


- Code changes
  - Replace `factoryForGrpcService(..., Envoy::Grpc::AsyncClientFactoryClusterChecks::Skip)` with `factoryForGrpcService(..., /*skip_cluster_check=*/true)` due to PR #15449 in Envoy
  - Delete test `test_nighthawk_client_v2_api_explicitly_set` and `test_nighthawk_test_server_envoy_deprecated_v2_api` in `test/integration/test_integration_basics.py` since they are broken by Envoy PR #15481
  - Delete test fixture `http_test_server_fixture_envoy_deprecated_v2_api` in `test/integration/integration_test_fixtures.py`
- Update MAINTAINERS.md

Signed-off-by: qqustc@gmail.com <qqin@google.com>