### PR TITLE
Update Envoy to 2c0e1f2 (Jun 2nd 2021).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "1c03ddcbd6feb5ad2507ce52d9aeaf52a3156554"  # June 1, 2021
-ENVOY_SHA = "c4fbbda0a434ba71f5859602f111fee1d8ea98c0d7ecee702ec8a620aa888744"
+ENVOY_COMMIT = "2c0e1f21837fdf78cc91d2eb8c3735731d510f7e"  # June 2, 2021
+ENVOY_SHA = "3b3a3f2c6cddcd0d9650e50b294ca211f4171c09b8ac7a3af86847329b24281b"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -516,11 +516,12 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
     };
     const Envoy::OptionsImpl envoy_options(
         /* args = */ {"process_impl"}, hot_restart_version_cb, spdlog::level::info);
+    envoy::config::core::v3::DnsResolverOptions dns_resolver_options;
     cluster_manager_factory_ = std::make_unique<ClusterManagerFactory>(
         admin_, Envoy::Runtime::LoaderSingleton::get(), store_root_, tls_,
-        dispatcher_->createDnsResolver({}, false), *ssl_context_manager_, *dispatcher_,
-        *local_info_, secret_manager_, validation_context_, *api_, http_context_, grpc_context_,
-        router_context_, access_log_manager_, *singleton_manager_, envoy_options);
+        dispatcher_->createDnsResolver({}, dns_resolver_options), *ssl_context_manager_,
+        *dispatcher_, *local_info_, secret_manager_, validation_context_, *api_, http_context_,
+        grpc_context_, router_context_, access_log_manager_, *singleton_manager_, envoy_options);
     cluster_manager_factory_->setConnectionReuseStrategy(
         options_.h1ConnectionReuseStrategy() == nighthawk::client::H1ConnectionReuseStrategy::LRU
             ? Http1PoolImpl::ConnectionReuseStrategy::LRU

--- a/source/common/uri_impl.cc
+++ b/source/common/uri_impl.cc
@@ -62,7 +62,8 @@ UriImpl::UriImpl(absl::string_view uri, absl::string_view default_scheme)
 
 bool UriImpl::performDnsLookup(Envoy::Event::Dispatcher& dispatcher,
                                const Envoy::Network::DnsLookupFamily dns_lookup_family) {
-  auto dns_resolver = dispatcher.createDnsResolver({}, false);
+  envoy::config::core::v3::DnsResolverOptions dns_resolver_options;
+  auto dns_resolver = dispatcher.createDnsResolver({}, dns_resolver_options);
   std::string hostname = std::string(hostWithoutPort());
 
   if (!hostname.empty() && hostname[0] == '[' && hostname[hostname.size() - 1] == ']') {


### PR DESCRIPTION
- Changing a `bool` to `envoy::config::core::v3::DnsResolverOptions` in calls to `Envoy::Event::Dispatcher::createDnsResolver` to match a recent Envoy change (https://github.com/envoyproxy/envoy/commit/2c0e1f21837fdf78cc91d2eb8c3735731d510f7e).

Signed-off-by: Jakub Sobon <mumak@google.com>