### PR TITLE
Update Envoy to ba474ac (Jul 19th 2021).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "5ab509b54bf6916235b5f2b65800b9d756032129"  # July 12, 2021
-ENVOY_SHA = "81f7e6142686cc3a9bcb5342ad97147b177d16a36546d8eab16c92abec0fa5e6"
+ENVOY_COMMIT = "ba474ac375418d5529a30a9510a8ff5f0a5ada9a"  # July 19, 2021
+ENVOY_SHA = "7042c9de30e8b2ece6b735135fa9328d88a288e77ceaac8d68d2be41e83d2fc4"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -115,7 +115,7 @@ void BenchmarkClientHttpImpl::terminate() {
     // No harm is done, but it does result in log lines warning about it. Avoid that, by
     // disabling latency measurement here.
     setShouldMeasureLatencies(false);
-    pool_data.value().addIdleCallback([this]() -> void {
+    pool_data.value().addDrainedCallback([this]() -> void {
       drain_timer_->disableTimer();
       dispatcher_.exit();
     });

--- a/source/common/request_source_impl.cc
+++ b/source/common/request_source_impl.cc
@@ -46,7 +46,8 @@ void RemoteRequestSourceImpl::connectToRequestStreamGrpcService() {
       cluster_manager_->grpcAsyncClientManager().factoryForGrpcService(grpc_service, scope_,
                                                                        /*skip_cluster_check=*/true);
   grpc_client_ = std::make_unique<RequestStreamGrpcClientImpl>(
-      cluster_manager->create(), dispatcher_, *base_header_, header_buffer_length_);
+      cluster_manager->createUncachedRawAsyncClient(), dispatcher_, *base_header_,
+      header_buffer_length_);
   grpc_client_->start();
   const Envoy::MonotonicTime start = time_source.monotonicTime();
   bool timeout = false;

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -435,7 +435,7 @@ TEST_F(BenchmarkClientHttpTest, DrainTimeoutFires) {
             return nullptr;
           });
   EXPECT_CALL(pool_, hasActiveConnections()).WillOnce([]() -> bool { return true; });
-  EXPECT_CALL(pool_, addIdleCallback(_));
+  EXPECT_CALL(pool_, addDrainedCallback(_));
   // We don't expect the callback that we pass here to fire.
   client_->tryStartRequest([](bool, bool) { EXPECT_TRUE(false); });
   // To get past this, the drain timeout within the benchmark client must execute.


### PR DESCRIPTION
- no changes in `.bazelrc`, `.bazelversion` or `ci/run_envoy_docker.sh`.
- reverting the `addIdleCallback` connection pool method back to `addDrainedCallback` as per https://github.com/envoyproxy/envoy/pull/17319.
- changing method call `AsyncClientFactory::create()` to `AsyncClientFactory::createUncachedRawAsyncClient()` as per https://github.com/envoyproxy/envoy/pull/15745.

Signed-off-by: Jakub Sobon <mumak@google.com>