### PR TITLE
Sink: add in memory sink, slightly refactor validation/testing.

### DIFF
--- a/include/nighthawk/sink/sink.h
+++ b/include/nighthawk/sink/sink.h
@@ -30,7 +30,7 @@ public:
    * @return absl::Status Indicates if the operation succeeded or not.
    */
   virtual absl::Status
-  StoreExecutionResultPiece(const nighthawk::client::ExecutionResponse& response) const PURE;
+  StoreExecutionResultPiece(const nighthawk::client::ExecutionResponse& response) PURE;
 
   /**
    * Attempt to load a vector of ExecutionResponse instances associated to an execution id.

--- a/source/sink/sink_impl.h
+++ b/source/sink/sink_impl.h
@@ -2,6 +2,8 @@
 
 #include "nighthawk/sink/sink.h"
 
+#include "absl/container/flat_hash_map.h"
+
 namespace Nighthawk {
 
 /**
@@ -11,9 +13,23 @@ namespace Nighthawk {
 class FileSinkImpl : public Sink {
 public:
   absl::Status
-  StoreExecutionResultPiece(const nighthawk::client::ExecutionResponse& response) const override;
+  StoreExecutionResultPiece(const nighthawk::client::ExecutionResponse& response) override;
   absl::StatusOr<std::vector<nighthawk::client::ExecutionResponse>>
   LoadExecutionResult(absl::string_view id) const override;
+};
+
+/**
+ * Memory based implementation of Sink.
+ */
+class InMemorySinkImpl : public Sink {
+public:
+  absl::Status
+  StoreExecutionResultPiece(const nighthawk::client::ExecutionResponse& response) override;
+  absl::StatusOr<std::vector<nighthawk::client::ExecutionResponse>>
+  LoadExecutionResult(absl::string_view id) const override;
+
+private:
+  absl::flat_hash_map<std::string, std::vector<nighthawk::client::ExecutionResponse>> map_;
 };
 
 } // namespace Nighthawk

--- a/test/mocks/sink/mock_sink.h
+++ b/test/mocks/sink/mock_sink.h
@@ -9,11 +9,10 @@ namespace Nighthawk {
 class MockSink : public Sink {
 public:
   MockSink();
-  MOCK_CONST_METHOD1(StoreExecutionResultPiece,
-                     absl::Status(const nighthawk::client::ExecutionResponse&));
-  MOCK_CONST_METHOD1(
-      LoadExecutionResult,
-      absl::StatusOr<std::vector<nighthawk::client::ExecutionResponse>>(absl::string_view));
+  MOCK_METHOD(absl::Status, StoreExecutionResultPiece,
+              (const nighthawk::client::ExecutionResponse&));
+  MOCK_METHOD(absl::StatusOr<std::vector<nighthawk::client::ExecutionResponse>>,
+              LoadExecutionResult, (absl::string_view), (const));
 };
 
 } // namespace Nighthawk


### PR DESCRIPTION
- Adds an in-memory sink. Comes in handy in tests, and could serve
  a future role if we want to converge the way results are handled
  in both distributed and non-distributed tests.
- Slightly refactors validation & testing to make it easier to see
  what is specific to FileSinkImpl, making things a little more
  natural in case someone else wants to  add a new sink type in the
  future.
- Avoid MOCK_METHOD_N in the Sink mock as per recommendation.

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>