### PR TITLE
Optional cooldown between benchmarks done by the adaptive controller.

### DIFF
--- a/api/adaptive_load/adaptive_load.proto
+++ b/api/adaptive_load/adaptive_load.proto
@@ -63,6 +63,11 @@ message AdaptiveLoadSessionSpec {
   // confirm the performance at the level of load found in the adjusting stage.
   // Optional, default 30 seconds.
   google.protobuf.Duration testing_stage_duration = 7;
+  // The duration to wait between individual short benchmarks during the
+  // adjusting stage and between the last short benchmark of the adjusting stage
+  // and the testing stage.
+  // Optional, defaults no zero duration.
+  google.protobuf.Duration benchmark_cooldown_duration = 9;
   // Selects and configures a StepController plugin. Required.
   envoy.config.core.v3.TypedExtensionConfig step_controller_config = 8
       [(validate.rules).message.required = true];

--- a/api/adaptive_load/adaptive_load.proto
+++ b/api/adaptive_load/adaptive_load.proto
@@ -66,7 +66,7 @@ message AdaptiveLoadSessionSpec {
   // The duration to wait between individual short benchmarks during the
   // adjusting stage and between the last short benchmark of the adjusting stage
   // and the testing stage.
-  // Optional, defaults no zero duration.
+  // Optional, defaults to zero duration.
   google.protobuf.Duration benchmark_cooldown_duration = 9;
   // Selects and configures a StepController plugin. Required.
   envoy.config.core.v3.TypedExtensionConfig step_controller_config = 8

--- a/api/adaptive_load/adaptive_load.proto
+++ b/api/adaptive_load/adaptive_load.proto
@@ -55,19 +55,23 @@ message AdaptiveLoadSessionSpec {
   nighthawk.client.CommandLineOptions nighthawk_traffic_template = 4
       [(validate.rules).message.required = true];
   // The duration of each short benchmark during the adjusting stage. Optional, default 10 seconds.
-  google.protobuf.Duration measuring_period = 5 [(validate.rules).duration.gt.seconds = 0];
-  // Maximum amount of time the adjusting stage should wait for convergence
-  // before returning an error. Optional, default 300 seconds.
-  google.protobuf.Duration convergence_deadline = 6 [(validate.rules).duration.gt.seconds = 0];
+  google.protobuf.Duration measuring_period = 5
+      [(validate.rules).duration = {gt {seconds: 0 nanos: 0}}];
+  //  Maximum amount of time the adjusting stage should wait for convergence
+  //  before returning an error. Optional, default 300 seconds.
+  google.protobuf.Duration convergence_deadline = 6
+      [(validate.rules).duration = {gt {seconds: 0 nanos: 0}}];
   // The duration of the single benchmark session of the testing stage to
   // confirm the performance at the level of load found in the adjusting stage.
   // Optional, default 30 seconds.
-  google.protobuf.Duration testing_stage_duration = 7;
+  google.protobuf.Duration testing_stage_duration = 7
+      [(validate.rules).duration = {gt {seconds: 0 nanos: 0}}];
   // The duration to wait between individual short benchmarks during the
   // adjusting stage and between the last short benchmark of the adjusting stage
   // and the testing stage.
   // Optional, defaults to zero duration.
-  google.protobuf.Duration benchmark_cooldown_duration = 9;
+  google.protobuf.Duration benchmark_cooldown_duration = 9
+      [(validate.rules).duration = {gt {seconds: 0 nanos: 0}}];
   // Selects and configures a StepController plugin. Required.
   envoy.config.core.v3.TypedExtensionConfig step_controller_config = 8
       [(validate.rules).message.required = true];

--- a/source/adaptive_load/adaptive_load_controller_impl.cc
+++ b/source/adaptive_load/adaptive_load_controller_impl.cc
@@ -13,6 +13,7 @@
 #include "external/envoy/source/common/common/logger.h"
 #include "external/envoy/source/common/common/statusor.h"
 #include "external/envoy/source/common/protobuf/protobuf.h"
+#include "external/envoy/source/common/protobuf/utility.h"
 
 #include "api/adaptive_load/adaptive_load.pb.h"
 #include "api/adaptive_load/benchmark_result.pb.h"

--- a/source/adaptive_load/adaptive_load_controller_impl.cc
+++ b/source/adaptive_load/adaptive_load_controller_impl.cc
@@ -13,7 +13,6 @@
 #include "external/envoy/source/common/common/logger.h"
 #include "external/envoy/source/common/common/statusor.h"
 #include "external/envoy/source/common/protobuf/protobuf.h"
-#include "external/envoy/source/common/protobuf/utility.h"
 
 #include "api/adaptive_load/adaptive_load.pb.h"
 #include "api/adaptive_load/benchmark_result.pb.h"
@@ -176,13 +175,9 @@ absl::StatusOr<AdaptiveLoadSessionOutput> AdaptiveLoadControllerImpl::PerformAda
     if (spec.has_benchmark_cooldown_duration()) {
       ENVOY_LOG_MISC(info, "Cooling down before the next benchmark for duration: {}",
                      spec.benchmark_cooldown_duration());
-      absl::StatusOr<uint64_t> sleep_time_ms =
-          Envoy::Protobuf::util::TimeUtil::DurationToMilliseconds(
-              spec.benchmark_cooldown_duration());
-      if (!sleep_time_ms.ok()) {
-        return sleep_time_ms.status();
-      }
-      absl::SleepFor(absl::Milliseconds(*sleep_time_ms));
+      uint64_t sleep_time_ms = Envoy::Protobuf::util::TimeUtil::DurationToMilliseconds(
+          spec.benchmark_cooldown_duration());
+      absl::SleepFor(absl::Milliseconds(sleep_time_ms));
     }
 
     const std::chrono::nanoseconds time_limit_ns(

--- a/source/adaptive_load/adaptive_load_controller_impl.cc
+++ b/source/adaptive_load/adaptive_load_controller_impl.cc
@@ -13,7 +13,6 @@
 #include "external/envoy/source/common/common/logger.h"
 #include "external/envoy/source/common/common/statusor.h"
 #include "external/envoy/source/common/protobuf/protobuf.h"
-#include "external/envoy/source/common/protobuf/utility.h"
 
 #include "api/adaptive_load/adaptive_load.pb.h"
 #include "api/adaptive_load/benchmark_result.pb.h"
@@ -83,22 +82,6 @@ StepControllerPtr LoadStepControllerPluginFromSpec(const AdaptiveLoadSessionSpec
           "StepController plugin loading error should have been caught during input validation: ",
           step_controller_or.status().message()));
   return std::move(step_controller_or.value());
-}
-
-/**
- * Converts the duration proto to a number of milliseconds.
- *
- * @param duration the duration to convert.
- *
- * @return the number of milliseconds or an error if the conversion failed.
- */
-absl::StatusOr<uint64_t>
-ProtobufDurationToMilliseconds(const Envoy::ProtobufWkt::Duration& duration) noexcept {
-  try {
-    return Envoy::DurationUtil::durationToMilliseconds(duration);
-  } catch (const Envoy::EnvoyException& e) {
-    return absl::InternalError(e.what());
-  }
 }
 
 } // namespace
@@ -192,12 +175,13 @@ absl::StatusOr<AdaptiveLoadSessionOutput> AdaptiveLoadControllerImpl::PerformAda
     if (spec.has_benchmark_cooldown_duration()) {
       ENVOY_LOG_MISC(info, "Cooling down before the next benchmark for duration: {}",
                      spec.benchmark_cooldown_duration());
-      absl::StatusOr<uint64_t> sleep_milliseconds =
-          ProtobufDurationToMilliseconds(spec.benchmark_cooldown_duration());
-      if (!sleep_milliseconds.ok()) {
-        return sleep_milliseconds.status();
+      absl::StatusOr<uint64_t> sleep_time_ms =
+          Envoy::Protobuf::util::TimeUtil::DurationToMilliseconds(
+              spec.benchmark_cooldown_duration());
+      if (!sleep_time_ms.ok()) {
+        return sleep_time_ms.status();
       }
-      absl::SleepFor(absl::Milliseconds(*sleep_milliseconds));
+      absl::SleepFor(absl::Milliseconds(*sleep_time_ms));
     }
 
     const std::chrono::nanoseconds time_limit_ns(

--- a/source/adaptive_load/session_spec_proto_helper_impl.cc
+++ b/source/adaptive_load/session_spec_proto_helper_impl.cc
@@ -3,8 +3,6 @@
 #include "nighthawk/adaptive_load/metrics_plugin.h"
 #include "nighthawk/adaptive_load/step_controller.h"
 
-#include "external/envoy/source/common/protobuf/utility.h"
-
 #include "api/adaptive_load/adaptive_load.pb.h"
 #include "api/adaptive_load/adaptive_load.pb.validate.h"
 #include "api/adaptive_load/metric_spec.pb.h"

--- a/test/adaptive_load/BUILD
+++ b/test/adaptive_load/BUILD
@@ -62,7 +62,6 @@ envoy_cc_test(
         "//test/mocks/common:mock_nighthawk_service_client",
         "@envoy//source/common/common:assert_lib_with_external_headers",
         "@envoy//source/common/common:statusor_lib_with_external_headers",
-        "@envoy//source/common/common:utility_lib_with_external_headers",
         "@envoy//source/common/config:utility_lib_with_external_headers",
         "@envoy//source/common/protobuf:protobuf_with_external_headers",
     ],

--- a/test/adaptive_load/BUILD
+++ b/test/adaptive_load/BUILD
@@ -62,6 +62,7 @@ envoy_cc_test(
         "//test/mocks/common:mock_nighthawk_service_client",
         "@envoy//source/common/common:assert_lib_with_external_headers",
         "@envoy//source/common/common:statusor_lib_with_external_headers",
+        "@envoy//source/common/common:utility_lib_with_external_headers",
         "@envoy//source/common/config:utility_lib_with_external_headers",
         "@envoy//source/common/protobuf:protobuf_with_external_headers",
     ],

--- a/test/adaptive_load/adaptive_load_controller_test.cc
+++ b/test/adaptive_load/adaptive_load_controller_test.cc
@@ -326,8 +326,8 @@ TEST_F(AdaptiveLoadControllerImplFixture, FailsWhenBenchmarkCooldownDurationIsNe
   absl::StatusOr<AdaptiveLoadSessionOutput> output_or =
       controller.PerformAdaptiveLoadSession(&mock_nighthawk_service_stub_, spec);
   ASSERT_FALSE(output_or.ok());
-  EXPECT_EQ(output_or.status().code(), absl::StatusCode::kInternal);
-  EXPECT_THAT(output_or.status().message(), HasSubstr("duration"));
+  EXPECT_EQ(output_or.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(output_or.status().message(), HasSubstr("BenchmarkCooldownDuration"));
 }
 
 } // namespace


### PR DESCRIPTION
Allows the user to specify a cooldown period to wait for between individual benchmarks executed by the adaptive load controller. Useful in situations where cooldown is required to allow previously used connections to time out.

Also ensuring all durations in the adative session spec are validated.

Signed-off-by: Jakub Sobon <mumak@google.com>