### PR TITLE
Fix local execution of the python integration tests.

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -109,6 +109,7 @@ py_library(
 py_library(
     name = "test_request_source_plugin_lib",
     srcs = ["test_request_source_plugin.py"],
+    data = ["//test/request_source:testdata"],
     deps = [":integration_test_base"],
 )
 

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -23,7 +23,7 @@ def _run_with_number_of_connections(fixture,
   # We add a delay to responses to make sure connections are needed, as the pool creates connections on-demand.
   args = [
       fixture.getTestServerRootUri(), "--rps",
-      str(rps), "--duration", "5", "--request-header", "x-envoy-fault-delay-request:500",
+      str(rps), "--duration", "2", "--request-header", "x-envoy-fault-delay-request:500",
       "--max-pending-requests",
       str(max_pending_requests), "--max-requests-per-connection",
       str(requests_per_connection), "--connections",
@@ -48,7 +48,7 @@ def test_http_h1_connection_management_1(http_test_server_fixture):
 @pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable in sanitizer runs")
 def test_http_h1_connection_management_2(http_test_server_fixture):
   """Test http h1 connection management with 2 connections and queueing disabled."""
-  _run_with_number_of_connections(http_test_server_fixture, 2)
+  _run_with_number_of_connections(http_test_server_fixture, 2, requests_per_connection=200)
 
 
 # A series that tests with queueing enabled

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -23,7 +23,7 @@ def _run_with_number_of_connections(fixture,
   # We add a delay to responses to make sure connections are needed, as the pool creates connections on-demand.
   args = [
       fixture.getTestServerRootUri(), "--rps",
-      str(rps), "--duration", "2", "--request-header", "x-envoy-fault-delay-request:500",
+      str(rps), "--duration", "5", "--request-header", "x-envoy-fault-delay-request:500",
       "--max-pending-requests",
       str(max_pending_requests), "--max-requests-per-connection",
       str(requests_per_connection), "--connections",


### PR DESCRIPTION
- decrease the number of requests per connection in `test_connection_management`. This almost guarantees that multiple connections will be used as the test expects.
- ensure that `test_request_source` has the testdata it needs.

Signed-off-by: Jakub Sobon <mumak@google.com>