### PR TITLE
Bringing test_gcc back by breaking the build into parts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,15 @@ jobs:
     steps:
       - checkout
       - run: ci/do_ci.sh clang_tidy
+  test_gcc:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          command: ci/do_ci.sh test_gcc
+          no_output_timeout: 30m
   coverage:
     docker:
       - image: *envoy-build-image
@@ -93,6 +102,7 @@ workflows:
     jobs:
       - build
       - test
+      - test_gcc
       - clang_tidy
       - coverage
       - integration_test_coverage

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -19,6 +19,39 @@ export SRCDIR=${SRCDIR:="${PWD}"}
 export CLANG_FORMAT=clang-format
 export NIGHTHAWK_BUILD_ARCH=$(uname -m)
 
+# We build in steps to avoid running out of memory in CI.
+# This list doesn't have to be complete, execution of bazel test will build any
+# remaining targets.
+# The order matters here, dependencies are placed before dependents.
+BUILD_PARTS=(
+    "//api/..."
+    "//source/exe/..."
+    "//source/server/..."
+    "//source/request_source/..."
+    "//source/adaptive_load/..."
+    "//test/mocks/..."
+    "//test/..."
+)
+
+#######################################
+# Runs the specified command on all the BUILD_PARTS.
+# Arguments:
+#   The command to execute, each part will be appended as the last argument to
+#   this command.
+# Returns:
+#   0 on success, exits with return code 1 on failure.
+#######################################
+function run_on_build_parts() {
+    local command="$1"
+    for part in ${BUILD_PARTS[@]}; do
+        eval "$command $part"
+        if (( $? != 0 )); then
+            echo "Error executing $command $part."
+            exit 1
+        fi
+    done
+}
+
 function do_build () {
     bazel build $BAZEL_BUILD_OPTIONS //:nighthawk
     tools/update_cli_readme_documentation.sh --mode check
@@ -30,7 +63,7 @@ function do_opt_build () {
 }
 
 function do_test() {
-    bazel build -c dbg $BAZEL_BUILD_OPTIONS //test/...
+    run_on_build_parts "bazel build -c dbg $BAZEL_BUILD_OPTIONS"
     bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all //test/...
 }
 
@@ -99,10 +132,7 @@ function do_sanitizer() {
     cd "${SRCDIR}"
 
     # We build this in steps to avoid running out of memory in CI
-    run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config="$CONFIG" -- //source/exe/... && \
-    run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config="$CONFIG" -- //source/server/... && \
-    run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config="$CONFIG" -- //test/mocks/... && \
-    run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config="$CONFIG" -- //test/... && \
+    run_on_build_parts "run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=$CONFIG --"
     run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config="$CONFIG" -- //test/...
 }
 


### PR DESCRIPTION
Building in multiple smaller bazel executions results in each of the executions having a smaller memory footprint.

Fixes #686.

Signed-off-by: Jakub Sobon <mumak@google.com>