### PR TITLE
Remove pip_repositories usage.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,9 +30,7 @@ load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 envoy_dependency_imports()
 
 # For PIP support:
-load("@rules_python//python:pip.bzl", "pip_install", "pip_repositories")
-
-pip_repositories()
+load("@rules_python//python:pip.bzl", "pip_install")
 
 # This rule translates the specified requirements.txt into
 # @my_deps//:requirements.bzl, which itself exposes a pip_install method.


### PR DESCRIPTION
The following gets emitted in the output of the build process:

```
DEPRECATED: the pip_repositories rule has been replaced with pip_install,
please see rules_python 0.1 release notes
```

This change stops that. It seems we no longer need it:
https://github.com/bazelbuild/rules_python/commit/8537cea11d867333c07c465d536778c1b7560cde

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>