### PR TITLE
Fixing flakes in the integration tests.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -31,7 +31,7 @@ function do_opt_build () {
 
 function do_test() {
     bazel build -c dbg $BAZEL_BUILD_OPTIONS //test/...
-    bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all //test:python_test
+    bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all //test/...
 }
 
 function do_clang_tidy() {

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -31,7 +31,7 @@ function do_opt_build () {
 
 function do_test() {
     bazel build -c dbg $BAZEL_BUILD_OPTIONS //test/...
-    bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all //test/...
+    bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all //test:python_test
 }
 
 function do_clang_tidy() {

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -2,8 +2,9 @@
 
 import logging
 import os
-import sys
 import pytest
+import sys
+import time
 
 from test.integration.integration_test_fixtures import (http_test_server_fixture, server_config)
 from test.integration import asserts
@@ -48,7 +49,7 @@ def test_http_h1_connection_management_1(http_test_server_fixture):
 @pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable in sanitizer runs")
 def test_http_h1_connection_management_2(http_test_server_fixture):
   """Test http h1 connection management with 2 connections and queueing disabled."""
-  _run_with_number_of_connections(http_test_server_fixture, 2, requests_per_connection=200)
+  _run_with_number_of_connections(http_test_server_fixture, 2, run_test_expectation=False)
 
 
 # A series that tests with queueing enabled

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -2,9 +2,8 @@
 
 import logging
 import os
-import pytest
 import sys
-import time
+import pytest
 
 from test.integration.integration_test_fixtures import (http_test_server_fixture, server_config)
 from test.integration import asserts

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -2,10 +2,11 @@
 
 import json
 import logging
+import math
 import os
+import pytest
 import subprocess
 import sys
-import pytest
 import time
 from threading import Thread
 
@@ -639,7 +640,7 @@ def qps_parameterization_fixture(request):
   yield param
 
 
-@pytest.fixture(scope="function", params=[1, 3])
+@pytest.fixture(scope="function", params=[5, 10])
 def duration_parameterization_fixture(request):
   """Yield duration values to iterate test parameterization on."""
   param = request.param
@@ -658,19 +659,29 @@ def test_http_request_release_timing(http_test_server_fixture, qps_parameterizat
         str(concurrency)
     ])
 
-    total_requests = qps_parameterization_fixture * concurrency * duration_parameterization_fixture
     global_histograms = http_test_server_fixture.getNighthawkGlobalHistogramsbyIdFromJson(
         parsed_json)
     counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-    asserts.assertEqual(
+
+    global_result = http_test_server_fixture.getGlobalResults(parsed_json)
+    actual_duration = utility.get_execution_duration_from_global_result_json(global_result)
+    # Ensure Nighthawk managed to execute for at least some time.
+    assert actual_duration >= 1
+
+    # The actual duration is a float, flooring if here allows us to use
+    # the GreaterEqual matchers below.
+    total_requests = qps_parameterization_fixture * concurrency * math.floor(actual_duration)
+    asserts.assertGreaterEqual(
         int(global_histograms["benchmark_http_client.request_to_response"]["count"]),
         total_requests)
-    asserts.assertEqual(int(global_histograms["benchmark_http_client.queue_to_connect"]["count"]),
-                        total_requests)
-    asserts.assertEqual(int(global_histograms["benchmark_http_client.latency_2xx"]["count"]),
-                        total_requests)
+    asserts.assertGreaterEqual(
+        int(global_histograms["benchmark_http_client.queue_to_connect"]["count"]), total_requests)
+    asserts.assertGreaterEqual(int(global_histograms["benchmark_http_client.latency_2xx"]["count"]),
+                               total_requests)
 
-    asserts.assertCounterEqual(counters, "benchmark.http_2xx", (total_requests))
+    asserts.assertCounterGreaterEqual(counters, "benchmark.http_2xx", (total_requests))
+    # Give system resources some time to recover after the last execution.
+    time.sleep(2)
 
 
 def _send_sigterm(process):

--- a/test/integration/unit_tests/BUILD
+++ b/test/integration/unit_tests/BUILD
@@ -9,3 +9,11 @@ py_test(
         "//test/integration:integration_test_base_lean",
     ],
 )
+
+py_test(
+    name = "test_utility",
+    srcs = ["test_utility.py"],
+    deps = [
+        "//test/integration:integration_test_base_lean",
+    ],
+)

--- a/test/integration/unit_tests/test_utility.py
+++ b/test/integration/unit_tests/test_utility.py
@@ -1,0 +1,44 @@
+"""Contains unit tests for functions in utility.py."""
+
+import pytest
+import re
+
+from test.integration import utility
+
+
+def test_get_execution_duration_from_global_result_json_retrieves_duration():
+  """Test for the successful case."""
+  global_result_json = {"execution_duration": "5s"}
+  duration = utility.get_execution_duration_from_global_result_json(global_result_json)
+  assert duration == 5
+
+
+def test_get_execution_duration_from_global_result_json_retrieves_zero_duration():
+  """Test when execution duration is zero."""
+  global_result_json = {"execution_duration": "0s"}
+  duration = utility.get_execution_duration_from_global_result_json(global_result_json)
+  assert duration == 0
+
+
+def test_get_execution_duration_from_global_result_json_retrieves_float_duration():
+  """Test when execution duration is a float."""
+  global_result_json = {"execution_duration": "2.7s"}
+  duration = utility.get_execution_duration_from_global_result_json(global_result_json)
+  assert duration == 2.7
+
+
+def test_get_execution_duration_from_global_result_json_missing_duration():
+  """Test for the failure when execution_duration is missing."""
+  with pytest.raises(utility.Error):
+    utility.get_execution_duration_from_global_result_json({})
+
+
+def test_get_execution_duration_from_global_result_json_missing_suffix():
+  """Test for the failure when execution_duration is missing the 's' suffix."""
+  global_result_json = {"execution_duration": "5"}
+  with pytest.raises(utility.Error):
+    utility.get_execution_duration_from_global_result_json(global_result_json)
+
+
+if __name__ == "__main__":
+  raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
In `test_integration_basics.py`:
- add a test utility that can retrieve the actual execution duration.
- increase the test duration to 5 and 10 seconds from 1 and 3 seconds.
- no longer expecting Nighthawk to execute for exactly the prescribed duration, instead calculating the number of expected requests / etc based on the actual execution duration. Still expecting that duration to be positive.
- adding a cooldown sleep between executions.

In `test_connection_management.py`:
- disabling test expectation for the number of used connections in `test_http_h1_connection_management_2` as it remains excessively flaky even after #700. Also undoing the requests_per_connection tweak done in the same PR.

Verified with 10 successful executions.

Fixes #701.

Signed-off-by: Jakub Sobon <mumak@google.com>