### PR TITLE
Update Envoy to 72bf41f (Jun 04, 2021).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "0fae6970ddaf93f024908ba304bbd2b34e997a51"  # Jun 4, 2021
-ENVOY_SHA = "9dd201f00c1ad4d37f17c969ba200c1a3dad6d28ea0ae2a76874d01a98f6b011"
+ENVOY_COMMIT = "72bf41fb0ecc039f196be02f534bfc2c9c69f348"  # Jun 4, 2021
+ENVOY_SHA = "db07426cf02fa2f8ed9891e64adf67ced39e72cdcce9ba121d420b471cc96766"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/sink/service_impl.cc
+++ b/source/sink/service_impl.cc
@@ -98,7 +98,7 @@ absl::Status mergeOutput(const nighthawk::client::Output& input_to_merge,
 }
 
 absl::StatusOr<nighthawk::client::ExecutionResponse>
-mergeExecutionResponses(absl::string_view requested_execution_id,
+mergeExecutionResponses(const std::string& requested_execution_id,
                         const std::vector<nighthawk::client::ExecutionResponse>& responses) {
   if (responses.size() == 0) {
     return absl::Status(absl::StatusCode::kNotFound, "No results");
@@ -106,7 +106,7 @@ mergeExecutionResponses(absl::string_view requested_execution_id,
 
   nighthawk::client::ExecutionResponse aggregated_response;
   nighthawk::client::Output aggregated_output;
-  aggregated_response.mutable_execution_id()->assign(requested_execution_id);
+  aggregated_response.set_execution_id(requested_execution_id);
   for (const nighthawk::client::ExecutionResponse& execution_response : responses) {
     if (execution_response.execution_id() != requested_execution_id) {
       return absl::Status(absl::StatusCode::kInternal,

--- a/source/sink/service_impl.h
+++ b/source/sink/service_impl.h
@@ -27,7 +27,7 @@ namespace Nighthawk {
  * status in case sanity checks failed.
  */
 absl::StatusOr<nighthawk::client::ExecutionResponse>
-mergeExecutionResponses(absl::string_view execution_id,
+mergeExecutionResponses(const std::string& execution_id,
                         const std::vector<nighthawk::client::ExecutionResponse>& responses);
 
 /**

--- a/test/adaptive_load/adaptive_load_client_main_test.cc
+++ b/test/adaptive_load/adaptive_load_client_main_test.cc
@@ -298,7 +298,7 @@ TEST(AdaptiveLoadClientMainTest, WritesOutputProtoToFile) {
   EXPECT_CALL(*mock_file, write_(_))
       .WillRepeatedly(Invoke(
           [&actual_outfile_contents](absl::string_view data) -> Envoy::Api::IoCallSizeResult {
-            actual_outfile_contents += data;
+            actual_outfile_contents += std::string(data);
             return Envoy::Api::IoCallSizeResult(
                 static_cast<ssize_t>(data.length()),
                 Envoy::Api::IoErrorPtr(nullptr, [](Envoy::Api::IoError*) {}));

--- a/test/request_source/request_source_plugin_test.cc
+++ b/test/request_source/request_source_plugin_test.cc
@@ -23,9 +23,9 @@ using nighthawk::request_source::StubPluginConfig;
 using ::testing::NiceMock;
 using ::testing::Test;
 nighthawk::request_source::FileBasedOptionsListRequestSourceConfig
-MakeFileBasedPluginConfigWithTestYaml(absl::string_view request_file) {
+MakeFileBasedPluginConfigWithTestYaml(const std::string& request_file) {
   nighthawk::request_source::FileBasedOptionsListRequestSourceConfig config;
-  config.mutable_file_path()->assign(request_file);
+  config.set_file_path(request_file);
   config.mutable_max_file_size()->set_value(4000);
   return config;
 }


### PR DESCRIPTION
After envoy switched to the true abseil type of string_view (https://github.com/envoyproxy/envoy/commit/72bf41fb0ecc039f196be02f534bfc2c9c69f348), we can no longer assign `absl::string_view` to `std::string`. Changing Nighthawk code accordingly.

Signed-off-by: Jakub Sobon <mumak@google.com>