### PR TITLE
Update Envoy to a066b5e (Aug 03th 2021)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -231,7 +231,7 @@ build:remote --strategy=Javac=remote,sandboxed,local
 build:remote --strategy=Closure=remote,sandboxed,local
 build:remote --strategy=Genrule=remote,sandboxed,local
 build:remote --remote_timeout=7200
-build:remote --auth_enabled=true
+build:remote --google_default_credentials=true
 build:remote --remote_download_toplevel
 
 # Windows bazel does not allow sandboxed as a spawn strategy
@@ -240,7 +240,7 @@ build:remote-windows --strategy=Javac=remote,local
 build:remote-windows --strategy=Closure=remote,local
 build:remote-windows --strategy=Genrule=remote,local
 build:remote-windows --remote_timeout=7200
-build:remote-windows --auth_enabled=true
+build:remote-windows --google_default_credentials=true
 build:remote-windows --remote_download_toplevel
 
 build:remote-clang --config=remote

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "b4027cf67516e094505d3e7d3489b3941c740a5a"  # July 26, 2021
-ENVOY_SHA = "c32b8d109c1569dbab9a2f627d431e2d646627720aabeb443890d256266c9edd"
+ENVOY_COMMIT = "a066b5ed9a06f2bed18fff9fc52d34c50948dcdd"  # August 03, 2021
+ENVOY_SHA = "67b56a8edb0340c7ed1d65cc9fceaf012c5c5fa71132634618c20da0d4b71c6c"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -115,7 +115,7 @@ void BenchmarkClientHttpImpl::terminate() {
     // No harm is done, but it does result in log lines warning about it. Avoid that, by
     // disabling latency measurement here.
     setShouldMeasureLatencies(false);
-    pool_data.value().addDrainedCallback([this]() -> void {
+    pool_data.value().addIdleCallback([this]() -> void {
       drain_timer_->disableTimer();
       dispatcher_.exit();
     });

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -435,7 +435,7 @@ TEST_F(BenchmarkClientHttpTest, DrainTimeoutFires) {
             return nullptr;
           });
   EXPECT_CALL(pool_, hasActiveConnections()).WillOnce([]() -> bool { return true; });
-  EXPECT_CALL(pool_, addDrainedCallback(_));
+  EXPECT_CALL(pool_, addIdleCallback(_));
   // We don't expect the callback that we pass here to fire.
   client_->tryStartRequest([](bool, bool) { EXPECT_TRUE(false); });
   // To get past this, the drain timeout within the benchmark client must execute.


### PR DESCRIPTION
Replacing drainedCallback with idleCallback in benchmark_client_impl and benchmark_client_test.
Replacing auth_enabled with google_default_credentials in bazelrc
Signed-off-by: William Juan <66322422+wjuan-AFK@users.noreply.github.com>