### PR TITLE
Skip mini stress test on local test executions.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -30,8 +30,11 @@ function do_opt_build () {
 }
 
 function do_test() {
-    bazel build -c dbg $BAZEL_BUILD_OPTIONS //test/...
-    bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all //test/...
+    # The environment variable CI is used to determine if some expensive tests
+    # that cannot run locally should be executed.
+    # E.g. test_http_h1_mini_stress_test_open_loop.
+    bazel build -c dbg $BAZEL_BUILD_OPTIONS --action_env=CI //test/...
+    bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all --action_env=CI //test/...
 }
 
 function do_clang_tidy() {

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -256,9 +256,9 @@ class IntegrationTestBase():
     stdout, stderr = client_process.communicate()
     logs = stderr.decode('utf-8')
     output = stdout.decode('utf-8')
-    logging.debug("Nighthawk client stdout: [%s]" % output)
+    logging.info("Nighthawk client stdout: [%s]" % output)
     if logs:
-      logging.debug("Nighthawk client stderr: [%s]" % logs)
+      logging.info("Nighthawk client stderr: [%s]" % logs)
     if as_json:
       output = json.loads(output)
     if expect_failure:

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -139,7 +139,8 @@ def test_http_h2_mini_stress_test_without_client_side_queueing(http_test_server_
   asserts.assertNotIn("upstream_rq_pending_overflow", counters)
 
 
-@pytest.mark.skipif(not utility.isRunningInCircleCi(), reason="Has very high failure rate in local executions.")
+@pytest.mark.skipif(not utility.isRunningInCircleCi(),
+                    reason="Has very high failure rate in local executions.")
 @pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable and very slow in sanitizer runs")
 def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   """Run an H1 open loop stress test. We expect higher pending and overflow counts."""
@@ -152,7 +153,8 @@ def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   asserts.assertCounterGreater(counters, "benchmark.pool_overflow", 10)
 
 
-@pytest.mark.skipif(not utility.isRunningInCircleCi(), reason="Has very high failure rate in local executions.")
+@pytest.mark.skipif(not utility.isRunningInCircleCi(),
+                    reason="Has very high failure rate in local executions.")
 @pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable and very slow in sanitizer runs")
 def test_http_h2_mini_stress_test_open_loop(http_test_server_fixture):
   """Run an H2 open loop stress test. We expect higher overflow counts."""

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -139,6 +139,7 @@ def test_http_h2_mini_stress_test_without_client_side_queueing(http_test_server_
   asserts.assertNotIn("upstream_rq_pending_overflow", counters)
 
 
+@pytest.mark.skipif(not utility.isRunningInCircleCi(), reason="Has very high failure rate in local executions.")
 @pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable and very slow in sanitizer runs")
 def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   """Run an H1 open loop stress test. We expect higher pending and overflow counts."""
@@ -151,6 +152,7 @@ def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   asserts.assertCounterGreater(counters, "benchmark.pool_overflow", 10)
 
 
+@pytest.mark.skipif(not utility.isRunningInCircleCi(), reason="Has very high failure rate in local executions.")
 @pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable and very slow in sanitizer runs")
 def test_http_h2_mini_stress_test_open_loop(http_test_server_fixture):
   """Run an H2 open loop stress test. We expect higher overflow counts."""

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -20,14 +20,12 @@ def isSanitizerRun():
 def isRunningInCircleCi():
   """Determine if the current execution is running in circleci.
 
-  Depends on the environment variable IS_RUNNING_IN_CIRCLECI which is configured
-  in the project settings, see:
-    https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
+  Depends on the environment variable CI=true which circleci sets by default.
 
   Returns:
       bool: True iff the current execution is running in circleci.
   """
-  return True if os.environ.get("IS_RUNNING_IN_CIRCLECI", "no") == "yes" else False
+  return True if os.environ.get("CI", "false") == "true" else False
 
 
 def run_binary_with_args(binary, args):

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -20,14 +20,13 @@ def isSanitizerRun():
 def isRunningInCircleCi():
   """Determine if the current execution is running in circleci.
 
-  Depends on the environment variable IS_RUNNING_IN_CIRCLECI which is configured
-  in the project settings, see:
-    https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
+  Depends on the environment variable CIRCLECI=true which circleci uses by
+  default.
 
   Returns:
       bool: True iff the current execution is running in circleci.
   """
-  return True if os.environ.get("IS_RUNNING_IN_CIRCLECI", "no") == "yes" else False
+  return True if os.environ.get("CIRCLECI", "false") == "true" else False
 
 
 def run_binary_with_args(binary, args):

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -20,13 +20,14 @@ def isSanitizerRun():
 def isRunningInCircleCi():
   """Determine if the current execution is running in circleci.
 
-  Depends on the environment variable CIRCLECI=true which circleci uses by
-  default.
+  Depends on the environment variable IS_RUNNING_IN_CIRCLECI which is configured
+  in the project settings, see:
+    https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
 
   Returns:
       bool: True iff the current execution is running in circleci.
   """
-  return True if os.environ.get("CIRCLECI", "false") == "true" else False
+  return True if os.environ.get("IS_RUNNING_IN_CIRCLECI", "no") == "yes" else False
 
 
 def run_binary_with_args(binary, args):

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -17,6 +17,19 @@ def isSanitizerRun():
   return True if os.environ.get("NH_INTEGRATION_TEST_SANITIZER_RUN", 0) == "1" else False
 
 
+def isRunningInCircleCi():
+  """Determine if the current execution is running in circleci.
+
+  Depends on the environment variable IS_RUNNING_IN_CIRCLECI which is configured
+  in the project settings, see:
+    https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
+
+  Returns:
+      bool: True iff the current execution is running in circleci.
+  """
+  return True if os.environ.get("IS_RUNNING_IN_CIRCLECI", "no") == "yes" else False
+
+
 def run_binary_with_args(binary, args):
   """Execute a Nighthawk binary with the provided arguments.
 


### PR DESCRIPTION
These remain very flaky locally, but succeed in circleci.

Also:
- changing logs in the test fixture from debug to info. They aren't noisy, because pytest only includes them on failures, yet they are very helpful on those failures.

Signed-off-by: Jakub Sobon <mumak@google.com>