### PR TITLE
Fix a race in integration tests.

### DIFF
--- a/source/client/service_impl.h
+++ b/source/client/service_impl.h
@@ -81,12 +81,22 @@ class RequestSourceServiceImpl final
       public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 
 public:
+  /**
+   * Constructs a new RequestSourceServiceImpl instance.
+   */
+  RequestSourceServiceImpl() {
+    logging_context_ = std::make_unique<Envoy::Logger::Context>(
+        spdlog::level::from_str("info"), "[%T.%f][%t][%L] %v", log_lock_, false);
+  }
+
   grpc::Status RequestStream(
       grpc::ServerContext* context,
       grpc::ServerReaderWriter<nighthawk::request_source::RequestStreamResponse,
                                nighthawk::request_source::RequestStreamRequest>* stream) override;
 
 private:
+  std::unique_ptr<Envoy::Logger::Context> logging_context_;
+  Envoy::Thread::MutexBasicLockable log_lock_;
   RequestSourcePtr createStaticEmptyRequestSource(const uint32_t amount);
 };
 

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -138,7 +138,8 @@ class IntegrationTestBase():
       caplog: The pytest `caplog` test fixture used to examine logged messages.
     """
     if self.grpc_service is not None:
-      assert (self.grpc_service.stop() == 0)
+      if self.grpc_service.stop() != 0:
+        pytest.fail("the Nighthawk GRPC service reported a non-zero exit code when stopped, log lines:\n{}".format('\n'.join(self.grpc_service.log_lines)))
 
     any_failed = False
     for test_server in self._test_servers:

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -139,7 +139,9 @@ class IntegrationTestBase():
     """
     if self.grpc_service is not None:
       if self.grpc_service.stop() != 0:
-        pytest.fail("the Nighthawk GRPC service reported a non-zero exit code when stopped, log lines:\n{}".format('\n'.join(self.grpc_service.log_lines)))
+        pytest.fail(
+            "the Nighthawk GRPC service reported a non-zero exit code when stopped, log lines:\n{}".
+            format('\n'.join(self.grpc_service.log_lines)))
 
     any_failed = False
     for test_server in self._test_servers:


### PR DESCRIPTION
Integration tests that are using the "dummy-request-source" service implementation had a race on logging which was causing `tsan` test runs to be excessively flaky.

- Improve logging when the GRPC service reports an error in integration tests. Previously we would just get an assertion failure without context.
- Create a logging lock when constructing the `RequestSourceServiceImpl`. If not done here, the log creation is racy as it happens at the first call to `ENVOY_LOG`.
 
Fixes #697.