### PR TITLE
Update Envoy to 751be72 (April 19th 2021)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -83,8 +83,6 @@ build:clang-asan --linkopt -fuse-ld=lld
 
 # macOS ASAN/UBSAN
 build:macos --cxxopt=-std=c++17
-build:macos --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-build:macos --action_env=BAZEL_LINKOPTS=-lm
 
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932
@@ -260,7 +258,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:3d0491e2034287959a292806e3891fd0b7dd2703
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
   envoy-build-image: &envoy-build-image # March 8th, 2021
-    envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
+    envoyproxy/envoy-build-ubuntu:3d0491e2034287959a292806e3891fd0b7dd2703
 version: 2
 jobs:
   build:

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "27f67d18277648affef80e659ccc68cdfaaa418c"  # April 12, 2021
-ENVOY_SHA = "82be18e5647fba9df97bf46a4ec2ccc7753e57addcde1e068b6f98a61d9f113f"
+ENVOY_COMMIT = "751be72c2eb967ff03759b6e50dde106c8cf5c84"  # April 19, 2021
+ENVOY_SHA = "43a538a299f0169cd6b15d3a8d757b51870487bb7e50766108f0917e5974f412"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/test/server/http_dynamic_delay_filter_integration_test.cc
+++ b/test/server/http_dynamic_delay_filter_integration_test.cc
@@ -65,19 +65,19 @@ typed_config:
   "@type": type.googleapis.com/nighthawk.server.ResponseOptions
 )");
   // Don't send any config request header ...
-  getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(getResponse(ResponseOrigin::UPSTREAM)->waitForEndStream());
   // ... we shouldn't observe any delay being requested via the upstream request headers.
   EXPECT_TRUE(upstream_request_->headers().get(kDelayHeaderString).empty());
 
   // Send a config request header with an empty / default configuration ....
   setRequestLevelConfiguration("{}");
-  getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(getResponse(ResponseOrigin::UPSTREAM)->waitForEndStream());
   // ... we shouldn't observe any delay being requested via the upstream request headers.
   EXPECT_TRUE(upstream_request_->headers().get(kDelayHeaderString).empty());
 
   // Send a config request header requesting a 1.6s delay...
   setRequestLevelConfiguration("{static_delay: \"1.6s\"}");
-  getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(getResponse(ResponseOrigin::UPSTREAM)->waitForEndStream());
   // ...we should observe a delay of 1.6s in the upstream request.
   ASSERT_EQ(upstream_request_->headers().get(kDelayHeaderString).size(), 1);
   EXPECT_EQ(upstream_request_->headers().get(kDelayHeaderString)[0]->value().getStringView(),
@@ -95,7 +95,7 @@ typed_config:
 
   // Without any request-level configuration, we expect the statically configured static delay to
   // apply.
-  getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(getResponse(ResponseOrigin::UPSTREAM)->waitForEndStream());
   ASSERT_EQ(upstream_request_->headers().get(kDelayHeaderString).size(), 1);
   EXPECT_EQ(upstream_request_->headers().get(kDelayHeaderString)[0]->value().getStringView(),
             "1330");
@@ -103,7 +103,7 @@ typed_config:
   // With an empty request-level configuration, we expect the statically configured static delay to
   // apply.
   setRequestLevelConfiguration("{}");
-  getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(getResponse(ResponseOrigin::UPSTREAM)->waitForEndStream());
   ASSERT_EQ(upstream_request_->headers().get(kDelayHeaderString).size(), 1);
   EXPECT_EQ(upstream_request_->headers().get(kDelayHeaderString)[0]->value().getStringView(),
             "1330");
@@ -111,7 +111,7 @@ typed_config:
   // Overriding the statically configured static delay via request-level configuration should be
   // reflected in the output.
   setRequestLevelConfiguration("{static_delay: \"0.2s\"}");
-  getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(getResponse(ResponseOrigin::UPSTREAM)->waitForEndStream());
   // TODO(#392): This fails, because the duration is a two-field message: it would make here to see
   // both the number of seconds and nanoseconds to be overridden.
   // However, the seconds part is set to '0', which equates to the default of the underlying int
@@ -123,7 +123,7 @@ typed_config:
   // Overriding the statically configured static delay via request-level configuration should be
   // reflected in the output.
   setRequestLevelConfiguration("{static_delay: \"2.2s\"}");
-  getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(getResponse(ResponseOrigin::UPSTREAM)->waitForEndStream());
   // 2.2 seconds -> 2200 ms.
   ASSERT_EQ(upstream_request_->headers().get(kDelayHeaderString).size(), 1);
   EXPECT_EQ(upstream_request_->headers().get(kDelayHeaderString)[0]->value().getStringView(),
@@ -140,7 +140,7 @@ typed_config:
     minimal_delay: 0.05s
     concurrency_delay_factor: 0.01s
 )EOF");
-  getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(getResponse(ResponseOrigin::UPSTREAM)->waitForEndStream());
   // Based on the algorithm of concurrency_based_linear_delay, for the first request we expect to
   // observe the configured minimal_delay + concurrency_delay_factor = 0.06s -> 60ms.
   ASSERT_EQ(upstream_request_->headers().get(kDelayHeaderString).size(), 1);

--- a/test/server/http_filter_base_test.cc
+++ b/test/server/http_filter_base_test.cc
@@ -61,6 +61,7 @@ typed_config:
 
 TEST_P(HttpFilterBaseIntegrationTest, NoRequestLevelConfigurationShouldSucceed) {
   Envoy::IntegrationStreamDecoderPtr response = getResponse(getHappyFlowResponseOrigin());
+  ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   EXPECT_TRUE(response->body().empty());
@@ -69,6 +70,7 @@ TEST_P(HttpFilterBaseIntegrationTest, NoRequestLevelConfigurationShouldSucceed) 
 TEST_P(HttpFilterBaseIntegrationTest, EmptyJsonRequestLevelConfigurationShouldSucceed) {
   setRequestLevelConfiguration("{}");
   Envoy::IntegrationStreamDecoderPtr response = getResponse(getHappyFlowResponseOrigin());
+  ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   EXPECT_TRUE(response->body().empty());
@@ -78,6 +80,7 @@ TEST_P(HttpFilterBaseIntegrationTest, BadJsonAsRequestLevelConfigurationShouldFa
   // When sending bad request-level configuration, the extension ought to reply directly.
   setRequestLevelConfiguration("bad_json");
   Envoy::IntegrationStreamDecoderPtr response = getResponse(ResponseOrigin::EXTENSION);
+  ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ(Envoy::Http::Utility::getResponseStatus(response->headers()), 500);
   EXPECT_THAT(response->body(), HasSubstr(kBadConfigErrorSentinel));
 }
@@ -86,6 +89,7 @@ TEST_P(HttpFilterBaseIntegrationTest, EmptyRequestLevelConfigurationShouldFail) 
   // When sending empty request-level configuration, the extension ought to reply directly.
   setRequestLevelConfiguration("");
   Envoy::IntegrationStreamDecoderPtr response = getResponse(ResponseOrigin::EXTENSION);
+  ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ(Envoy::Http::Utility::getResponseStatus(response->headers()), 500);
   EXPECT_THAT(response->body(), HasSubstr(kBadConfigErrorSentinel));
 }
@@ -95,6 +99,7 @@ TEST_P(HttpFilterBaseIntegrationTest, MultipleValidConfigurationHeadersFails) {
   setRequestLevelConfiguration("{}");
   appendRequestLevelConfiguration("{}");
   Envoy::IntegrationStreamDecoderPtr response = getResponse(ResponseOrigin::EXTENSION);
+  ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   EXPECT_THAT(response->body(),
               HasSubstr("Received multiple configuration headers in the request"));
@@ -105,6 +110,7 @@ TEST_P(HttpFilterBaseIntegrationTest, SingleValidPlusEmptyConfigurationHeadersFa
   setRequestLevelConfiguration("{}");
   appendRequestLevelConfiguration("");
   Envoy::IntegrationStreamDecoderPtr response = getResponse(ResponseOrigin::EXTENSION);
+  ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   EXPECT_THAT(response->body(),
               HasSubstr("Received multiple configuration headers in the request"));

--- a/test/server/http_filter_integration_test_base.cc
+++ b/test/server/http_filter_integration_test_base.cc
@@ -66,7 +66,7 @@ HttpFilterIntegrationTestBase::getResponse(ResponseOrigin expected_origin) {
     } else {
       response = codec_client_->makeHeaderOnlyRequest(request_headers_);
     }
-    response->waitForEndStream();
+    ASSERT_TRUE(response->waitForEndStream());
   }
   return response;
 }

--- a/test/server/http_filter_integration_test_base.cc
+++ b/test/server/http_filter_integration_test_base.cc
@@ -66,7 +66,6 @@ HttpFilterIntegrationTestBase::getResponse(ResponseOrigin expected_origin) {
     } else {
       response = codec_client_->makeHeaderOnlyRequest(request_headers_);
     }
-    ASSERT_TRUE(response->waitForEndStream());
   }
   return response;
 }

--- a/test/server/http_time_tracking_filter_integration_test.cc
+++ b/test/server/http_time_tracking_filter_integration_test.cc
@@ -61,12 +61,14 @@ TEST_P(HttpTimeTrackingIntegrationTest, ReturnsPositiveLatencyForStaticConfigura
 
   // As the first request doesn't have a prior one, we should not observe a delta.
   Envoy::IntegrationStreamDecoderPtr response = getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(response->waitForEndStream());
   int64_t latency;
   EXPECT_EQ(
       response->headers().get(Envoy::Http::LowerCaseString(kLatencyResponseHeaderName)).size(), 0);
 
   // On the second request we should observe a delta.
   response = getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(response->waitForEndStream());
   const Envoy::Http::HeaderMap::GetResult& latency_header =
       response->headers().get(Envoy::Http::LowerCaseString(kLatencyResponseHeaderName));
   ASSERT_EQ(latency_header.size(), 1);
@@ -80,6 +82,7 @@ TEST_P(HttpTimeTrackingIntegrationTest, ReturnsPositiveLatencyForPerRequestConfi
   // As the first request doesn't have a prior one, we should not observe a delta.
   setRequestLevelConfiguration("{}");
   Envoy::IntegrationStreamDecoderPtr response = getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(
       response->headers().get(Envoy::Http::LowerCaseString(kLatencyResponseHeaderName)).empty());
 
@@ -87,6 +90,7 @@ TEST_P(HttpTimeTrackingIntegrationTest, ReturnsPositiveLatencyForPerRequestConfi
   // we should be able to observe it.
   setRequestLevelConfiguration(fmt::format("{{{}}}", kDefaultProtoFragment));
   response = getResponse(ResponseOrigin::UPSTREAM);
+  ASSERT_TRUE(response->waitForEndStream());
   const Envoy::Http::HeaderMap::GetResult& latency_header =
       response->headers().get(Envoy::Http::LowerCaseString(kLatencyResponseHeaderName));
   ASSERT_EQ(latency_header.size(), 1);


### PR DESCRIPTION
- Sync .bazelrc
- Update Docker image version in .circleci/config.yml
- ci/run_envoy_docker.sh was unchanged
- Code changes
  - Remove `response->waitForEndStream();` from `HttpFilterIntegrationTestBase::getResponse()` in test/server/http_filter_integration_test_base.cc due to https://github.com/envoyproxy/envoy/pull/15972. We can't simply change it to `ASSERT_TRUE(response->waitForEndStream());` in `HttpFilterIntegrationTestBase::getResponse()` since this will cause error:
    ```
    test/server/http_filter_integration_test_base.cc:69:5: error: no viable conversion from returned value of type 'void' to function return type 'Envoy::IntegrationStreamDecoderPtr' (aka 'unique_ptr<Envoy::IntegrationStreamDecoder>')
        ASSERT_TRUE(response->waitForEndStream());
    ```
   - Added `ASSERT_TRUE(response->waitForEndStream());` to all places where `HttpFilterIntegrationTestBase::getResponse()` is called in the tests.

Signed-off-by: qqustc@gmail.com <qqin@google.com>