### PR TITLE
Update Envoy to c5833f2 (May 17th 2021)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -248,6 +248,10 @@ build:remote-msan --config=remote
 build:remote-msan --config=rbe-toolchain-clang-libc++
 build:remote-msan --config=rbe-toolchain-msan
 
+build:remote-tsan --config=remote
+build:remote-tsan --config=rbe-toolchain-clang-libc++
+build:remote-tsan --config=rbe-toolchain-tsan
+
 build:remote-msvc-cl --config=remote-windows
 build:remote-msvc-cl --config=msvc-cl
 build:remote-msvc-cl --config=rbe-toolchain-msvc-cl
@@ -275,6 +279,10 @@ build:docker-clang-libc++ --config=rbe-toolchain-clang-libc++
 
 build:docker-gcc --config=docker-sandbox
 build:docker-gcc --config=rbe-toolchain-gcc
+
+build:docker-asan --config=docker-sandbox
+build:docker-asan --config=rbe-toolchain-clang-libc++
+build:docker-asan --config=rbe-toolchain-asan
 
 build:docker-msan --config=docker-sandbox
 build:docker-msan --config=rbe-toolchain-clang-libc++

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
   test_gcc:
     docker:
       - image: *envoy-build-image
-    resource_class: xlarge
+    resource_class: 22xlarge
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,6 @@ jobs:
     steps:
       - checkout
       - run: ci/do_ci.sh clang_tidy
-  test_gcc:
-    docker:
-      - image: *envoy-build-image
-    resource_class: 2xlarge
-    steps:
-      - checkout
-      - run:
-          command: ci/do_ci.sh test_gcc
-          no_output_timeout: 30m
   coverage:
     docker:
       - image: *envoy-build-image
@@ -102,7 +93,6 @@ workflows:
     jobs:
       - build
       - test
-      - test_gcc
       - clang_tidy
       - coverage
       - integration_test_coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
   test_gcc:
     docker:
       - image: *envoy-build-image
-    resource_class: 22xlarge
+    resource_class: 2xlarge
     steps:
       - checkout
       - run:

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "5afbb4dd36afed5c94e1b62386851045fe3fdb1a"  # May 10, 2021
-ENVOY_SHA = "625df7797c6a38fed4ec92bc0dc558e704aeda615b2325330f40b89a55bff6a2"
+ENVOY_COMMIT = "c5833f2149cebec9fcdc8de0aec4bf425e0781d3"  # May 17, 2021
+ENVOY_SHA = "e732adc6315f147f3afa8b384722ae579d838d49f56cc91d816cc62e9e38b7de"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
- Sync .bazelrc
- Update bazel/repositories.bzl
- disable test_gcc due to #686 


Signed-off-by: qqustc@gmail.com <qqin@google.com>