### PR TITLE
Update Envoy to ff2c0e5 (Jun 2 2021).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "2c0e1f21837fdf78cc91d2eb8c3735731d510f7e"  # June 2, 2021
-ENVOY_SHA = "3b3a3f2c6cddcd0d9650e50b294ca211f4171c09b8ac7a3af86847329b24281b"
+ENVOY_COMMIT = "ff2c0e517c8677dd1c553e1c6ef55d2b14cdd996"  # June 2, 2021
+ENVOY_SHA = "ebeba4ff8f54e9a7f9f86997b696d4b647a2471685e569af9bbc38dd9b496dbb"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -107,17 +107,21 @@ BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(
 }
 
 void BenchmarkClientHttpImpl::terminate() {
-  if (pool() != nullptr && pool()->hasActiveConnections()) {
+  absl::optional<Envoy::Upstream::HttpPoolData> pool_data = pool();
+  if (pool_data.has_value() &&
+      Envoy::Upstream::HttpPoolDataPeer(pool_data.value()).getPool()->hasActiveConnections()) {
     // We don't report what happens after this call in the output, but latencies may still be
     // reported via callbacks. This may happen after a long time (60s), which HdrHistogram can't
     // track the way we configure it today, as that exceeds the max that it can record.
     // No harm is done, but it does result in log lines warning about it. Avoid that, by
     // disabling latency measurement here.
     setShouldMeasureLatencies(false);
-    pool()->addDrainedCallback([this]() -> void {
-      drain_timer_->disableTimer();
-      dispatcher_.exit();
-    });
+    Envoy::Upstream::HttpPoolDataPeer(pool_data.value())
+        .getPool()
+        ->addDrainedCallback([this]() -> void {
+          drain_timer_->disableTimer();
+          dispatcher_.exit();
+        });
     // Set up a timer with a callback which caps the time we wait for the pool to drain.
     drain_timer_ = dispatcher_.createTimer([this]() -> void {
       ENVOY_LOG(info, "Wait for the connection pool drain timed out, proceeding to hard shutdown.");
@@ -147,8 +151,8 @@ StatisticPtrMap BenchmarkClientHttpImpl::statistics() const {
 };
 
 bool BenchmarkClientHttpImpl::tryStartRequest(CompletionCallback caller_completion_callback) {
-  auto* pool_ptr = pool();
-  if (pool_ptr == nullptr) {
+  absl::optional<Envoy::Upstream::HttpPoolData> pool_data = pool();
+  if (!pool_data.has_value()) {
     return false;
   }
   if (provide_resource_backpressure_) {
@@ -185,7 +189,7 @@ bool BenchmarkClientHttpImpl::tryStartRequest(CompletionCallback caller_completi
       *statistic_.origin_latency_statistic, request->header(), shouldMeasureLatencies(),
       content_length, generator_, http_tracer_, latency_response_header_name_);
   requests_initiated_++;
-  pool_ptr->newStream(*stream_decoder, *stream_decoder);
+  pool_data.value().newStream(*stream_decoder, *stream_decoder);
   return true;
 }
 

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -24,7 +24,25 @@
 
 #include "common/statistic_impl.h"
 
+#include "source/client/stream_decoder.h"
+#include "source/common/statistic_impl.h"
+
 #include "client/stream_decoder.h"
+
+// TODO(yanavlasov): temporary hack to until Envoy::Upstream::HttpPoolData supports
+// hasActiveConnections
+namespace Envoy {
+namespace Upstream {
+class HttpPoolDataPeer {
+public:
+  HttpPoolDataPeer(HttpPoolData& data) : data_(data) {}
+  Http::ConnectionPool::Instance* getPool() { return data_.pool_; };
+
+private:
+  HttpPoolData& data_;
+};
+} // namespace Upstream
+} // namespace Envoy
 
 namespace Nighthawk {
 namespace Client {
@@ -135,7 +153,7 @@ public:
   void exportLatency(const uint32_t response_code, const uint64_t latency_ns) override;
 
   // Helpers
-  Envoy::Http::ConnectionPool::Instance* pool() {
+  absl::optional<::Envoy::Upstream::HttpPoolData> pool() {
     auto proto = use_h2_ ? Envoy::Http::Protocol::Http2 : Envoy::Http::Protocol::Http11;
     const auto thread_local_cluster = cluster_manager_->getThreadLocalCluster(cluster_name_);
     return thread_local_cluster->httpConnPool(Envoy::Upstream::ResourcePriority::Default, proto,

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -29,7 +29,7 @@
 
 #include "client/stream_decoder.h"
 
-// TODO(yanavlasov): temporary hack to until Envoy::Upstream::HttpPoolData supports
+// TODO(#695): temporary hack to until Envoy::Upstream::HttpPoolData supports
 // hasActiveConnections
 namespace Envoy {
 namespace Upstream {

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -70,7 +70,8 @@ public:
     EXPECT_CALL(cluster_manager(), getThreadLocalCluster(_))
         .WillRepeatedly(Return(&thread_local_cluster_));
     EXPECT_CALL(thread_local_cluster_, info()).WillRepeatedly(Return(cluster_info_));
-    EXPECT_CALL(thread_local_cluster_, httpConnPool(_, _, _)).WillRepeatedly(Return(&pool_));
+    EXPECT_CALL(thread_local_cluster_, httpConnPool(_, _, _))
+        .WillRepeatedly(Return(Envoy::Upstream::HttpPoolData([]() {}, &pool_)));
 
     auto& tracer = static_cast<Envoy::Tracing::MockHttpTracer&>(*http_tracer_);
     EXPECT_CALL(tracer, startSpan_(_, _, _, _))


### PR DESCRIPTION
Changing how the HTTP connection pool is accessed after it was moved behind a new class `HttpPoolData` in Envoy (https://github.com/envoyproxy/envoy/commit/ff2c0e517c8677dd1c553e1c6ef55d2b14cdd996).

- Borrowing a temporary hack originally proposed by @yanavlasov in PR #693 which accesses the pool by defining a local class that happens to be a friend of `HttpPoolData`.

Signed-off-by: Jakub Sobon <mumak@google.com>