### PR TITLE
Enable test_gcc on arm64 platform for ci

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -17,6 +17,7 @@ export BAZEL_OPTIONS=${BAZEL_OPTIONS:=""}
 export BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS:=""}
 export SRCDIR=${SRCDIR:="${PWD}"}
 export CLANG_FORMAT=clang-format
+export NIGHTHAWK_BUILD_ARCH=$(uname -m)
 
 function do_build () {
     bazel build $BAZEL_BUILD_OPTIONS //:nighthawk
@@ -60,6 +61,8 @@ function setup_gcc_toolchain() {
     export CC=gcc
     export CXX=g++
     export BAZEL_COMPILER=gcc
+    [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS="$BAZEL_BUILD_OPTIONS --copt -march=armv8-a+crypto"
+    [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_TEST_OPTIONS="$BAZEL_TEST_OPTIONS --copt -march=armv8-a+crypto"
     echo "$CC/$CXX toolchain configured"
 }
 


### PR DESCRIPTION
Add aarch64 Bazel build options for GCC toolchain
which would enable the test_gcc for ci script on
arm platform.

Signed-off-by: trevor tao <trevor.tao@arm.com>