### PR TITLE
Update Envoy to 2858cd2 (April 06th 2021)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -154,7 +154,7 @@ build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --experimental_use_llvm_covmap
 build:coverage --collect_code_coverage
 build:coverage --test_tag_filters=-nocoverage
-build:coverage --instrumentation_filter="//source(?!/common/chromium_url|/extensions/quic_listeners/quiche/platform)[/:],//include[/:]"
+build:coverage --instrumentation_filter="//source(?!/common/chromium_url|/common/quic/platform)[/:],//include[/:]"
 build:test-coverage --test_arg="-l trace"
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "486cd88789625afe786de80d0b3f3b07576f3557"  # March 28, 2021
-ENVOY_SHA = "595282e9e7565d2957083b44e0c1fccc7a09b36397d46b149194871b47ae55b4"
+ENVOY_COMMIT = "2858cd25cb206f15f4a02f360186d23cc4167da3"  # April 06, 2021
+ENVOY_SHA = ""
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 ENVOY_COMMIT = "2858cd25cb206f15f4a02f360186d23cc4167da3"  # April 06, 2021
-ENVOY_SHA = ""
+ENVOY_SHA = "95df261de8ab7d71936d3e4822de5c7b2d96c41461422203d59b4bc4c6b4f4dd"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
Followed instructions from: https://github.com/envoyproxy/nighthawk/blob/main/MAINTAINERS.md#updates-to-the-envoy-dependency 
Tests passed, no changes required.