### PR TITLE
Store the start and end time of each benchmark done by the adaptive load controller.

### DIFF
--- a/api/adaptive_load/benchmark_result.proto
+++ b/api/adaptive_load/benchmark_result.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package nighthawk.adaptive_load;
 
 import "api/client/output.proto";
+import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
 // Records the status of a single metric during a benchmark session.
@@ -33,4 +34,9 @@ message BenchmarkResult {
   // Status of all declared metrics during this benchmark session. Not present
   // in the event of Nighthawk Service errors.
   repeated MetricEvaluation metric_evaluations = 3;
+
+  // The time this benchmark session started.
+  google.protobuf.Timestamp start_time = 4;
+  // The time this benchmark session ended.
+  google.protobuf.Timestamp end_time = 5;
 }

--- a/source/adaptive_load/BUILD
+++ b/source/adaptive_load/BUILD
@@ -29,6 +29,7 @@ envoy_cc_library(
         "//include/nighthawk/adaptive_load:session_spec_proto_helper",
         "//include/nighthawk/adaptive_load:step_controller",
         "//include/nighthawk/common:nighthawk_service_client",
+        "@envoy//source/common/protobuf:utility_lib_with_external_headers",
     ],
 )
 

--- a/test/adaptive_load/adaptive_load_controller_test.cc
+++ b/test/adaptive_load/adaptive_load_controller_test.cc
@@ -119,7 +119,7 @@ public:
 protected:
   NiceMock<MockNighthawkServiceClient> mock_nighthawk_service_client_;
   NiceMock<MockMetricsEvaluator> mock_metrics_evaluator_;
-  FakeIncrementingMonotonicTimeSource fake_time_source_;
+  FakeIncrementingTimeSource fake_time_source_;
   MockNighthawkServiceStub mock_nighthawk_service_stub_;
   // Real spec helper is simpler to use because SetSessionSpecDefaults preserves values a test
   // sets in the spec; the mock inconveniently discards the input and returns an empty spec.

--- a/test/adaptive_load/adaptive_load_controller_test.cc
+++ b/test/adaptive_load/adaptive_load_controller_test.cc
@@ -66,6 +66,9 @@ using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::SetArgPointee;
 
+// The start time used in these tests.
+const int kFakeStartTimeSeconds = 10;
+
 /**
  * Creates a valid BenchmarkResult proto with only the score set. Useful for controlling the
  * FakeStepController, which returns convergence for score > 0 and doom for a score < 0.
@@ -107,6 +110,8 @@ AdaptiveLoadSessionSpec MakeValidAdaptiveLoadSessionSpec() {
 class AdaptiveLoadControllerImplFixture : public testing::Test {
 public:
   void SetUp() override {
+    fake_time_source_.setSystemTimeSeconds(kFakeStartTimeSeconds);
+
     ON_CALL(mock_nighthawk_service_client_, PerformNighthawkBenchmark)
         .WillByDefault(Return(nighthawk::client::ExecutionResponse()));
   }
@@ -265,6 +270,9 @@ TEST_F(AdaptiveLoadControllerImplFixture, PropagatesErrorFromMetricsEvaluator) {
 
 TEST_F(AdaptiveLoadControllerImplFixture, StoresAdjustingStageResult) {
   BenchmarkResult expected_benchmark_result = MakeBenchmarkResultWithScore(1.0);
+  expected_benchmark_result.mutable_start_time()->set_seconds(kFakeStartTimeSeconds);
+  expected_benchmark_result.mutable_end_time()->set_seconds(kFakeStartTimeSeconds + 1);
+
   EXPECT_CALL(mock_metrics_evaluator_, AnalyzeNighthawkBenchmark(_, _, _))
       .WillRepeatedly(Return(expected_benchmark_result));
 
@@ -283,6 +291,11 @@ TEST_F(AdaptiveLoadControllerImplFixture, StoresAdjustingStageResult) {
 
 TEST_F(AdaptiveLoadControllerImplFixture, StoresTestingStageResult) {
   BenchmarkResult expected_benchmark_result = MakeBenchmarkResultWithScore(1.0);
+  // Times kFakeStartTimeSeconds and kFakeStartTimeSeconds + 1 are taken by the
+  // adjusting stage.
+  expected_benchmark_result.mutable_start_time()->set_seconds(kFakeStartTimeSeconds + 2);
+  expected_benchmark_result.mutable_end_time()->set_seconds(kFakeStartTimeSeconds + 3);
+
   EXPECT_CALL(mock_metrics_evaluator_, AnalyzeNighthawkBenchmark(_, _, _))
       .WillRepeatedly(Return(expected_benchmark_result));
 

--- a/test/common/fake_time_source.cc
+++ b/test/common/fake_time_source.cc
@@ -4,13 +4,15 @@ namespace Nighthawk {
 
 Envoy::SystemTime FakeIncrementingMonotonicTimeSource::systemTime() {
   Envoy::SystemTime epoch;
-  return epoch;
+  Envoy::SystemTime result = epoch + std::chrono::seconds(system_seconds_since_epoch_);
+  ++system_seconds_since_epoch_;
+  return result;
 }
 
 Envoy::MonotonicTime FakeIncrementingMonotonicTimeSource::monotonicTime() {
   Envoy::MonotonicTime epoch;
-  Envoy::MonotonicTime result = epoch + std::chrono::seconds(seconds_since_epoch_);
-  ++seconds_since_epoch_;
+  Envoy::MonotonicTime result = epoch + std::chrono::seconds(monotonic_seconds_since_epoch_);
+  ++monotonic_seconds_since_epoch_;
   return result;
 }
 

--- a/test/common/fake_time_source.cc
+++ b/test/common/fake_time_source.cc
@@ -2,25 +2,25 @@
 
 namespace Nighthawk {
 
-Envoy::SystemTime FakeIncrementingMonotonicTimeSource::systemTime() {
+Envoy::SystemTime FakeIncrementingTimeSource::systemTime() {
   Envoy::SystemTime epoch;
   Envoy::SystemTime result = epoch + std::chrono::seconds(system_seconds_since_epoch_);
   ++system_seconds_since_epoch_;
   return result;
 }
 
-Envoy::MonotonicTime FakeIncrementingMonotonicTimeSource::monotonicTime() {
+Envoy::MonotonicTime FakeIncrementingTimeSource::monotonicTime() {
   Envoy::MonotonicTime epoch;
   Envoy::MonotonicTime result = epoch + std::chrono::seconds(monotonic_seconds_since_epoch_);
   ++monotonic_seconds_since_epoch_;
   return result;
 }
 
-void FakeIncrementingMonotonicTimeSource::setSystemTimeSeconds(int seconds) {
+void FakeIncrementingTimeSource::setSystemTimeSeconds(int seconds) {
   system_seconds_since_epoch_ = seconds;
 }
 
-void FakeIncrementingMonotonicTimeSource::setMonotonicTimeSeconds(int seconds) {
+void FakeIncrementingTimeSource::setMonotonicTimeSeconds(int seconds) {
   monotonic_seconds_since_epoch_ = seconds;
 }
 

--- a/test/common/fake_time_source.cc
+++ b/test/common/fake_time_source.cc
@@ -16,4 +16,12 @@ Envoy::MonotonicTime FakeIncrementingMonotonicTimeSource::monotonicTime() {
   return result;
 }
 
+void FakeIncrementingMonotonicTimeSource::setSystemTimeSeconds(int seconds) {
+  system_seconds_since_epoch_ = seconds;
+}
+
+void FakeIncrementingMonotonicTimeSource::setMonotonicTimeSeconds(int seconds) {
+  monotonic_seconds_since_epoch_ = seconds;
+}
+
 } // namespace Nighthawk

--- a/test/common/fake_time_source.h
+++ b/test/common/fake_time_source.h
@@ -4,15 +4,14 @@
 
 namespace Nighthawk {
 /**
- * Fake time source that ticks 1 second on every query, starting from the Unix epoch. Supports only
- * monotonicTime().
+ * Fake time source that ticks 1 second on every query, starting from the Unix epoch.
  */
 class FakeIncrementingMonotonicTimeSource : public Envoy::TimeSource {
 public:
   /**
-   * Not supported.
+   * Ticks forward 1 second on each call.
    *
-   * @return Envoy::SystemTime Fixed value of the Unix epoch.
+   * @return Envoy::SystemTime Fake time value.
    */
   Envoy::SystemTime systemTime() override;
   /**
@@ -23,7 +22,8 @@ public:
   Envoy::MonotonicTime monotonicTime() override;
 
 private:
-  int seconds_since_epoch_{0};
+  int system_seconds_since_epoch_{0};
+  int monotonic_seconds_since_epoch_{0};
 };
 
 } // namespace Nighthawk

--- a/test/common/fake_time_source.h
+++ b/test/common/fake_time_source.h
@@ -6,7 +6,7 @@ namespace Nighthawk {
 /**
  * Fake time source that ticks 1 second on every query, starting from the Unix epoch.
  */
-class FakeIncrementingMonotonicTimeSource : public Envoy::TimeSource {
+class FakeIncrementingTimeSource : public Envoy::TimeSource {
 public:
   /**
    * Ticks forward 1 second on each call.

--- a/test/common/fake_time_source.h
+++ b/test/common/fake_time_source.h
@@ -21,6 +21,19 @@ public:
    */
   Envoy::MonotonicTime monotonicTime() override;
 
+  /**
+   * Sets the current value of the system time.
+   *
+   * @param seconds the number of seconds to set the system time to.
+   */
+  void setSystemTimeSeconds(int seconds);
+  /**
+   * Sets the current value of the monotonic time.
+   *
+   * @param seconds the number of seconds to set the monotonic time to.
+   */
+  void setMonotonicTimeSeconds(int seconds);
+
 private:
   int system_seconds_since_epoch_{0};
   int monotonic_seconds_since_epoch_{0};

--- a/test/common/fake_time_source_test.cc
+++ b/test/common/fake_time_source_test.cc
@@ -5,15 +5,15 @@
 namespace Nighthawk {
 namespace {
 
-TEST(FakeIncrementingMonotonicTimeSource, SystemTimeStartsFromEpoch) {
-  FakeIncrementingMonotonicTimeSource time_source;
+TEST(FakeIncrementingTimeSource, SystemTimeStartsFromEpoch) {
+  FakeIncrementingTimeSource time_source;
   Envoy::SystemTime epoch;
   Envoy::SystemTime time = time_source.systemTime();
   EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time - epoch).count(), 0);
 }
 
-TEST(FakeIncrementingMonotonicTimeSource, SystemTimeIncrementsOneSecondPerCall) {
-  FakeIncrementingMonotonicTimeSource time_source;
+TEST(FakeIncrementingTimeSource, SystemTimeIncrementsOneSecondPerCall) {
+  FakeIncrementingTimeSource time_source;
   Envoy::SystemTime time1 = time_source.systemTime();
   Envoy::SystemTime time2 = time_source.systemTime();
   Envoy::SystemTime time3 = time_source.systemTime();
@@ -21,8 +21,8 @@ TEST(FakeIncrementingMonotonicTimeSource, SystemTimeIncrementsOneSecondPerCall) 
   EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time3 - time2).count(), 1);
 }
 
-TEST(FakeIncrementingMonotonicTimeSource, SetsSystemTimeSecondsThenIncrementsOneSecondPerCall) {
-  FakeIncrementingMonotonicTimeSource time_source;
+TEST(FakeIncrementingTimeSource, SetsSystemTimeSecondsThenIncrementsOneSecondPerCall) {
+  FakeIncrementingTimeSource time_source;
   time_source.setSystemTimeSeconds(10);
   Envoy::SystemTime time1 = time_source.systemTime();
   Envoy::SystemTime time2 = time_source.systemTime();
@@ -30,15 +30,15 @@ TEST(FakeIncrementingMonotonicTimeSource, SetsSystemTimeSecondsThenIncrementsOne
   EXPECT_EQ(time2.time_since_epoch(), std::chrono::seconds(11));
 }
 
-TEST(FakeIncrementingMonotonicTimeSource, MonotonicTimeStartsFromEpoch) {
-  FakeIncrementingMonotonicTimeSource time_source;
+TEST(FakeIncrementingTimeSource, MonotonicTimeStartsFromEpoch) {
+  FakeIncrementingTimeSource time_source;
   Envoy::MonotonicTime epoch;
   Envoy::MonotonicTime time = time_source.monotonicTime();
   EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time - epoch).count(), 0);
 }
 
-TEST(FakeIncrementingMonotonicTimeSource, MonotonicTimeIncrementsOneSecondPerCall) {
-  FakeIncrementingMonotonicTimeSource time_source;
+TEST(FakeIncrementingTimeSource, MonotonicTimeIncrementsOneSecondPerCall) {
+  FakeIncrementingTimeSource time_source;
   Envoy::MonotonicTime time1 = time_source.monotonicTime();
   Envoy::MonotonicTime time2 = time_source.monotonicTime();
   Envoy::MonotonicTime time3 = time_source.monotonicTime();
@@ -46,8 +46,8 @@ TEST(FakeIncrementingMonotonicTimeSource, MonotonicTimeIncrementsOneSecondPerCal
   EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time3 - time2).count(), 1);
 }
 
-TEST(FakeIncrementingMonotonicTimeSource, SetsMonotonicTimeSecondsThenIncrementsOneSecondPerCall) {
-  FakeIncrementingMonotonicTimeSource time_source;
+TEST(FakeIncrementingTimeSource, SetsMonotonicTimeSecondsThenIncrementsOneSecondPerCall) {
+  FakeIncrementingTimeSource time_source;
   time_source.setMonotonicTimeSeconds(10);
   Envoy::MonotonicTime time1 = time_source.monotonicTime();
   Envoy::MonotonicTime time2 = time_source.monotonicTime();

--- a/test/common/fake_time_source_test.cc
+++ b/test/common/fake_time_source_test.cc
@@ -21,6 +21,15 @@ TEST(FakeIncrementingMonotonicTimeSource, SystemTimeIncrementsOneSecondPerCall) 
   EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time3 - time2).count(), 1);
 }
 
+TEST(FakeIncrementingMonotonicTimeSource, SetsSystemTimeSecondsThenIncrementsOneSecondPerCall) {
+  FakeIncrementingMonotonicTimeSource time_source;
+  time_source.setSystemTimeSeconds(10);
+  Envoy::SystemTime time1 = time_source.systemTime();
+  Envoy::SystemTime time2 = time_source.systemTime();
+  EXPECT_EQ(time1.time_since_epoch(), std::chrono::seconds(10));
+  EXPECT_EQ(time2.time_since_epoch(), std::chrono::seconds(11));
+}
+
 TEST(FakeIncrementingMonotonicTimeSource, MonotonicTimeStartsFromEpoch) {
   FakeIncrementingMonotonicTimeSource time_source;
   Envoy::MonotonicTime epoch;
@@ -35,6 +44,15 @@ TEST(FakeIncrementingMonotonicTimeSource, MonotonicTimeIncrementsOneSecondPerCal
   Envoy::MonotonicTime time3 = time_source.monotonicTime();
   EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time2 - time1).count(), 1);
   EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time3 - time2).count(), 1);
+}
+
+TEST(FakeIncrementingMonotonicTimeSource, SetsMonotonicTimeSecondsThenIncrementsOneSecondPerCall) {
+  FakeIncrementingMonotonicTimeSource time_source;
+  time_source.setMonotonicTimeSeconds(10);
+  Envoy::MonotonicTime time1 = time_source.monotonicTime();
+  Envoy::MonotonicTime time2 = time_source.monotonicTime();
+  EXPECT_EQ(time1.time_since_epoch(), std::chrono::seconds(10));
+  EXPECT_EQ(time2.time_since_epoch(), std::chrono::seconds(11));
 }
 
 } // namespace

--- a/test/common/fake_time_source_test.cc
+++ b/test/common/fake_time_source_test.cc
@@ -5,11 +5,20 @@
 namespace Nighthawk {
 namespace {
 
-TEST(FakeIncrementingMonotonicTimeSource, SystemTimeAlwaysReturnsEpoch) {
+TEST(FakeIncrementingMonotonicTimeSource, SystemTimeStartsFromEpoch) {
   FakeIncrementingMonotonicTimeSource time_source;
   Envoy::SystemTime epoch;
-  EXPECT_EQ(time_source.systemTime(), epoch);
-  EXPECT_EQ(time_source.systemTime(), epoch);
+  Envoy::SystemTime time = time_source.systemTime();
+  EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time - epoch).count(), 0);
+}
+
+TEST(FakeIncrementingMonotonicTimeSource, SystemTimeIncrementsOneSecondPerCall) {
+  FakeIncrementingMonotonicTimeSource time_source;
+  Envoy::SystemTime time1 = time_source.systemTime();
+  Envoy::SystemTime time2 = time_source.systemTime();
+  Envoy::SystemTime time3 = time_source.systemTime();
+  EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time2 - time1).count(), 1);
+  EXPECT_EQ(std::chrono::duration_cast<std::chrono::seconds>(time3 - time2).count(), 1);
 }
 
 TEST(FakeIncrementingMonotonicTimeSource, MonotonicTimeStartsFromEpoch) {

--- a/test/stopwatch_test.cc
+++ b/test/stopwatch_test.cc
@@ -38,7 +38,7 @@ TEST(ThreadSafeStopwatchTest, ThreadedStopwatchSpamming) {
   constexpr uint64_t kFakeTimeSourceDefaultTick = 1000000000;
   constexpr uint32_t kNumThreads = 100;
   ThreadSafeMontonicTimeStopwatch stopwatch;
-  FakeIncrementingMonotonicTimeSource time_system;
+  FakeIncrementingTimeSource time_system;
   std::vector<std::thread> threads(kNumThreads);
   std::promise<void> signal_all_threads_running;
   std::shared_future<void> future(signal_all_threads_running.get_future());


### PR DESCRIPTION
This will allow users of the adaptive load controller to correlate statistics collected from the system under test with individual benchmark stages (adjusting stage, testing stage).

Done here:
- updated the `FakeIncrementingMonotonicTimeSource` to also support incrementing system time.
- renamed `FakeIncrementingMonotonicTimeSource` to `FakeIncrementingTimeSource`, since it is no longer specific just to the monotonic time.
- added new methods that allow resetting the `FakeIncrementingTimeSource` to a specific epoch value. 
- added start and end time to the `BenchmarkResult` message and populating them while the adaptive controller executes.

Signed-off-by: Jakub Sobon <mumak@google.com>