### PR TITLE
Add execution-id & separate the options BUILD targets

### DIFF
--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -106,7 +106,7 @@ message H1ConnectionReuseStrategy {
 
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
-// highest unused number is 39
+// highest unused number is 40
 message CommandLineOptions {
   // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
@@ -225,4 +225,10 @@ message CommandLineOptions {
   google.protobuf.Timestamp scheduled_start = 105;
 
   reserved 38; // deprecated
+  // Provide a unique execution id. Will be reflected in the output when set.
+  // This is intended for future use in horizontally scaled scenarios in mind.
+  // When populating this field, it is recommended to use unique identifiers for forward
+  // compatibility purposes. In the future, this field may be auto-populated when left unset and
+  // circumstances mandate so (distributed load test execution).
+  google.protobuf.StringValue execution_id = 39;
 }

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -106,7 +106,7 @@ message H1ConnectionReuseStrategy {
 
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
-// highest unused number is 40
+// highest unused number is 107
 message CommandLineOptions {
   // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
@@ -230,5 +230,5 @@ message CommandLineOptions {
   // When populating this field, it is recommended to use unique identifiers for forward
   // compatibility purposes. In the future, this field may be auto-populated when left unset and
   // circumstances mandate so (distributed load test execution).
-  google.protobuf.StringValue execution_id = 39;
+  google.protobuf.StringValue execution_id = 106;
 }

--- a/include/nighthawk/client/BUILD
+++ b/include/nighthawk/client/BUILD
@@ -9,16 +9,32 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_basic_cc_library(
+    name = "options_lib",
+    hdrs = [
+        "options.h",
+    ],
+    include_prefix = "nighthawk/client",
+    deps = [
+        "//api/client:base_cc_proto",
+        "//include/nighthawk/common:base_includes",
+        "@envoy//include/envoy/common:time_interface",
+        "@envoy//source/common/common:minimal_logger_lib_with_external_headers",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_basic_cc_library(
     name = "client_includes",
     hdrs = [
         "benchmark_client.h",
         "client_worker.h",
         "factories.h",
-        "options.h",
         "process.h",
     ],
     include_prefix = "nighthawk/client",
     deps = [
+        ":options_lib",
         ":output_collector_lib",
         ":output_formatter_lib",
         "//api/client:base_cc_proto",

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -77,6 +77,8 @@ public:
   virtual std::string responseHeaderWithLatencyInput() const PURE;
 
   virtual absl::optional<Envoy::SystemTime> scheduled_start() const PURE;
+  virtual absl::optional<std::string> executionId() const PURE;
+
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option
    * values.

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -9,6 +9,25 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_library(
+    name = "options_impl_lib",
+    srcs = [
+        "options_impl.cc",
+    ],
+    hdrs = [
+        "options_impl.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":output_formatter_impl_lib",
+        "//include/nighthawk/client:options_lib",
+        "@envoy//source/common/protobuf:message_validator_lib_with_external_headers",
+        "@envoy//source/common/protobuf:utility_lib_with_external_headers",
+        "@envoy//source/server:options_lib_with_external_headers",
+    ],
+)
+
+envoy_cc_library(
     name = "nighthawk_client_lib",
     srcs = [
         "benchmark_client_impl.cc",
@@ -16,7 +35,6 @@ envoy_cc_library(
         "client_worker_impl.cc",
         "factories_impl.cc",
         "flush_worker_impl.cc",
-        "options_impl.cc",
         "process_impl.cc",
         "remote_process_impl.cc",
         "sni_utility.cc",
@@ -28,7 +46,6 @@ envoy_cc_library(
         "client_worker_impl.h",
         "factories_impl.h",
         "flush_worker_impl.h",
-        "options_impl.h",
         "process_impl.h",
         "remote_process_impl.h",
         "sni_utility.h",
@@ -41,6 +58,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        ":options_impl_lib",
         ":output_collector_impl_lib",
         ":output_formatter_impl_lib",
         "//api/client:base_cc_proto",
@@ -87,7 +105,6 @@ envoy_cc_library(
         "@envoy//source/extensions/request_id/uuid:config_with_external_headers",
         "@envoy//source/extensions/transport_sockets:well_known_names_with_external_headers",
         "@envoy//source/extensions/transport_sockets/tls:context_lib_with_external_headers",
-        "@envoy//source/server:options_lib_with_external_headers",
         "@envoy//source/server:server_lib_with_external_headers",
         "@envoy//source/server/config_validation:admin_lib_with_external_headers",
         "@envoy//include/envoy/http:protocol_interface_with_external_headers",

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -659,6 +659,9 @@ OptionsImpl::OptionsImpl(const nighthawk::client::CommandLineOptions& options) {
     scheduled_start_ =
         Envoy::SystemTime(std::chrono::time_point<std::chrono::system_clock>(elapsed_since_epoch));
   }
+  if (options.has_execution_id()) {
+    execution_id_ = options.execution_id().value();
+  }
   validate();
 }
 
@@ -839,6 +842,9 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
     *(command_line_options->mutable_scheduled_start()) =
         Envoy::ProtobufUtil::TimeUtil::NanosecondsToTimestamp(
             scheduled_start_.value().time_since_epoch().count());
+  }
+  if (execution_id_.has_value()) {
+    command_line_options->mutable_execution_id()->set_value(execution_id_.value());
   }
   return command_line_options;
 }

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -94,6 +94,7 @@ public:
     return latency_response_header_name_;
   };
   absl::optional<Envoy::SystemTime> scheduled_start() const override { return scheduled_start_; }
+  absl::optional<std::string> executionId() const override { return execution_id_; }
 
 private:
   void parsePredicates(const TCLAP::MultiArg<std::string>& arg,
@@ -151,6 +152,7 @@ private:
   uint32_t stats_flush_interval_{5};
   std::string latency_response_header_name_;
   absl::optional<Envoy::SystemTime> scheduled_start_;
+  absl::optional<std::string> execution_id_;
 };
 
 } // namespace Client

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -58,6 +58,7 @@ public:
   MOCK_CONST_METHOD0(statsFlushInterval, uint32_t());
   MOCK_CONST_METHOD0(responseHeaderWithLatencyInput, std::string());
   MOCK_CONST_METHOD0(scheduled_start, absl::optional<Envoy::SystemTime>());
+  MOCK_CONST_METHOD0(executionId, absl::optional<std::string>());
 };
 
 } // namespace Client


### PR DESCRIPTION
Another prelude to distributed test execution. Being able to
identify executions and associate results is going to come in
handy.

Also, this separates some BUILD targets to allow for a leaner build
process of future things that are going to depend on it.

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>