### PR TITLE
Update Envoy to 14cca0a (Jun 08, 2021).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "72bf41fb0ecc039f196be02f534bfc2c9c69f348"  # Jun 4, 2021
-ENVOY_SHA = "db07426cf02fa2f8ed9891e64adf67ced39e72cdcce9ba121d420b471cc96766"
+ENVOY_COMMIT = "14cca0ab26c6e65adc4ef9b6e756ca48fac9b886"  # Jun 8, 2021
+ENVOY_SHA = "760f7f75263b51933e5e7c3e0a4c52583553d9460b4f407bb389e16c0191d44f"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -103,7 +103,6 @@ envoy_cc_library(
         "@envoy//source/exe:platform_impl_lib",
         "@envoy//source/exe:process_wide_lib_with_external_headers",
         "@envoy//source/extensions/request_id/uuid:config_with_external_headers",
-        "@envoy//source/extensions/transport_sockets:well_known_names_with_external_headers",
         "@envoy//source/extensions/transport_sockets/tls:context_lib_with_external_headers",
         "@envoy//source/server:server_lib_with_external_headers",
         "@envoy//source/server/config_validation:admin_lib_with_external_headers",

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -25,21 +25,6 @@
 #include "source/client/stream_decoder.h"
 #include "source/common/statistic_impl.h"
 
-// TODO(#695): temporary hack to until Envoy::Upstream::HttpPoolData supports
-// hasActiveConnections
-namespace Envoy {
-namespace Upstream {
-class HttpPoolDataPeer {
-public:
-  HttpPoolDataPeer(HttpPoolData& data) : data_(data) {}
-  Http::ConnectionPool::Instance* getPool() { return data_.pool_; };
-
-private:
-  HttpPoolData& data_;
-};
-} // namespace Upstream
-} // namespace Envoy
-
 namespace Nighthawk {
 namespace Client {
 

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -38,7 +38,6 @@
 #ifdef ZIPKIN_ENABLED
 #include "external/envoy/source/extensions/tracers/zipkin/zipkin_tracer_impl.h"
 #endif
-#include "external/envoy/source/extensions/transport_sockets/well_known_names.h"
 #include "external/envoy/source/server/options_impl.h"
 #include "external/envoy/source/server/options_impl_platform.h"
 


### PR DESCRIPTION
- Removing reference to header file `transport_sockets/well_known_names.h` that was deleted by Envoy (https://github.com/envoyproxy/envoy/commit/97d4792449b9c42d6d2f6d727f7cc47ee20d2243).
- Undoing temporary workaround for Nighthawk's pool access now that https://github.com/envoyproxy/envoy/pull/16865 was merged in.

Fixes #695.

Signed-off-by: Jakub Sobon <mumak@google.com>