### PR TITLE
[QUIC 010]: Adding command line options for HTTP/3 Quic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ bazel-bin/nighthawk_client  [--latency-response-header-name <string>]
 uint64_t>] ... [--termination-predicate
 <string, uint64_t>] ... [--trace <uri
 format>] [--sequencer-idle-strategy <spin
-|poll|sleep>] [--max-requests-per-connection
+|poll|sleep>] [--max-concurrent-streams
+<uint32_t>] [--max-requests-per-connection
 <uint32_t>] [--max-active-requests
 <uint32_t>] [--max-pending-requests
 <uint32_t>] [--transport-socket <string>]
@@ -74,11 +75,11 @@ format>] [--sequencer-idle-strategy <spin
 <json|human|yaml|dotted|fortio
 |experimental_fortio_pedantic>] [-v <trace
 |debug|info|warn|error|critical>]
-[--concurrency <string>] [--h2] [--timeout
-<uint32_t>] [--duration <uint32_t>]
-[--connections <uint32_t>] [--rps
-<uint32_t>] [--] [--version] [-h] <uri
-format>
+[--concurrency <string>] [--h3] [--h2]
+[--timeout <uint32_t>] [--duration
+<uint32_t>] [--connections <uint32_t>]
+[--rps <uint32_t>] [--] [--version] [-h]
+<uri format>
 
 
 Where:
@@ -145,8 +146,8 @@ spread traffic across all endpoints with round robin distribution.
 Mutually exclusive with providing a URI.
 
 --experimental-h2-use-multiple-connections
-Use experimental HTTP/2 pool which will use multiple connections.
-WARNING: feature may be removed or changed in the future!
+DO NOT USE: This options is deprecated, if this behavior is desired,
+set --max-concurrent-streams to one instead.
 
 --nighthawk-service <uri format>
 Nighthawk service uri. Example: grpc://localhost:8843/. Default is
@@ -182,6 +183,10 @@ empty.
 --sequencer-idle-strategy <spin|poll|sleep>
 Choose between using a busy spin/yield loop or have the thread poll or
 sleep while waiting for the next scheduled request (default: spin).
+
+--max-concurrent-streams <uint32_t>
+Max concurrent streams allowed on one HTTP/2 or HTTP/3 connection.
+Does not apply to HTTP/1. (default: 2147483647).
 
 --max-requests-per-connection <uint32_t>
 Max requests per connection (default: 4294937295).
@@ -250,8 +255,15 @@ Nighthawk process. Note that increasing this results in an effective
 load multiplier combined with the configured --rps and --connections
 values. Default: 1.
 
+--h3
+Encapsulate requests in HTTP/3 Quic. Mutually exclusive with --h2.
+Requests are encapsulated in HTTP/1 by default when neither of --h2 or
+--h3 is used.
+
 --h2
-Use HTTP/2
+Encapsulate requests in HTTP/2. Mutually exclusive with --h3. Requests
+are encapsulated in HTTP/1 by default when neither of --h2 or --h3 is
+used.
 
 --timeout <uint32_t>
 Connection connect timeout period in seconds. Default: 30.

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -106,7 +106,7 @@ message H1ConnectionReuseStrategy {
 
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
-// highest unused number is 107
+// Highest unused number is 109.
 message CommandLineOptions {
   // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
@@ -121,8 +121,16 @@ message CommandLineOptions {
   }
   // Connection connect timeout period in seconds. Default: 30.
   google.protobuf.Duration timeout = 4 [(validate.rules).duration.gte.seconds = 0];
-  // Use HTTP/2
-  google.protobuf.BoolValue h2 = 5;
+
+  // The protocol to use when encapsulating requests.
+  // Defaults to HTTP/1 if no value is selected.
+  oneof request_protocol {
+    // Use HTTP/2.
+    google.protobuf.BoolValue h2 = 5;
+    // Use HTTP/3 Quic.
+    google.protobuf.BoolValue h3 = 107;
+  }
+
   // The number of concurrent event loops that should be used. Specify 'auto' to let
   // Nighthawk leverage all vCPUs that have affinity to the Nighthawk process. Note that
   // increasing this results in an effective load multiplier combined with the configured
@@ -161,7 +169,8 @@ message CommandLineOptions {
   // Max pending requests (default: 0, no client side queuing. Specifying any other value will allow
   // client-side queuing of requests).
   google.protobuf.UInt32Value max_pending_requests = 14;
-  // The maximum allowed number of concurrently active requests. HTTP/2 only. (default: 100).
+  // The maximum allowed number of concurrently active requests.
+  // HTTP/2 and HTTP/3 only. (default: 100).
   google.protobuf.UInt32Value max_active_requests = 15 [(validate.rules).uint32 = {gte: 1}];
   // Max requests per connection (default: 4294937295).
   google.protobuf.UInt32Value max_requests_per_connection = 16 [(validate.rules).uint32 = {gte: 1}];
@@ -198,9 +207,26 @@ message CommandLineOptions {
   // Default is empty.
   // NOTE: not relevant to gRPC service
   google.protobuf.StringValue nighthawk_service = 31; // [(validate.rules).string.uri = true];
-  // Use experimental HTTP/2 pool which will use multiple connections.
-  // WARNING: feature may be removed or changed in the future!
-  google.protobuf.BoolValue experimental_h2_use_multiple_connections = 30;
+  // DO NOT USE: This options is deprecated, if this behavior is desired, set
+  // max_concurrent_streams to one instead.
+  google.protobuf.BoolValue experimental_h2_use_multiple_connections = 30 [deprecated = true];
+
+  // The maximum concurrent streams allowed on one HTTP/2 or HTTP/3 connection.
+  //
+  // Does not apply to HTTP/1.
+  // See https://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2 for more
+  // details.
+  //
+  // This limits how many streams Nighthawk will initiate concurrently on a
+  // single connection. If the limit is reached, Nighthawk may queue requests or
+  // use additional connections depending on the other configuration values.
+  // E.g. setting this to 1 makes Nighthawk use a new connection for each
+  // request.
+  //
+  // (default: 2147483647).
+  google.protobuf.UInt32Value max_concurrent_streams = 108
+      [(validate.rules).uint32 = {lte: 2147483647 gte: 1}];
+
   // Label. Allows specifying multiple labels which will be persisted in structured output formats.
   repeated string labels = 28;
   // TransportSocket configuration to use in every request

--- a/include/nighthawk/client/BUILD
+++ b/include/nighthawk/client/BUILD
@@ -18,6 +18,7 @@ envoy_basic_cc_library(
         "//api/client:base_cc_proto",
         "//include/nighthawk/common:base_includes",
         "@envoy//envoy/common:time_interface",
+        "@envoy//envoy/http:protocol_interface_with_external_headers",
         "@envoy//source/common/common:minimal_logger_lib_with_external_headers",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -10,6 +10,7 @@
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/metrics/v3/stats.pb.h"
+#include "envoy/http/protocol.h"
 
 #include "nighthawk/common/termination_predicate.h"
 
@@ -35,7 +36,11 @@ public:
   virtual std::chrono::seconds timeout() const PURE;
   // URI is absent when the user specified --multi-target-* instead.
   virtual absl::optional<std::string> uri() const PURE;
-  virtual bool h2() const PURE;
+
+  // The upstream protocol to encapsulate requests in.
+  // Defaults to HTTP/1.1 if the user doesn't make an explicit selection.
+  virtual Envoy::Http::Protocol upstreamProtocol() const PURE;
+
   virtual std::string concurrency() const PURE;
   virtual nighthawk::client::Verbosity::VerbosityOptions verbosity() const PURE;
   virtual nighthawk::client::OutputFormat::OutputFormatOptions outputFormat() const PURE;
@@ -52,6 +57,11 @@ public:
   virtual uint32_t maxPendingRequests() const PURE;
   virtual uint32_t maxActiveRequests() const PURE;
   virtual uint32_t maxRequestsPerConnection() const PURE;
+
+  // The maximum concurrent streams allowed on one HTTP/2 or HTTP/3 connection.
+  // Does not apply to HTTP/1.
+  virtual uint32_t maxConcurrentStreams() const PURE;
+
   virtual nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions
   sequencerIdleStrategy() const PURE;
   virtual std::string requestSource() const PURE;
@@ -65,7 +75,6 @@ public:
   virtual bool openLoop() const PURE;
   virtual std::chrono::nanoseconds jitterUniform() const PURE;
   virtual std::string nighthawkService() const PURE;
-  virtual bool h2UseMultipleConnections() const PURE;
   virtual std::vector<nighthawk::client::MultiTarget::Endpoint> multiTargetEndpoints() const PURE;
   virtual std::string multiTargetPath() const PURE;
   virtual bool multiTargetUseHttps() const PURE;

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -81,13 +81,13 @@ Http1PoolImpl::newStream(Envoy::Http::ResponseDecoder& response_decoder,
 
 BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(
     Envoy::Api::Api& api, Envoy::Event::Dispatcher& dispatcher, Envoy::Stats::Scope& scope,
-    BenchmarkClientStatistic& statistic, bool use_h2,
+    BenchmarkClientStatistic& statistic, Envoy::Http::Protocol upstream_protocol,
     Envoy::Upstream::ClusterManagerPtr& cluster_manager,
     Envoy::Tracing::HttpTracerSharedPtr& http_tracer, absl::string_view cluster_name,
     RequestGenerator request_generator, const bool provide_resource_backpressure,
     absl::string_view latency_response_header_name)
     : api_(api), dispatcher_(dispatcher), scope_(scope.createScope("benchmark.")),
-      statistic_(std::move(statistic)), use_h2_(use_h2),
+      statistic_(std::move(statistic)), upstream_protocol_(upstream_protocol),
       benchmark_client_counters_({ALL_BENCHMARK_CLIENT_COUNTERS(POOL_COUNTER(*scope_))}),
       cluster_manager_(cluster_manager), http_tracer_(http_tracer),
       cluster_name_(std::string(cluster_name)), request_generator_(std::move(request_generator)),
@@ -153,8 +153,14 @@ bool BenchmarkClientHttpImpl::tryStartRequest(CompletionCallback caller_completi
     return false;
   }
   if (provide_resource_backpressure_) {
-    const uint64_t max_in_flight =
-        max_pending_requests_ + (use_h2_ ? max_active_requests_ : connection_limit_);
+    uint64_t max_active_requests = 0;
+    if (upstream_protocol_ == Envoy::Http::Protocol::Http2 ||
+        upstream_protocol_ == Envoy::Http::Protocol::Http3) {
+      max_active_requests = max_active_requests_;
+    } else {
+      max_active_requests = connection_limit_;
+    }
+    const uint64_t max_in_flight = max_pending_requests_ + max_active_requests;
 
     if (requests_initiated_ - requests_completed_ >= max_in_flight) {
       // When we allow client-side queueing, we want to have a sense of time spend waiting on that

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -102,7 +102,8 @@ class BenchmarkClientHttpImpl : public BenchmarkClient,
 public:
   BenchmarkClientHttpImpl(Envoy::Api::Api& api, Envoy::Event::Dispatcher& dispatcher,
                           Envoy::Stats::Scope& scope, BenchmarkClientStatistic& statistic,
-                          bool use_h2, Envoy::Upstream::ClusterManagerPtr& cluster_manager,
+                          Envoy::Http::Protocol upstream_protocol,
+                          Envoy::Upstream::ClusterManagerPtr& cluster_manager,
                           Envoy::Tracing::HttpTracerSharedPtr& http_tracer,
                           absl::string_view cluster_name, RequestGenerator request_generator,
                           const bool provide_resource_backpressure,
@@ -135,10 +136,9 @@ public:
 
   // Helpers
   absl::optional<::Envoy::Upstream::HttpPoolData> pool() {
-    auto proto = use_h2_ ? Envoy::Http::Protocol::Http2 : Envoy::Http::Protocol::Http11;
     const auto thread_local_cluster = cluster_manager_->getThreadLocalCluster(cluster_name_);
-    return thread_local_cluster->httpConnPool(Envoy::Upstream::ResourcePriority::Default, proto,
-                                              nullptr);
+    return thread_local_cluster->httpConnPool(Envoy::Upstream::ResourcePriority::Default,
+                                              upstream_protocol_, nullptr);
   }
 
 private:
@@ -146,7 +146,7 @@ private:
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::Stats::ScopePtr scope_;
   BenchmarkClientStatistic statistic_;
-  const bool use_h2_;
+  const Envoy::Http::Protocol upstream_protocol_;
   std::chrono::seconds timeout_{5s};
   uint32_t connection_limit_{1};
   uint32_t max_pending_requests_{1};

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -50,8 +50,9 @@ BenchmarkClientPtr BenchmarkClientFactoryImpl::create(
                                      std::make_unique<SinkableHdrStatistic>(scope, worker_id),
                                      std::make_unique<SinkableHdrStatistic>(scope, worker_id));
   auto benchmark_client = std::make_unique<BenchmarkClientHttpImpl>(
-      api, dispatcher, scope, statistic, options_.h2(), cluster_manager, http_tracer, cluster_name,
-      request_generator.get(), !options_.openLoop(), options_.responseHeaderWithLatencyInput());
+      api, dispatcher, scope, statistic, options_.upstreamProtocol(), cluster_manager, http_tracer,
+      cluster_name, request_generator.get(), !options_.openLoop(),
+      options_.responseHeaderWithLatencyInput());
   auto request_options = options_.toCommandLineOptions()->request_options();
   benchmark_client->setConnectionLimit(options_.connections());
   benchmark_client->setMaxPendingRequests(options_.maxPendingRequests());

--- a/source/client/output_formatter_impl.cc
+++ b/source/client/output_formatter_impl.cc
@@ -292,11 +292,11 @@ FortioOutputFormatterImpl::formatProto(const nighthawk::client::Output& output) 
   fortio_output.set_runtype("HTTP");
 
   // The stock Envoy h2 pool doesn't offer support for multiple connections here. So we must ignore
-  // the connections setting when h2 is enabled and the experimental h2-pool which supports multiple
-  // connections isn't enabled. Also, the number of workers acts as a multiplier.
+  // the connections setting when h2 is enabled and the h2-pool is allowed to send multiple streams
+  // over a single connection (i.e. it won't be using multiple connections).
+  // Also, the number of workers acts as a multiplier.
   const uint32_t number_of_connections =
-      ((output.options().h2().value() &&
-        !output.options().experimental_h2_use_multiple_connections().value())
+      ((output.options().h2().value() && output.options().max_concurrent_streams().value() > 1)
            ? 1
            : output.options().connections().value()) *
       number_of_workers;

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -316,15 +316,16 @@ void ProcessImpl::createBootstrapConfiguration(envoy::config::bootstrap::v3::Boo
       transport_socket->set_name("envoy.transport_sockets.tls");
       envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext context =
           options_.tlsContext();
-      const std::string sni_host = SniUtility::computeSniHost(
-          uris, options_.requestHeaders(),
-          options_.h2() ? Envoy::Http::Protocol::Http2 : Envoy::Http::Protocol::Http11);
+      const std::string sni_host =
+          SniUtility::computeSniHost(uris, options_.requestHeaders(), options_.upstreamProtocol());
       if (!sni_host.empty()) {
         *context.mutable_sni() = sni_host;
       }
       auto* common_tls_context = context.mutable_common_tls_context();
-      if (options_.h2()) {
+      if (options_.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
         common_tls_context->add_alpn_protocols("h2");
+      } else if (options_.upstreamProtocol() == Envoy::Http::Protocol::Http3) {
+        throw NighthawkException("HTTP/3 Quic support isn't implemented yet.");
       } else {
         common_tls_context->add_alpn_protocols("http/1.1");
       }
@@ -336,11 +337,10 @@ void ProcessImpl::createBootstrapConfiguration(envoy::config::bootstrap::v3::Boo
     cluster->set_name(fmt::format("{}", i));
     cluster->mutable_connect_timeout()->set_seconds(options_.timeout().count());
     cluster->mutable_max_requests_per_connection()->set_value(options_.maxRequestsPerConnection());
-    if (options_.h2()) {
+    if (options_.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
       auto* cluster_http2_protocol_options = cluster->mutable_http2_protocol_options();
-      if (options_.h2UseMultipleConnections()) {
-        cluster_http2_protocol_options->mutable_max_concurrent_streams()->set_value(1);
-      }
+      cluster_http2_protocol_options->mutable_max_concurrent_streams()->set_value(
+          options_.maxConcurrentStreams());
     }
 
     auto thresholds = cluster->mutable_circuit_breakers()->add_thresholds();

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -179,8 +179,8 @@ public:
   // verifyBenchmarkClientProcessesExpectedInflightRequests.
   void setupBenchmarkClient(const RequestGenerator& request_generator) {
     client_ = std::make_unique<Client::BenchmarkClientHttpImpl>(
-        *api_, *dispatcher_, store_, statistic_, /*use_h2*/ false, cluster_manager_, http_tracer_,
-        "benchmark", request_generator, /*provide_resource_backpressure*/ true,
+        *api_, *dispatcher_, store_, statistic_, Envoy::Http::Protocol::Http11, cluster_manager_,
+        http_tracer_, "benchmark", request_generator, /*provide_resource_backpressure*/ true,
         /*response_header_with_latency_input=*/"");
   }
 

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -36,7 +36,7 @@ TEST_F(FactoriesTest, CreateBenchmarkClient) {
   BenchmarkClientFactoryImpl factory(options_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   EXPECT_CALL(options_, connections());
-  EXPECT_CALL(options_, h2());
+  EXPECT_CALL(options_, upstreamProtocol()).WillOnce(Return(Envoy::Http::Protocol::Http11));
   EXPECT_CALL(options_, maxPendingRequests());
   EXPECT_CALL(options_, maxActiveRequests());
   EXPECT_CALL(options_, maxRequestsPerConnection());

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -285,8 +285,7 @@ def test_https_h2_multiple_connections(https_test_server_fixture):
       "--h2",
       https_test_server_fixture.getTestServerRootUri(), "--rps", "100", "--duration", "100",
       "--termination-predicate", "benchmark.http_2xx:99", "--max-active-requests", "10",
-      "--max-pending-requests", "10", "--experimental-h2-use-multiple-connections", "--burst-size",
-      "10"
+      "--max-pending-requests", "10", "--max-concurrent-streams", "1", "--burst-size", "10"
   ])
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterGreaterEqual(counters, "benchmark.http_2xx", 100)

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -16,7 +16,7 @@ public:
   MOCK_CONST_METHOD0(duration, std::chrono::seconds());
   MOCK_CONST_METHOD0(timeout, std::chrono::seconds());
   MOCK_CONST_METHOD0(uri, absl::optional<std::string>());
-  MOCK_CONST_METHOD0(h2, bool());
+  MOCK_CONST_METHOD0(upstreamProtocol, Envoy::Http::Protocol());
   MOCK_CONST_METHOD0(concurrency, std::string());
   MOCK_CONST_METHOD0(verbosity, nighthawk::client::Verbosity::VerbosityOptions());
   MOCK_CONST_METHOD0(outputFormat, nighthawk::client::OutputFormat::OutputFormatOptions());
@@ -32,6 +32,7 @@ public:
   MOCK_CONST_METHOD0(maxPendingRequests, uint32_t());
   MOCK_CONST_METHOD0(maxActiveRequests, uint32_t());
   MOCK_CONST_METHOD0(maxRequestsPerConnection, uint32_t());
+  MOCK_CONST_METHOD0(maxConcurrentStreams, uint32_t());
   MOCK_CONST_METHOD0(toCommandLineOptions, CommandLineOptionsPtr());
   MOCK_CONST_METHOD0(sequencerIdleStrategy,
                      nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions());
@@ -47,7 +48,6 @@ public:
   MOCK_CONST_METHOD0(openLoop, bool());
   MOCK_CONST_METHOD0(jitterUniform, std::chrono::nanoseconds());
   MOCK_CONST_METHOD0(nighthawkService, std::string());
-  MOCK_CONST_METHOD0(h2UseMultipleConnections, bool());
   MOCK_CONST_METHOD0(multiTargetEndpoints, std::vector<nighthawk::client::MultiTarget::Endpoint>());
   MOCK_CONST_METHOD0(multiTargetPath, std::string());
   MOCK_CONST_METHOD0(multiTargetUseHttps, bool());

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -115,7 +115,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
       "--max-active-requests 11 --max-requests-per-connection 12 --sequencer-idle-strategy sleep "
       "--termination-predicate t1:1 --termination-predicate t2:2 --failure-predicate f1:1 "
       "--failure-predicate f2:2 --jitter-uniform .00001s "
-      "--experimental-h2-use-multiple-connections "
+      "--max-concurrent-streams 42 "
       "--experimental-h1-connection-reuse-strategy lru --label label1 --label label2 {} "
       "--simple-warmup --stats-sinks {} --stats-sinks {} --stats-flush-interval 10 "
       "--latency-response-header-name zz",
@@ -131,7 +131,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
   EXPECT_EQ(5, options->connections());
   EXPECT_EQ(6s, options->duration());
   EXPECT_EQ(7s, options->timeout());
-  EXPECT_EQ(true, options->h2());
+  EXPECT_EQ(Envoy::Http::Protocol::Http2, options->upstreamProtocol());
   EXPECT_EQ("8", options->concurrency());
   EXPECT_EQ(nighthawk::client::Verbosity::ERROR, options->verbosity());
   EXPECT_EQ(nighthawk::client::OutputFormat::YAML, options->outputFormat());
@@ -167,7 +167,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
   EXPECT_EQ(1, options->failurePredicates()["f1"]);
   EXPECT_EQ(2, options->failurePredicates()["f2"]);
   EXPECT_EQ(10us, options->jitterUniform());
-  EXPECT_EQ(true, options->h2UseMultipleConnections());
+  EXPECT_EQ(42, options->maxConcurrentStreams());
   EXPECT_EQ(nighthawk::client::H1ConnectionReuseStrategy::LRU,
             options->h1ConnectionReuseStrategy());
   const std::vector<std::string> expected_labels{"label1", "label2"};
@@ -200,7 +200,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
   EXPECT_EQ(cmd->connections().value(), options->connections());
   EXPECT_EQ(cmd->duration().seconds(), options->duration().count());
   EXPECT_EQ(cmd->timeout().seconds(), options->timeout().count());
-  EXPECT_EQ(cmd->h2().value(), options->h2());
+  EXPECT_TRUE(cmd->h2().value());
   EXPECT_EQ(cmd->concurrency().value(), options->concurrency());
   EXPECT_EQ(cmd->verbosity().value(), options->verbosity());
   EXPECT_EQ(cmd->output_format().value(), options->outputFormat());
@@ -240,8 +240,7 @@ TEST_F(OptionsImplTest, AlmostAll) {
   EXPECT_EQ(1, cmd->mutable_failure_predicates()->erase("f1"));
   EXPECT_EQ(1, cmd->mutable_termination_predicates()->erase("t1"));
   EXPECT_EQ(cmd->jitter_uniform().nanos(), options->jitterUniform().count());
-  EXPECT_EQ(cmd->experimental_h2_use_multiple_connections().value(),
-            options->h2UseMultipleConnections());
+  EXPECT_EQ(cmd->max_concurrent_streams().value(), options->maxConcurrentStreams());
   EXPECT_EQ(cmd->experimental_h1_connection_reuse_strategy().value(),
             options->h1ConnectionReuseStrategy());
   EXPECT_THAT(cmd->labels(), ElementsAreArray(expected_labels));
@@ -568,19 +567,90 @@ INSTANTIATE_TEST_SUITE_P(IntOptionTests, OptionsImplIntTest,
                                 "burst-size", "max-pending-requests", "max-active-requests",
                                 "max-requests-per-connection"));
 
-// Test behaviour of the boolean valued --h2 flag.
-TEST_F(OptionsImplTest, H2Flag) {
-  EXPECT_FALSE(
-      TestUtility::createOptionsImpl(fmt::format("{} {}", client_name_, good_test_uri_))->h2());
-  EXPECT_TRUE(
-      TestUtility::createOptionsImpl(fmt::format("{} --h2 {}", client_name_, good_test_uri_))
-          ->h2());
+TEST_F(OptionsImplTest, MaxConcurrentStreamsHasDefaultValue) {
+  const std::unique_ptr<OptionsImpl> option =
+      TestUtility::createOptionsImpl(fmt::format("{} {}", client_name_, good_test_uri_));
+
+  EXPECT_EQ(OptionsImpl::largest_acceptable_concurrent_streams_value,
+            option->maxConcurrentStreams());
+  // Verify the default remains when converting back from proto.
+  CommandLineOptionsPtr proto = option->toCommandLineOptions();
+  const auto converted_option = std::make_unique<OptionsImpl>(*proto);
+  EXPECT_EQ(OptionsImpl::largest_acceptable_concurrent_streams_value,
+            converted_option->maxConcurrentStreams());
+}
+
+TEST_F(OptionsImplTest, UsesHttp11ByDefault) {
+  const std::unique_ptr<OptionsImpl> option =
+      TestUtility::createOptionsImpl(fmt::format("{} {}", client_name_, good_test_uri_));
+
+  EXPECT_EQ(Envoy::Http::Protocol::Http11, option->upstreamProtocol());
+  // Verify the default remains HTTP/1.1 when converting back from proto.
+  CommandLineOptionsPtr proto = option->toCommandLineOptions();
+  const auto converted_option = std::make_unique<OptionsImpl>(*proto);
+  EXPECT_EQ(Envoy::Http::Protocol::Http11, converted_option->upstreamProtocol());
+}
+
+TEST_F(OptionsImplTest, UsesHttp2WhenH2FlagIsSet) {
+  const std::unique_ptr<OptionsImpl> option =
+      TestUtility::createOptionsImpl(fmt::format("{} --h2 {}", client_name_, good_test_uri_));
+
+  EXPECT_EQ(Envoy::Http::Protocol::Http2, option->upstreamProtocol());
+  // Verify the default remains HTTP/2 when converting back from proto.
+  CommandLineOptionsPtr proto = option->toCommandLineOptions();
+  const auto converted_option = std::make_unique<OptionsImpl>(*proto);
+  EXPECT_EQ(Envoy::Http::Protocol::Http2, converted_option->upstreamProtocol());
+}
+
+TEST_F(OptionsImplTest, FailsForInvalidH2FlagValues) {
   EXPECT_THROW_WITH_REGEX(
       TestUtility::createOptionsImpl(fmt::format("{} --h2 0 {}", client_name_, good_test_uri_)),
       MalformedArgvException, "Couldn't find match for argument");
   EXPECT_THROW_WITH_REGEX(
       TestUtility::createOptionsImpl(fmt::format("{} --h2 true {}", client_name_, good_test_uri_)),
       MalformedArgvException, "Couldn't find match for argument");
+}
+
+TEST_F(OptionsImplTest, UsesHttp3WhenH3FlagIsSet) {
+  const std::unique_ptr<OptionsImpl> option =
+      TestUtility::createOptionsImpl(fmt::format("{} --h3 {}", client_name_, good_test_uri_));
+
+  EXPECT_EQ(Envoy::Http::Protocol::Http3, option->upstreamProtocol());
+  // Verify the default remains HTTP/3 when converting back from proto.
+  CommandLineOptionsPtr proto = option->toCommandLineOptions();
+  const auto converted_option = std::make_unique<OptionsImpl>(*proto);
+  EXPECT_EQ(Envoy::Http::Protocol::Http3, converted_option->upstreamProtocol());
+}
+
+TEST_F(OptionsImplTest, FailsForInvalidH3FlagValues) {
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(fmt::format("{} --h3 0 {}", client_name_, good_test_uri_)),
+      MalformedArgvException, "Couldn't find match for argument");
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(fmt::format("{} --h3 true {}", client_name_, good_test_uri_)),
+      MalformedArgvException, "Couldn't find match for argument");
+}
+
+TEST_F(OptionsImplTest, FailsWhenBothH2AndH3AreSet) {
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(fmt::format("{} --h2 --h3 http://foo", client_name_)),
+      MalformedArgvException, "mutually exclusive");
+}
+
+TEST_F(OptionsImplTest, FailsWhenDeprecatedExperimentalH2UseMultipleConnectionsIsSetOnCommandLine) {
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(
+          fmt::format("{} --experimental-h2-use-multiple-connections http://foo", client_name_)),
+      MalformedArgvException, "experimental-h2-use-multiple-connections");
+}
+
+TEST_F(OptionsImplTest, FailsWhenDeprecatedExperimentalH2UseMultipleConnectionsIsSetViaProto) {
+  const std::unique_ptr<OptionsImpl> option =
+      TestUtility::createOptionsImpl(fmt::format("{} http://127.0.0.1/", client_name_));
+  CommandLineOptionsPtr proto = option->toCommandLineOptions();
+  proto->mutable_experimental_h2_use_multiple_connections()->set_value(true);
+  EXPECT_THROW_WITH_REGEX(std::make_unique<OptionsImpl>(*proto), MalformedArgvException,
+                          "experimental_h2_use_multiple_connections");
 }
 
 TEST_F(OptionsImplTest, PrefetchConnectionsFlag) {

--- a/test/test_data/output_formatter.medium.proto.gold
+++ b/test/test_data/output_formatter.medium.proto.gold
@@ -46,7 +46,7 @@
   "uri": "https://www.google.com/",
   "trace": "",
   "open_loop": false,
-  "experimental_h2_use_multiple_connections": false,
+  "max_concurrent_streams": 2147483647,
   "labels": "Nighthawk",
   "jitter_uniform": "0.000000494s",
  },


### PR DESCRIPTION
The Quic support isn't fully implemented yet. Nitghhawk will currently throw on executions with the new `h3` options specified. The implementation will be finished in following PRs. The implementation was broken into multiple PRs to simplify code reviews.

Done here:

- adding command line option `h3` which is in a oneof with the pre-existing `h2`.
- adding option `max_concurrent_streams` which applies both to HTTP/2 and HTTP/3.
- deprecating the `experimental_h2_use_multiple_connections` which was just indirectly setting `max_concurrent_streams`. Any users interested in this behavior can set `max_concurrent_streams` to one.
- the `Options` interface now has an `upstreamProtocol()` method which exposes the selected HTTP protocol version to the rest of Nighthawk instead of using multiple bools.