### PR TITLE
[QUIC 020]: Moving code that creates the Envoy bootstrap into its own library.

### DIFF
--- a/docs/root/overview.md
+++ b/docs/root/overview.md
@@ -104,16 +104,12 @@ timing offsets to an underlying **RateLimiter**) and **LinearRampingRateLimiter*
 ### BenchmarkClient
 
 As of today, there’s a single implementation called **BenchmarkClientImpl**,
-which wraps Envoy’s **Upstream** concept and (slightly) customized H1/H2
+which wraps Envoy’s **Upstream** concept and (slightly) customized H1/H2/H3
 **Pool** concepts. For executing requests, the pool will be requested to create
 a **StreamEncoder**, and Nighthawk will pass its own **StreamDecoderImpl** into
 that as an argument. The integration surface between **BenchmarkClient** is
 defined via `BenchmarkClient::tryStartRequest()` and a callback specification
 which will be fired upon completion of a successfully started request.
-
-For H3, it is anticipated that it will fit into this model, but if all else
-fails, it will be entirely possible to wire in a new type of
-**BenchmarkClient**.
 
 ### RequestSource
 

--- a/extensions_build_config.bzl
+++ b/extensions_build_config.bzl
@@ -6,6 +6,7 @@ EXTENSIONS = {
     "envoy.filters.network.http_connection_manager": "//source/extensions/filters/network/http_connection_manager:config",
     "envoy.tracers.zipkin": "//source/extensions/tracers/zipkin:config",
     "envoy.transport_sockets.raw_buffer": "//source/extensions/transport_sockets/raw_buffer:config",
+    "envoy.access_loggers.file": "//source/extensions/access_loggers/file:config",
 }
 
 DISABLED_BY_DEFAULT_EXTENSIONS = {

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -28,6 +28,33 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "sni_utility",
+    srcs = ["sni_utility.cc"],
+    hdrs = ["sni_utility.h"],
+    repository = "@envoy",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//source/common:nighthawk_common_lib",
+        "@envoy//envoy/http:protocol_interface_with_external_headers",
+    ],
+)
+
+envoy_cc_library(
+    name = "process_bootstrap",
+    srcs = ["process_bootstrap.cc"],
+    hdrs = ["process_bootstrap.h"],
+    repository = "@envoy",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":sni_utility",
+        "//include/nighthawk/client:options_lib",
+        "//source/common:nighthawk_common_lib",
+        "@envoy//source/common/common:statusor_lib_with_external_headers",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "nighthawk_client_lib",
     srcs = [
         "benchmark_client_impl.cc",
@@ -37,7 +64,6 @@ envoy_cc_library(
         "flush_worker_impl.cc",
         "process_impl.cc",
         "remote_process_impl.cc",
-        "sni_utility.cc",
         "stream_decoder.cc",
     ],
     hdrs = [
@@ -48,7 +74,6 @@ envoy_cc_library(
         "flush_worker_impl.h",
         "process_impl.h",
         "remote_process_impl.h",
-        "sni_utility.h",
         "stream_decoder.h",
     ],
     copts = select({
@@ -61,6 +86,7 @@ envoy_cc_library(
         ":options_impl_lib",
         ":output_collector_impl_lib",
         ":output_formatter_impl_lib",
+        ":process_bootstrap",
         "//api/client:base_cc_proto",
         "//include/nighthawk/client:client_includes",
         "//include/nighthawk/common:base_includes",

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -57,15 +57,15 @@ absl::StatusOr<Bootstrap> createBootstrapConfiguration(const Client::Options& op
       transport_socket->set_name("envoy.transport_sockets.tls");
       envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext context =
           options.tlsContext();
-      const std::string sni_host = Client::SniUtility::computeSniHost(
-          uris, options.requestHeaders(), options.upstreamProtocol());
+      const std::string sni_host =
+          Client::SniUtility::computeSniHost(uris, options.requestHeaders(), options.protocol());
       if (!sni_host.empty()) {
         *context.mutable_sni() = sni_host;
       }
       auto* common_tls_context = context.mutable_common_tls_context();
-      if (options.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
+      if (options.protocol() == Envoy::Http::Protocol::Http2) {
         common_tls_context->add_alpn_protocols("h2");
-      } else if (options.upstreamProtocol() == Envoy::Http::Protocol::Http3) {
+      } else if (options.protocol() == Envoy::Http::Protocol::Http3) {
         return absl::UnimplementedError("HTTP/3 Quic support isn't implemented yet.");
       } else {
         common_tls_context->add_alpn_protocols("http/1.1");
@@ -78,7 +78,7 @@ absl::StatusOr<Bootstrap> createBootstrapConfiguration(const Client::Options& op
     cluster->set_name(fmt::format("{}", i));
     cluster->mutable_connect_timeout()->set_seconds(options.timeout().count());
     cluster->mutable_max_requests_per_connection()->set_value(options.maxRequestsPerConnection());
-    if (options.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
+    if (options.protocol() == Envoy::Http::Protocol::Http2) {
       auto* cluster_http2_protocol_options = cluster->mutable_http2_protocol_options();
       cluster_http2_protocol_options->mutable_max_concurrent_streams()->set_value(
           options.maxConcurrentStreams());

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -8,34 +8,171 @@
 
 #include "external/envoy/source/common/common/statusor.h"
 #include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "external/envoy_api/envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.h"
+#include "external/envoy_api/envoy/extensions/upstreams/http/v3/http_protocol_options.pb.h"
 
 #include "source/client/sni_utility.h"
 
 namespace Nighthawk {
 namespace {
 
-using envoy::config::bootstrap::v3::Bootstrap;
+using ::envoy::config::bootstrap::v3::Bootstrap;
+using ::envoy::config::cluster::v3::CircuitBreakers;
+using ::envoy::config::cluster::v3::Cluster;
+using ::envoy::config::core::v3::Http2ProtocolOptions;
+using ::envoy::config::core::v3::Http3ProtocolOptions;
+using ::envoy::config::core::v3::SocketAddress;
+using ::envoy::config::core::v3::TransportSocket;
+using ::envoy::config::endpoint::v3::ClusterLoadAssignment;
+using ::envoy::config::endpoint::v3::LocalityLbEndpoints;
+using ::envoy::config::metrics::v3::StatsSink;
+using ::envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport;
+using ::envoy::extensions::transport_sockets::tls::v3::CommonTlsContext;
+using ::envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext;
 
-// Adds a cluster for the request source into the bootstrap.
-void addRequestSourceCluster(const Client::Options& options, const Uri& uri, int worker_number,
-                             Bootstrap& bootstrap) {
-  auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
-  cluster->mutable_http2_protocol_options();
-  cluster->set_name(fmt::format("{}.requestsource", worker_number));
-  cluster->set_type(
-      envoy::config::cluster::v3::Cluster::DiscoveryType::Cluster_DiscoveryType_STATIC);
-  cluster->mutable_connect_timeout()->set_seconds(options.timeout().count());
+// Adds the address and port specified in the URI to the endpoints.
+void addUriToEndpoints(const Uri& uri, LocalityLbEndpoints* endpoints) {
+  SocketAddress* socket_address = endpoints->add_lb_endpoints()
+                                      ->mutable_endpoint()
+                                      ->mutable_address()
+                                      ->mutable_socket_address();
+  socket_address->set_address(uri.address()->ip()->addressAsString());
+  socket_address->set_port_value(uri.port());
+}
 
-  auto* load_assignment = cluster->mutable_load_assignment();
-  load_assignment->set_cluster_name(cluster->name());
-  auto* socket = cluster->mutable_load_assignment()
-                     ->add_endpoints()
-                     ->add_lb_endpoints()
-                     ->mutable_endpoint()
-                     ->mutable_address()
-                     ->mutable_socket_address();
-  socket->set_address(uri.address()->ip()->addressAsString());
-  socket->set_port_value(uri.port());
+// Creates a cluster used for communication with request source for the
+// specified worker number.
+Cluster createRequestSourceClusterForWorker(const Client::Options& options,
+                                            const Uri& request_source_uri, int worker_number) {
+  Cluster cluster;
+
+  envoy::extensions::upstreams::http::v3::HttpProtocolOptions http_options;
+  http_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+  (*cluster.mutable_typed_extension_protocol_options())
+      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+          .PackFrom(http_options);
+
+  cluster.set_name(fmt::format("{}.requestsource", worker_number));
+  cluster.set_type(Cluster::STATIC);
+  cluster.mutable_connect_timeout()->set_seconds(options.timeout().count());
+
+  ClusterLoadAssignment* load_assignment = cluster.mutable_load_assignment();
+  load_assignment->set_cluster_name(cluster.name());
+  LocalityLbEndpoints* endpoints = load_assignment->add_endpoints();
+  addUriToEndpoints(request_source_uri, endpoints);
+  return cluster;
+}
+
+// Determines whether the generated bootstrap requires transport socket
+// configuration.
+// Transport socket is required if the URI scheme is "https", or if the user
+// specified a custom transport socket on the command line.
+bool needTransportSocket(const Client::Options& options, const std::vector<UriPtr>& uris) {
+  return uris[0]->scheme() == "https" || options.transportSocket().has_value();
+}
+
+// Creates the transport socket configuration.
+absl::StatusOr<TransportSocket> createTransportSocket(const Client::Options& options,
+                                                      const std::vector<UriPtr>& uris) {
+  // User specified transport socket configuration takes precedence.
+  if (options.transportSocket().has_value()) {
+    return options.transportSocket().value();
+  }
+
+  TransportSocket transport_socket;
+
+  UpstreamTlsContext upstream_tls_context = options.tlsContext();
+  const std::string sni_host =
+      Client::SniUtility::computeSniHost(uris, options.requestHeaders(), options.protocol());
+  if (!sni_host.empty()) {
+    *upstream_tls_context.mutable_sni() = sni_host;
+  }
+
+  CommonTlsContext* common_tls_context = upstream_tls_context.mutable_common_tls_context();
+  if (options.protocol() == Envoy::Http::Protocol::Http2) {
+    transport_socket.set_name("envoy.transport_sockets.tls");
+    common_tls_context->add_alpn_protocols("h2");
+    transport_socket.mutable_typed_config()->PackFrom(upstream_tls_context);
+
+  } else if (options.protocol() == Envoy::Http::Protocol::Http3) {
+    transport_socket.set_name("envoy.transport_sockets.quic");
+    common_tls_context->add_alpn_protocols("h3");
+
+    QuicUpstreamTransport quic_upstream_transport;
+    *quic_upstream_transport.mutable_upstream_tls_context() = upstream_tls_context;
+    transport_socket.mutable_typed_config()->PackFrom(quic_upstream_transport);
+
+  } else {
+    transport_socket.set_name("envoy.transport_sockets.tls");
+    common_tls_context->add_alpn_protocols("http/1.1");
+    transport_socket.mutable_typed_config()->PackFrom(upstream_tls_context);
+  }
+
+  return transport_socket;
+}
+
+// Creates circuit breakers configuration based on the specified options.
+CircuitBreakers createCircuitBreakers(const Client::Options& options) {
+  CircuitBreakers circuit_breakers;
+  CircuitBreakers::Thresholds* thresholds = circuit_breakers.add_thresholds();
+
+  // We do not support any retrying.
+  thresholds->mutable_max_retries()->set_value(0);
+  thresholds->mutable_max_connections()->set_value(options.connections());
+
+  // We specialize on 0 below, as that is not supported natively. The benchmark client will track
+  // in flight work and avoid creating pending requests in this case.
+  thresholds->mutable_max_pending_requests()->set_value(
+      options.maxPendingRequests() == 0 ? 1 : options.maxPendingRequests());
+  thresholds->mutable_max_requests()->set_value(options.maxActiveRequests());
+
+  return circuit_breakers;
+}
+
+// Creates a cluster used by Nighthawk to upstream requests to the uris by the specified worker
+// number.
+Cluster createNighthawkClusterForWorker(const Client::Options& options,
+                                        const std::vector<UriPtr>& uris, int worker_number) {
+  Cluster cluster;
+
+  cluster.set_name(fmt::format("{}", worker_number));
+  cluster.mutable_connect_timeout()->set_seconds(options.timeout().count());
+
+  envoy::extensions::upstreams::http::v3::HttpProtocolOptions http_options;
+  http_options.mutable_common_http_protocol_options()
+      ->mutable_max_requests_per_connection()
+      ->set_value(options.maxRequestsPerConnection());
+
+  if (options.protocol() == Envoy::Http::Protocol::Http2) {
+    Http2ProtocolOptions* http2_options =
+        http_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+    http2_options->mutable_max_concurrent_streams()->set_value(options.maxConcurrentStreams());
+
+  } else if (options.protocol() == Envoy::Http::Protocol::Http3) {
+    Http3ProtocolOptions* http3_options =
+        http_options.mutable_explicit_http_config()->mutable_http3_protocol_options();
+    http3_options->mutable_quic_protocol_options()->mutable_max_concurrent_streams()->set_value(
+        options.maxConcurrentStreams());
+
+  } else {
+    http_options.mutable_explicit_http_config()->mutable_http_protocol_options();
+  }
+
+  (*cluster.mutable_typed_extension_protocol_options())
+      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+          .PackFrom(http_options);
+
+  *cluster.mutable_circuit_breakers() = createCircuitBreakers(options);
+
+  cluster.set_type(Cluster::STATIC);
+
+  ClusterLoadAssignment* load_assignment = cluster.mutable_load_assignment();
+  load_assignment->set_cluster_name(cluster.name());
+  LocalityLbEndpoints* endpoints = load_assignment->add_endpoints();
+  for (const UriPtr& uri : uris) {
+    addUriToEndpoints(*uri, endpoints);
+  }
+  return cluster;
 }
 
 } // namespace
@@ -44,79 +181,35 @@ absl::StatusOr<Bootstrap> createBootstrapConfiguration(const Client::Options& op
                                                        const std::vector<UriPtr>& uris,
                                                        const UriPtr& request_source_uri,
                                                        int number_of_workers) {
+  if (uris.empty()) {
+    return absl::InvalidArgumentError(
+        "illegal configuration with zero endpoints, at least one uri must be specified");
+  }
+
   Bootstrap bootstrap;
-  for (int i = 0; i < number_of_workers; i++) {
-    auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
+  for (int worker_number = 0; worker_number < number_of_workers; worker_number++) {
+    Cluster nighthawk_cluster = createNighthawkClusterForWorker(options, uris, worker_number);
 
-    if (uris.empty()) {
-      return absl::InvalidArgumentError(
-          "illegal configuration with zero endpoints, at least one uri must be specified");
-    }
-    if (uris[0]->scheme() == "https") {
-      auto* transport_socket = cluster->mutable_transport_socket();
-      transport_socket->set_name("envoy.transport_sockets.tls");
-      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext context =
-          options.tlsContext();
-      const std::string sni_host =
-          Client::SniUtility::computeSniHost(uris, options.requestHeaders(), options.protocol());
-      if (!sni_host.empty()) {
-        *context.mutable_sni() = sni_host;
+    if (needTransportSocket(options, uris)) {
+      absl::StatusOr<TransportSocket> transport_socket = createTransportSocket(options, uris);
+      if (!transport_socket.ok()) {
+        return transport_socket.status();
       }
-      auto* common_tls_context = context.mutable_common_tls_context();
-      if (options.protocol() == Envoy::Http::Protocol::Http2) {
-        common_tls_context->add_alpn_protocols("h2");
-      } else if (options.protocol() == Envoy::Http::Protocol::Http3) {
-        return absl::UnimplementedError("HTTP/3 Quic support isn't implemented yet.");
-      } else {
-        common_tls_context->add_alpn_protocols("http/1.1");
-      }
-      transport_socket->mutable_typed_config()->PackFrom(context);
+      *nighthawk_cluster.mutable_transport_socket() = *transport_socket;
     }
-    if (options.transportSocket().has_value()) {
-      *cluster->mutable_transport_socket() = options.transportSocket().value();
-    }
-    cluster->set_name(fmt::format("{}", i));
-    cluster->mutable_connect_timeout()->set_seconds(options.timeout().count());
-    cluster->mutable_max_requests_per_connection()->set_value(options.maxRequestsPerConnection());
-    if (options.protocol() == Envoy::Http::Protocol::Http2) {
-      auto* cluster_http2_protocol_options = cluster->mutable_http2_protocol_options();
-      cluster_http2_protocol_options->mutable_max_concurrent_streams()->set_value(
-          options.maxConcurrentStreams());
-    }
+    *bootstrap.mutable_static_resources()->add_clusters() = nighthawk_cluster;
 
-    auto thresholds = cluster->mutable_circuit_breakers()->add_thresholds();
-    // We do not support any retrying.
-    thresholds->mutable_max_retries()->set_value(0);
-    thresholds->mutable_max_connections()->set_value(options.connections());
-    // We specialize on 0 below, as that is not supported natively. The benchmark client will track
-    // in flight work and avoid creating pending requests in this case.
-    thresholds->mutable_max_pending_requests()->set_value(
-        options.maxPendingRequests() == 0 ? 1 : options.maxPendingRequests());
-    thresholds->mutable_max_requests()->set_value(options.maxActiveRequests());
-
-    cluster->set_type(
-        envoy::config::cluster::v3::Cluster::DiscoveryType::Cluster_DiscoveryType_STATIC);
-
-    auto* load_assignment = cluster->mutable_load_assignment();
-    load_assignment->set_cluster_name(cluster->name());
-    auto* endpoints = cluster->mutable_load_assignment()->add_endpoints();
-    for (const UriPtr& uri : uris) {
-      auto* socket = endpoints->add_lb_endpoints()
-                         ->mutable_endpoint()
-                         ->mutable_address()
-                         ->mutable_socket_address();
-      socket->set_address(uri->address()->ip()->addressAsString());
-      socket->set_port_value(uri->port());
-    }
     if (request_source_uri != nullptr) {
-      addRequestSourceCluster(options, *request_source_uri, i, bootstrap);
+      *bootstrap.mutable_static_resources()->add_clusters() =
+          createRequestSourceClusterForWorker(options, *request_source_uri, worker_number);
     }
   }
 
-  for (const envoy::config::metrics::v3::StatsSink& stats_sink : options.statsSinks()) {
+  for (const StatsSink& stats_sink : options.statsSinks()) {
     *bootstrap.add_stats_sinks() = stats_sink;
   }
   bootstrap.mutable_stats_flush_interval()->set_seconds(options.statsFlushInterval());
+
   return bootstrap;
 }
 

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -1,0 +1,123 @@
+#include "source/client/process_bootstrap.h"
+
+#include <string>
+#include <vector>
+
+#include "nighthawk/client/options.h"
+#include "nighthawk/common/uri.h"
+
+#include "external/envoy/source/common/common/statusor.h"
+#include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
+
+#include "source/client/sni_utility.h"
+
+namespace Nighthawk {
+namespace {
+
+using envoy::config::bootstrap::v3::Bootstrap;
+
+// Adds a cluster for the request source into the bootstrap.
+void addRequestSourceCluster(const Client::Options& options, const Uri& uri, int worker_number,
+                             Bootstrap& bootstrap) {
+  auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
+  cluster->mutable_http2_protocol_options();
+  cluster->set_name(fmt::format("{}.requestsource", worker_number));
+  cluster->set_type(
+      envoy::config::cluster::v3::Cluster::DiscoveryType::Cluster_DiscoveryType_STATIC);
+  cluster->mutable_connect_timeout()->set_seconds(options.timeout().count());
+
+  auto* load_assignment = cluster->mutable_load_assignment();
+  load_assignment->set_cluster_name(cluster->name());
+  auto* socket = cluster->mutable_load_assignment()
+                     ->add_endpoints()
+                     ->add_lb_endpoints()
+                     ->mutable_endpoint()
+                     ->mutable_address()
+                     ->mutable_socket_address();
+  socket->set_address(uri.address()->ip()->addressAsString());
+  socket->set_port_value(uri.port());
+}
+
+} // namespace
+
+absl::StatusOr<Bootstrap> createBootstrapConfiguration(const Client::Options& options,
+                                                       const std::vector<UriPtr>& uris,
+                                                       const UriPtr& request_source_uri,
+                                                       int number_of_workers) {
+  Bootstrap bootstrap;
+  for (int i = 0; i < number_of_workers; i++) {
+    auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
+
+    if (uris.empty()) {
+      return absl::InvalidArgumentError(
+          "illegal configuration with zero endpoints, at least one uri must be specified");
+    }
+    if (uris[0]->scheme() == "https") {
+      auto* transport_socket = cluster->mutable_transport_socket();
+      transport_socket->set_name("envoy.transport_sockets.tls");
+      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext context =
+          options.tlsContext();
+      const std::string sni_host = Client::SniUtility::computeSniHost(
+          uris, options.requestHeaders(), options.upstreamProtocol());
+      if (!sni_host.empty()) {
+        *context.mutable_sni() = sni_host;
+      }
+      auto* common_tls_context = context.mutable_common_tls_context();
+      if (options.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
+        common_tls_context->add_alpn_protocols("h2");
+      } else if (options.upstreamProtocol() == Envoy::Http::Protocol::Http3) {
+        return absl::UnimplementedError("HTTP/3 Quic support isn't implemented yet.");
+      } else {
+        common_tls_context->add_alpn_protocols("http/1.1");
+      }
+      transport_socket->mutable_typed_config()->PackFrom(context);
+    }
+    if (options.transportSocket().has_value()) {
+      *cluster->mutable_transport_socket() = options.transportSocket().value();
+    }
+    cluster->set_name(fmt::format("{}", i));
+    cluster->mutable_connect_timeout()->set_seconds(options.timeout().count());
+    cluster->mutable_max_requests_per_connection()->set_value(options.maxRequestsPerConnection());
+    if (options.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
+      auto* cluster_http2_protocol_options = cluster->mutable_http2_protocol_options();
+      cluster_http2_protocol_options->mutable_max_concurrent_streams()->set_value(
+          options.maxConcurrentStreams());
+    }
+
+    auto thresholds = cluster->mutable_circuit_breakers()->add_thresholds();
+    // We do not support any retrying.
+    thresholds->mutable_max_retries()->set_value(0);
+    thresholds->mutable_max_connections()->set_value(options.connections());
+    // We specialize on 0 below, as that is not supported natively. The benchmark client will track
+    // in flight work and avoid creating pending requests in this case.
+    thresholds->mutable_max_pending_requests()->set_value(
+        options.maxPendingRequests() == 0 ? 1 : options.maxPendingRequests());
+    thresholds->mutable_max_requests()->set_value(options.maxActiveRequests());
+
+    cluster->set_type(
+        envoy::config::cluster::v3::Cluster::DiscoveryType::Cluster_DiscoveryType_STATIC);
+
+    auto* load_assignment = cluster->mutable_load_assignment();
+    load_assignment->set_cluster_name(cluster->name());
+    auto* endpoints = cluster->mutable_load_assignment()->add_endpoints();
+    for (const UriPtr& uri : uris) {
+      auto* socket = endpoints->add_lb_endpoints()
+                         ->mutable_endpoint()
+                         ->mutable_address()
+                         ->mutable_socket_address();
+      socket->set_address(uri->address()->ip()->addressAsString());
+      socket->set_port_value(uri->port());
+    }
+    if (request_source_uri != nullptr) {
+      addRequestSourceCluster(options, *request_source_uri, i, bootstrap);
+    }
+  }
+
+  for (const envoy::config::metrics::v3::StatsSink& stats_sink : options.statsSinks()) {
+    *bootstrap.add_stats_sinks() = stats_sink;
+  }
+  bootstrap.mutable_stats_flush_interval()->set_seconds(options.statsFlushInterval());
+  return bootstrap;
+}
+
+} // namespace Nighthawk

--- a/source/client/process_bootstrap.h
+++ b/source/client/process_bootstrap.h
@@ -1,0 +1,34 @@
+#include <vector>
+
+#include "nighthawk/client/options.h"
+#include "nighthawk/common/uri.h"
+
+#include "external/envoy/source/common/common/statusor.h"
+#include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
+
+namespace Nighthawk {
+
+/**
+ * Creates Envoy bootstrap configuration.
+ *
+ * The created bootstrap configuration can be used to upstream requests to the
+ * specified uris.
+ *
+ * @param options are the options Nighthawk was started with.
+ * @param uris are the endpoints to which the requests will be upstreamed. At
+ *        least one uri must be specified. It is assumed that all the uris have
+ *        the same scheme (e.g. https). All the uri objects must already be
+ *        resolved.
+ * @param request_source_uri is the address of the request source service to
+ *        use, can be NULL if request source isn't used. If not NULL, the uri
+ *        object must already be resolved.
+ * @param number_of_workers indicates how many Nighthawk workers will be
+ *        upstreaming requests. A separate cluster is generated for each worker.
+ *
+ * @return the created bootstrap configuration.
+ */
+absl::StatusOr<envoy::config::bootstrap::v3::Bootstrap>
+createBootstrapConfiguration(const Client::Options& options, const std::vector<UriPtr>& uris,
+                             const UriPtr& request_source_uri, int number_of_workers);
+
+} // namespace Nighthawk

--- a/source/client/process_bootstrap.h
+++ b/source/client/process_bootstrap.h
@@ -14,7 +14,7 @@ namespace Nighthawk {
  * The created bootstrap configuration can be used to upstream requests to the
  * specified uris.
  *
- * @param options are the options Nighthawk was started with.
+ * @param options are the options this Nighthawk execution was triggered with.
  * @param uris are the endpoints to which the requests will be upstreamed. At
  *        least one uri must be specified. It is assumed that all the uris have
  *        the same scheme (e.g. https). All the uri objects must already be

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -18,6 +18,7 @@
 
 #include "external/envoy/source/common/api/api_impl.h"
 #include "external/envoy/source/common/common/cleanup.h"
+#include "external/envoy/source/common/common/statusor.h"
 #include "external/envoy/source/common/config/utility.h"
 #include "external/envoy/source/common/event/dispatcher_impl.h"
 #include "external/envoy/source/common/event/real_time_system.h"
@@ -29,6 +30,8 @@
 #include "external/envoy/source/common/thread_local/thread_local_impl.h"
 #include "external/envoy/source/server/server.h"
 #include "external/envoy_api/envoy/config/core/v3/resolver.pb.h"
+
+#include "source/client/process_bootstrap.h"
 
 #include "absl/strings/str_replace.h"
 #include "absl/types/optional.h"
@@ -304,80 +307,6 @@ ProcessImpl::mergeWorkerStatistics(const std::vector<ClientWorkerPtr>& workers) 
   return merged_statistics;
 }
 
-void ProcessImpl::createBootstrapConfiguration(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
-                                               const std::vector<UriPtr>& uris,
-                                               const UriPtr& request_source_uri,
-                                               int number_of_clusters) const {
-  for (int i = 0; i < number_of_clusters; i++) {
-    auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
-    RELEASE_ASSERT(!uris.empty(), "illegal configuration with zero endpoints");
-    if (uris[0]->scheme() == "https") {
-      auto* transport_socket = cluster->mutable_transport_socket();
-      transport_socket->set_name("envoy.transport_sockets.tls");
-      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext context =
-          options_.tlsContext();
-      const std::string sni_host =
-          SniUtility::computeSniHost(uris, options_.requestHeaders(), options_.upstreamProtocol());
-      if (!sni_host.empty()) {
-        *context.mutable_sni() = sni_host;
-      }
-      auto* common_tls_context = context.mutable_common_tls_context();
-      if (options_.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
-        common_tls_context->add_alpn_protocols("h2");
-      } else if (options_.upstreamProtocol() == Envoy::Http::Protocol::Http3) {
-        throw NighthawkException("HTTP/3 Quic support isn't implemented yet.");
-      } else {
-        common_tls_context->add_alpn_protocols("http/1.1");
-      }
-      transport_socket->mutable_typed_config()->PackFrom(context);
-    }
-    if (options_.transportSocket().has_value()) {
-      *cluster->mutable_transport_socket() = options_.transportSocket().value();
-    }
-    cluster->set_name(fmt::format("{}", i));
-    cluster->mutable_connect_timeout()->set_seconds(options_.timeout().count());
-    cluster->mutable_max_requests_per_connection()->set_value(options_.maxRequestsPerConnection());
-    if (options_.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
-      auto* cluster_http2_protocol_options = cluster->mutable_http2_protocol_options();
-      cluster_http2_protocol_options->mutable_max_concurrent_streams()->set_value(
-          options_.maxConcurrentStreams());
-    }
-
-    auto thresholds = cluster->mutable_circuit_breakers()->add_thresholds();
-    // We do not support any retrying.
-    thresholds->mutable_max_retries()->set_value(0);
-    thresholds->mutable_max_connections()->set_value(options_.connections());
-    // We specialize on 0 below, as that is not supported natively. The benchmark client will track
-    // in flight work and avoid creating pending requests in this case.
-    thresholds->mutable_max_pending_requests()->set_value(
-        options_.maxPendingRequests() == 0 ? 1 : options_.maxPendingRequests());
-    thresholds->mutable_max_requests()->set_value(options_.maxActiveRequests());
-
-    cluster->set_type(
-        envoy::config::cluster::v3::Cluster::DiscoveryType::Cluster_DiscoveryType_STATIC);
-
-    auto* load_assignment = cluster->mutable_load_assignment();
-    load_assignment->set_cluster_name(cluster->name());
-    auto* endpoints = cluster->mutable_load_assignment()->add_endpoints();
-    for (const UriPtr& uri : uris) {
-      auto* socket = endpoints->add_lb_endpoints()
-                         ->mutable_endpoint()
-                         ->mutable_address()
-                         ->mutable_socket_address();
-      socket->set_address(uri->address()->ip()->addressAsString());
-      socket->set_port_value(uri->port());
-    }
-    if (request_source_uri != nullptr) {
-      addRequestSourceCluster(*request_source_uri, i, bootstrap);
-    }
-  }
-
-  for (const envoy::config::metrics::v3::StatsSink& stats_sink : options_.statsSinks()) {
-    *bootstrap.add_stats_sinks() = stats_sink;
-  }
-  bootstrap.mutable_stats_flush_interval()->set_seconds(options_.statsFlushInterval());
-}
-
 void ProcessImpl::addTracingCluster(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                                     const Uri& uri) const {
   auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
@@ -444,27 +373,6 @@ void ProcessImpl::maybeCreateTracingDriver(const envoy::config::trace::v3::Traci
   }
 }
 
-void ProcessImpl::addRequestSourceCluster(
-    const Uri& uri, int worker_number, envoy::config::bootstrap::v3::Bootstrap& bootstrap) const {
-  auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
-  cluster->mutable_http2_protocol_options();
-  cluster->set_name(fmt::format("{}.requestsource", worker_number));
-  cluster->set_type(
-      envoy::config::cluster::v3::Cluster::DiscoveryType::Cluster_DiscoveryType_STATIC);
-  cluster->mutable_connect_timeout()->set_seconds(options_.timeout().count());
-
-  auto* load_assignment = cluster->mutable_load_assignment();
-  load_assignment->set_cluster_name(cluster->name());
-  auto* socket = cluster->mutable_load_assignment()
-                     ->add_endpoints()
-                     ->add_lb_endpoints()
-                     ->mutable_endpoint()
-                     ->mutable_address()
-                     ->mutable_socket_address();
-  socket->set_address(uri.address()->ip()->addressAsString());
-  socket->set_port_value(uri.port());
-}
-
 void ProcessImpl::setupStatsSinks(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                                   std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks) {
   for (const envoy::config::metrics::v3::StatsSink& stats_sink : bootstrap.stats_sinks()) {
@@ -493,12 +401,19 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
     }
     int number_of_workers = determineConcurrency();
     shutdown_ = false;
-    envoy::config::bootstrap::v3::Bootstrap bootstrap;
-    createBootstrapConfiguration(bootstrap, uris, request_source_uri, number_of_workers);
+
+    absl::StatusOr<envoy::config::bootstrap::v3::Bootstrap> bootstrap =
+        createBootstrapConfiguration(options_, uris, request_source_uri, number_of_workers);
+    if (!bootstrap.ok()) {
+      ENVOY_LOG(error, "Failed to create bootstrap configuration: {}",
+                bootstrap.status().message());
+      return false;
+    }
+
     // Needs to happen as early as possible (before createWorkers()) in the instantiation to preempt
     // the objects that require stats.
     if (!options_.statsSinks().empty()) {
-      store_root_.setTagProducer(Envoy::Config::Utility::createTagProducer(bootstrap));
+      store_root_.setTagProducer(Envoy::Config::Utility::createTagProducer(*bootstrap));
     }
 
     createWorkers(number_of_workers, scheduled_start);
@@ -531,21 +446,21 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const std::vector<UriP
             : Http1PoolImpl::ConnectionReuseStrategy::MRU);
     cluster_manager_factory_->setPrefetchConnections(options_.prefetchConnections());
     if (tracing_uri != nullptr) {
-      setupTracingImplementation(bootstrap, *tracing_uri);
-      addTracingCluster(bootstrap, *tracing_uri);
+      setupTracingImplementation(*bootstrap, *tracing_uri);
+      addTracingCluster(*bootstrap, *tracing_uri);
     }
-    ENVOY_LOG(debug, "Computed configuration: {}", bootstrap.DebugString());
-    cluster_manager_ = cluster_manager_factory_->clusterManagerFromProto(bootstrap);
-    maybeCreateTracingDriver(bootstrap.tracing());
+    ENVOY_LOG(debug, "Computed configuration: {}", bootstrap->DebugString());
+    cluster_manager_ = cluster_manager_factory_->clusterManagerFromProto(*bootstrap);
+    maybeCreateTracingDriver(bootstrap->tracing());
     cluster_manager_->setInitializedCb(
         [this]() -> void { init_manager_.initialize(init_watcher_); });
 
     Envoy::Runtime::LoaderSingleton::get().initialize(*cluster_manager_);
 
     std::list<std::unique_ptr<Envoy::Stats::Sink>> stats_sinks;
-    setupStatsSinks(bootstrap, stats_sinks);
+    setupStatsSinks(*bootstrap, stats_sinks);
     std::chrono::milliseconds stats_flush_interval = std::chrono::milliseconds(
-        Envoy::DurationUtil::durationToMilliseconds(bootstrap.stats_flush_interval()));
+        Envoy::DurationUtil::durationToMilliseconds(bootstrap->stats_flush_interval()));
 
     if (!options_.statsSinks().empty()) {
       // There should be only a single live flush worker instance at any time.

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -88,21 +88,9 @@ public:
   bool requestExecutionCancellation() override;
 
 private:
-  /**
-   * @brief Creates a cluster for usage by a remote request source.
-   *
-   * @param uri The parsed uri of the remote request source.
-   * @param worker_number The worker number that we are creating this cluster for.
-   * @param config The bootstrap configuration that will be modified.
-   */
-  void addRequestSourceCluster(const Uri& uri, int worker_number,
-                               envoy::config::bootstrap::v3::Bootstrap& config) const;
   void addTracingCluster(envoy::config::bootstrap::v3::Bootstrap& bootstrap, const Uri& uri) const;
   void setupTracingImplementation(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                                   const Uri& uri) const;
-  void createBootstrapConfiguration(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
-                                    const std::vector<UriPtr>& uris,
-                                    const UriPtr& request_source_uri, int number_of_workers) const;
   void maybeCreateTracingDriver(const envoy::config::trace::v3::Tracing& configuration);
   void configureComponentLogLevels(spdlog::level::level_enum level);
   /**

--- a/test/BUILD
+++ b/test/BUILD
@@ -339,8 +339,27 @@ envoy_cc_test(
     srcs = ["sni_utility_test.cc"],
     repository = "@envoy",
     deps = [
-        "//source/client:nighthawk_client_lib",
+        "//source/client:sni_utility",
         "@envoy//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "process_bootstrap_test",
+    srcs = ["process_bootstrap_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/client:options_impl_lib",
+        "//source/client:process_bootstrap",
+        "//source/common:nighthawk_common_lib",
+        "//test/client:utility_lib",
+        "//test/mocks/client:mock_options",
+        "//test/test_common:proto_matchers",
+        "@envoy//test/test_common:status_utility_lib",
+        "@envoy//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -9,13 +9,15 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+filegroup(
+    name = "test_server_configs",
+    data = glob(["configurations/*"]),
+)
+
 py_library(
     name = "integration_test_base",
     data = [
-        "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_https_origin.yaml",
-        "configurations/nighthawk_track_timings.yaml",
-        "configurations/sni_origin.yaml",
+        ":test_server_configs",
         "//:nighthawk_client",
         "//:nighthawk_output_transform",
         "//:nighthawk_service",
@@ -38,9 +40,7 @@ py_library(
         "utility.py",
     ],
     data = [
-        "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_https_origin.yaml",
-        "configurations/sni_origin.yaml",
+        ":test_server_configs",
         "@envoy//test/config/integration/certs",
     ],
     deps = [

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -1,0 +1,58 @@
+admin:
+  access_log:
+    - name: envoy.access_loggers.file
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: $tmpdir/nighthawk-test-server-admin-access.log
+  profile_path: $tmpdir/nighthawk-test-server.prof
+  address:
+    socket_address: { address: $server_ip, port_value: 0 }
+static_resources:
+  listeners:
+    - name: listener_udp
+      address:
+        socket_address:
+          protocol: UDP
+          address: $server_ip
+          port_value: 0
+      udp_listener_config:
+        quic_options: {}
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                generate_request_id: false
+                codec_type: HTTP3
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: service
+                      domains:
+                        - "*"
+                http_filters:
+                  - name: dynamic-delay
+                  - name: test-server
+                    typed_config:
+                      "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+                      response_body_size: 10
+                      v3_response_headers:
+                        - { header: { key: "x-nh", value: "1" } }
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                      dynamic_stats: false
+          transport_socket:
+            name: envoy.transport_sockets.quic
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicDownstreamTransport
+              downstream_tls_context:
+                common_tls_context:
+                  tls_certificates:
+                    - certificate_chain:
+                          inline_string: |
+                            @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/servercert.pem
+                      private_key:
+                          inline_string: |
+                            @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -923,6 +923,8 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeast
   uris_.push_back(std::make_unique<UriImpl>("http://www.example.org"));
   resolveAllUris();
 
+  // The tested behavior is that even though we set --max-pending-requests 0,
+  // the code will configure a value of 1.
   std::unique_ptr<Client::OptionsImpl> options = Client::TestUtility::createOptionsImpl(
       "nighthawk_client --max-pending-requests 0 http://www.example.org");
 

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -567,7 +567,7 @@ TEST_F(CreateBootstrapConfigurationTest, FailsForUnimplementedH3) {
   resolveAllUris();
 
   std::unique_ptr<Client::OptionsImpl> options = Client::TestUtility::createOptionsImpl(
-      "nighthawk_client --upstream-protocol http3 https://www.example.org");
+      "nighthawk_client --protocol http3 https://www.example.org");
 
   absl::StatusOr<Bootstrap> bootstrap =
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -566,8 +566,8 @@ TEST_F(CreateBootstrapConfigurationTest, FailsForUnimplementedH3) {
   uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
   resolveAllUris();
 
-  std::unique_ptr<Client::OptionsImpl> options =
-      Client::TestUtility::createOptionsImpl("nighthawk_client --h3 https://www.example.org");
+  std::unique_ptr<Client::OptionsImpl> options = Client::TestUtility::createOptionsImpl(
+      "nighthawk_client --upstream-protocol http3 https://www.example.org");
 
   absl::StatusOr<Bootstrap> bootstrap =
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -4,12 +4,13 @@
 #include "nighthawk/common/uri.h"
 
 #include "external/envoy/source/common/common/statusor.h"
+#include "external/envoy/source/common/protobuf/message_validator_impl.h"
 #include "external/envoy/source/common/protobuf/protobuf.h"
 #include "external/envoy/test/mocks/event/mocks.h"
 #include "external/envoy/test/mocks/network/mocks.h"
 #include "external/envoy/test/test_common/status_utility.h"
 #include "external/envoy/test/test_common/utility.h"
-#include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.validate.h"
 #include "external/envoy_api/envoy/config/core/v3/base.pb.h"
 #include "external/envoy_api/envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
 
@@ -148,6 +149,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1) {
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithMultipleUris) {
@@ -221,6 +225,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithMultipleUris) 
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithTls) {
@@ -294,6 +301,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithTls) {
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers) {
@@ -396,6 +406,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
       *options, uris_, request_source_uri_, /* number_of_workers = */ 2);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
@@ -463,6 +476,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
@@ -541,6 +557,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, FailsForUnimplementedH3) {
@@ -640,6 +659,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCus
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMultipleWorkers) {
@@ -791,6 +813,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
       *options, uris_, request_source_uri_, /* number_of_workers = */ 2);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomOptions) {
@@ -889,6 +914,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomOptions) {
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeastOne) {
@@ -951,6 +979,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeast
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomTransportSocket) {
@@ -1035,6 +1066,9 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomTransportSock
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, DeterminesSniFromRequestHeader) {
@@ -1110,6 +1144,9 @@ TEST_F(CreateBootstrapConfigurationTest, DeterminesSniFromRequestHeader) {
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
   ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
   EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 } // namespace

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -45,7 +45,7 @@ absl::StatusOr<Bootstrap> parseBootstrapFromText(const std::string& bootstrap_te
 
 class CreateBootstrapConfigurationTest : public testing::Test {
 protected:
-  CreateBootstrapConfigurationTest() {}
+  CreateBootstrapConfigurationTest() = default;
 
   // Resolves all the uris_, so they can be passed to createBootstrapConfiguration().
   void resolveAllUris() {
@@ -53,6 +53,9 @@ protected:
 
     EXPECT_CALL(*mock_resolver_, resolve(_, _, _))
         .WillRepeatedly(Invoke([](const std::string&, Envoy::Network::DnsLookupFamily,
+                                  // Even though clang-tidy is right, we cannot
+                                  // change the function declaration here.
+                                  // NOLINTNEXTLINE(performance-unnecessary-value-param)
                                   Envoy::Network::DnsResolver::ResolveCb callback) {
           callback(Envoy::Network::DnsResolver::ResolutionStatus::Success,
                    Envoy::TestUtility::makeDnsResponse({"127.0.0.1"}));

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -1,0 +1,962 @@
+#include <string>
+#include <vector>
+
+#include "nighthawk/common/uri.h"
+
+#include "external/envoy/source/common/common/statusor.h"
+#include "external/envoy/source/common/protobuf/protobuf.h"
+#include "external/envoy/test/mocks/event/mocks.h"
+#include "external/envoy/test/mocks/network/mocks.h"
+#include "external/envoy/test/test_common/status_utility.h"
+#include "external/envoy/test/test_common/utility.h"
+#include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "external/envoy_api/envoy/config/core/v3/base.pb.h"
+#include "external/envoy_api/envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
+
+#include "source/client/options_impl.h"
+#include "source/client/process_bootstrap.h"
+#include "source/common/uri_impl.h"
+
+#include "test/client/utility.h"
+#include "test/test_common/proto_matchers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Nighthawk {
+namespace {
+
+using ::envoy::config::bootstrap::v3::Bootstrap;
+using ::Envoy::StatusHelpers::StatusIs;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+// Parses text into Bootstrap.
+absl::StatusOr<Bootstrap> parseBootstrapFromText(const std::string& bootstrap_text) {
+  Bootstrap bootstrap;
+  if (!Envoy::Protobuf::TextFormat::ParseFromString(bootstrap_text, &bootstrap)) {
+    return absl::InvalidArgumentError(
+        fmt::format("cannot parse bootstrap text:\n{}", bootstrap_text));
+  }
+  return bootstrap;
+}
+
+class CreateBootstrapConfigurationTest : public testing::Test {
+protected:
+  CreateBootstrapConfigurationTest() {}
+
+  // Resolves all the uris_, so they can be passed to createBootstrapConfiguration().
+  void resolveAllUris() {
+    ON_CALL(mock_dispatcher_, createDnsResolver(_, _)).WillByDefault(Return(mock_resolver_));
+
+    EXPECT_CALL(*mock_resolver_, resolve(_, _, _))
+        .WillRepeatedly(Invoke([](const std::string&, Envoy::Network::DnsLookupFamily,
+                                  Envoy::Network::DnsResolver::ResolveCb callback) {
+          callback(Envoy::Network::DnsResolver::ResolutionStatus::Success,
+                   Envoy::TestUtility::makeDnsResponse({"127.0.0.1"}));
+          return nullptr;
+        }));
+
+    for (const UriPtr& uri : uris_) {
+      uri->resolve(mock_dispatcher_, Envoy::Network::DnsLookupFamily::Auto);
+    }
+
+    if (request_source_uri_ != nullptr) {
+      request_source_uri_->resolve(mock_dispatcher_, Envoy::Network::DnsLookupFamily::Auto);
+    }
+  }
+
+  std::shared_ptr<Envoy::Network::MockDnsResolver> mock_resolver_{
+      std::make_shared<Envoy::Network::MockDnsResolver>()};
+  NiceMock<Envoy::Event::MockDispatcher> mock_dispatcher_;
+  std::vector<UriPtr> uris_;
+  UriPtr request_source_uri_;
+  int number_of_workers_{1};
+};
+
+TEST_F(CreateBootstrapConfigurationTest, FailsWithoutUris) {
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client https://www.example.org");
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1) {
+  uris_.push_back(std::make_unique<UriImpl>("http://www.example.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client http://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithMultipleUris) {
+  uris_.push_back(std::make_unique<UriImpl>("http://www.example.org"));
+  uris_.push_back(std::make_unique<UriImpl>("http://www.example2.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client http://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 80
+                  }
+                }
+              }
+            }
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithTls) {
+  uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client https://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        transport_socket {
+          name: "envoy.transport_sockets.tls"
+          typed_config {
+            [type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext] {
+              common_tls_context {
+                alpn_protocols: "http/1.1"
+              }
+              sni: "www.example.org"
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 443
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers) {
+  uris_.push_back(std::make_unique<UriImpl>("http://www.example.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client http://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      clusters {
+        name: "1"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "1"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap = createBootstrapConfiguration(
+      *options, uris_, request_source_uri_, /* number_of_workers = */ 2);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
+  uris_.push_back(std::make_unique<UriImpl>("http://www.example.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client --h2 http://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        http2_protocol_options {
+          max_concurrent_streams {
+            value: 2147483647
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
+  uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client --h2 https://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        http2_protocol_options {
+          max_concurrent_streams {
+            value: 2147483647
+          }
+        }
+        transport_socket {
+          name: "envoy.transport_sockets.tls"
+          typed_config {
+            [type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext] {
+              common_tls_context {
+                alpn_protocols: "h2"
+              }
+              sni: "www.example.org"
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 443
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, FailsForUnimplementedH3) {
+  uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client --h3 https://www.example.org");
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kUnimplemented));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCustomTimeout) {
+  uris_.push_back(std::make_unique<UriImpl>("http://www.example.org"));
+  request_source_uri_ = std::make_unique<UriImpl>("127.0.0.1:6000");
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options = Client::TestUtility::createOptionsImpl(
+      "nighthawk_client --timeout 10 http://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 10
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      clusters {
+        name: "0.requestsource"
+        type: STATIC
+        connect_timeout {
+          seconds: 10
+        }
+        http2_protocol_options {
+        }
+        load_assignment {
+          cluster_name: "0.requestsource"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 6000
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomOptions) {
+  uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
+  resolveAllUris();
+
+  const std::string stats_sink_json =
+      "{name:\"envoy.stat_sinks.statsd\",typed_config:{\"@type\":\"type."
+      "googleapis.com/"
+      "envoy.config.metrics.v3.StatsdSink\",tcp_cluster_name:\"statsd\"}}";
+
+  const std::string tls_context_json = "{common_tls_context:{tls_params:{"
+                                       "cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}";
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl(fmt::format("nighthawk_client "
+                                                         "--max-pending-requests 10 "
+                                                         "--stats-sinks {} "
+                                                         "--stats-flush-interval 20 "
+                                                         "--tls-context {} "
+                                                         "https://www.example.org",
+                                                         stats_sink_json, tls_context_json));
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 10
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        transport_socket {
+          name: "envoy.transport_sockets.tls"
+          typed_config {
+            [type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext] {
+              common_tls_context {
+                tls_params {
+                  cipher_suites: "-ALL:ECDHE-RSA-AES256-GCM-SHA384"
+                }
+                alpn_protocols: "http/1.1"
+              }
+              sni: "www.example.org"
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 443
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_sinks {
+      name: "envoy.stat_sinks.statsd"
+      typed_config {
+        [type.googleapis.com/envoy.config.metrics.v3.StatsdSink] {
+          tcp_cluster_name: "statsd"
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 20
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeastOne) {
+  uris_.push_back(std::make_unique<UriImpl>("http://www.example.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options = Client::TestUtility::createOptionsImpl(
+      "nighthawk_client --max-pending-requests 0 http://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomTransportSocket) {
+  uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
+  resolveAllUris();
+
+  const std::string transport_socket_json =
+      "{name:\"envoy.transport_sockets.tls\","
+      "typed_config:{\"@type\":\"type.googleapis.com/"
+      "envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\","
+      "common_tls_context:{tls_params:{"
+      "cipher_suites:[\"-ALL:ECDHE-RSA-AES256-GCM-SHA384\"]}}}}";
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl(fmt::format("nighthawk_client "
+                                                         "--transport-socket {} "
+                                                         "https://www.example.org",
+                                                         transport_socket_json));
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        transport_socket {
+          name: "envoy.transport_sockets.tls"
+          typed_config {
+            [type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext] {
+              common_tls_context {
+                tls_params {
+                  cipher_suites: "-ALL:ECDHE-RSA-AES256-GCM-SHA384"
+                }
+              }
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 443
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+TEST_F(CreateBootstrapConfigurationTest, DeterminesSniFromRequestHeader) {
+  uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
+  resolveAllUris();
+
+  std::unique_ptr<Client::OptionsImpl> options =
+      Client::TestUtility::createOptionsImpl("nighthawk_client "
+                                             "--request-header Host:test.example.com "
+                                             "https://www.example.org");
+
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        max_requests_per_connection {
+          value: 4294937295
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        transport_socket {
+          name: "envoy.transport_sockets.tls"
+          typed_config {
+            [type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext] {
+              common_tls_context {
+                alpn_protocols: "http/1.1"
+              }
+              sni: "test.example.com"
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 443
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
+  absl::StatusOr<Bootstrap> bootstrap =
+      createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+}
+
+} // namespace
+} // namespace Nighthawk

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -104,9 +104,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1) {
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -132,6 +129,22 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1) {
                     address: "127.0.0.1"
                     port_value: 80
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }
@@ -170,9 +183,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithMultipleUris) 
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -213,6 +223,22 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithMultipleUris) 
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
     }
     stats_flush_interval {
@@ -244,9 +270,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithTls) {
         type: STATIC
         connect_timeout {
           seconds: 30
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -289,6 +312,22 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithTls) {
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
     }
     stats_flush_interval {
@@ -321,9 +360,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -354,15 +390,28 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "1"
         type: STATIC
         connect_timeout {
           seconds: 30
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -389,6 +438,22 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
                     address: "127.0.0.1"
                     port_value: 80
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }
@@ -426,9 +491,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -444,11 +506,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
             }
           }
         }
-        http2_protocol_options {
-          max_concurrent_streams {
-            value: 2147483647
-          }
-        }
         load_assignment {
           cluster_name: "0"
           endpoints {
@@ -458,6 +515,25 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
                   socket_address {
                     address: "127.0.0.1"
                     port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http2_protocol_options {
+                  max_concurrent_streams {
+                    value: 2147483647
                   }
                 }
               }
@@ -496,9 +572,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -512,11 +585,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
             }
             max_retries {
             }
-          }
-        }
-        http2_protocol_options {
-          max_concurrent_streams {
-            value: 2147483647
           }
         }
         transport_socket {
@@ -545,6 +613,25 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http2_protocol_options {
+                  max_concurrent_streams {
+                    value: 2147483647
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
     stats_flush_interval {
@@ -562,16 +649,100 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
   Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
-TEST_F(CreateBootstrapConfigurationTest, FailsForUnimplementedH3) {
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH3) {
   uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
   resolveAllUris();
 
   std::unique_ptr<Client::OptionsImpl> options = Client::TestUtility::createOptionsImpl(
       "nighthawk_client --protocol http3 https://www.example.org");
 
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        transport_socket {
+          name: "envoy.transport_sockets.quic"
+          typed_config {
+            [type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicUpstreamTransport] {
+              upstream_tls_context {
+                common_tls_context {
+                  alpn_protocols: "h3"
+                }
+                sni: "www.example.org"
+              }
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 443
+                  }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http3_protocol_options {
+                  quic_protocol_options {
+                    max_concurrent_streams {
+                      value: 2147483647
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
   absl::StatusOr<Bootstrap> bootstrap =
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
-  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kUnimplemented));
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCustomTimeout) {
@@ -589,9 +760,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCus
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -623,14 +791,28 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCus
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "0.requestsource"
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        http2_protocol_options {
         }
         load_assignment {
           cluster_name: "0.requestsource"
@@ -642,6 +824,17 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCus
                     address: "127.0.0.1"
                     port_value: 6000
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              explicit_http_config {
+                http2_protocol_options {
                 }
               }
             }
@@ -680,9 +873,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
         connect_timeout {
           seconds: 10
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -713,14 +903,28 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "0.requestsource"
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        http2_protocol_options {
         }
         load_assignment {
           cluster_name: "0.requestsource"
@@ -737,15 +941,23 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              explicit_http_config {
+                http2_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "1"
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -777,14 +989,28 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "1.requestsource"
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        http2_protocol_options {
         }
         load_assignment {
           cluster_name: "1.requestsource"
@@ -796,6 +1022,17 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
                     address: "127.0.0.1"
                     port_value: 6000
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              explicit_http_config {
+                http2_protocol_options {
                 }
               }
             }
@@ -847,9 +1084,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomOptions) {
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -889,6 +1123,22 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomOptions) {
                     address: "127.0.0.1"
                     port_value: 443
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }
@@ -936,9 +1186,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeast
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -964,6 +1211,22 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeast
                     address: "127.0.0.1"
                     port_value: 80
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }
@@ -1011,9 +1274,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomTransportSock
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -1056,6 +1316,22 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomTransportSock
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
     }
     stats_flush_interval {
@@ -1089,9 +1365,6 @@ TEST_F(CreateBootstrapConfigurationTest, DeterminesSniFromRequestHeader) {
         type: STATIC
         connect_timeout {
           seconds: 30
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -1129,6 +1402,22 @@ TEST_F(CreateBootstrapConfigurationTest, DeterminesSniFromRequestHeader) {
                     address: "127.0.0.1"
                     port_value: 443
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -18,3 +18,13 @@ envoy_cc_test_library(
         "@envoy//test/test_common:environment_lib",
     ],
 )
+
+envoy_cc_test_library(
+    name = "proto_matchers",
+    srcs = ["proto_matchers.cc"],
+    hdrs = ["proto_matchers.h"],
+    repository = "@envoy",
+    deps = [
+        "@envoy//test/test_common:utility_lib",
+    ],
+)

--- a/test/test_common/proto_matchers.cc
+++ b/test/test_common/proto_matchers.cc
@@ -1,0 +1,31 @@
+#include "test/test_common/proto_matchers.h"
+
+#include <string>
+
+#include "external/envoy/source/common/protobuf/protobuf.h"
+
+#include "gtest/gtest.h"
+
+namespace Nighthawk {
+
+using ::Envoy::Protobuf::FieldDescriptor;
+using ::Envoy::Protobuf::Message;
+using ::Envoy::Protobuf::util::MessageDifferencer;
+
+IgnoreUnknownFieldsGloballyByNumber::IgnoreUnknownFieldsGloballyByNumber(int ignored_field_number)
+    : ignored_field_number_(ignored_field_number) {}
+
+bool IgnoreUnknownFieldsGloballyByNumber::IsIgnored(
+    const Message&, const Message&, const FieldDescriptor*,
+    const std::vector<MessageDifferencer::SpecificField>&) {
+  return false;
+}
+
+bool IgnoreUnknownFieldsGloballyByNumber::IsUnknownFieldIgnored(
+    const Envoy::Protobuf::Message&, const Envoy::Protobuf::Message&,
+    const Envoy::Protobuf::util::MessageDifferencer::SpecificField& field,
+    const std::vector<MessageDifferencer::SpecificField>&) {
+  return field.unknown_field_number == ignored_field_number_;
+}
+
+} // namespace Nighthawk

--- a/test/test_common/proto_matchers.h
+++ b/test/test_common/proto_matchers.h
@@ -45,7 +45,7 @@ private:
 //   proto2::Message expected_proto;
 //
 //   EXPECT_THAT(actual_proto, EqualsProto(expected_proto));
-MATCHER_P(EqualsProto, expected_proto, "") {
+MATCHER_P(EqualsProto, expected_proto, "is equal to the expected_proto") {
   std::string diff;
   Envoy::Protobuf::util::MessageDifferencer differ;
   differ.ReportDifferencesToString(&diff);

--- a/test/test_common/proto_matchers.h
+++ b/test/test_common/proto_matchers.h
@@ -1,0 +1,72 @@
+#include <string>
+
+#include "external/envoy/source/common/protobuf/protobuf.h"
+#include "external/envoy/source/common/protobuf/well_known.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Nighthawk {
+
+// A custom IgnoreCriteria that can be added to a MessageDifferencer to ignore
+// unknown fields by their field number, regardless of where they appear in a
+// message.
+class IgnoreUnknownFieldsGloballyByNumber
+    : public Envoy::Protobuf::util::MessageDifferencer::IgnoreCriteria {
+public:
+  // Constructs an ignore criteria instance that will ignore differences in all
+  // unknown proto fields whose field number matches the one specified.
+  explicit IgnoreUnknownFieldsGloballyByNumber(int ignored_field_number);
+
+  // Does not ignore any fields on this implementation.
+  // Implemented only to satisfy the interface.
+  bool IsIgnored(const Envoy::Protobuf::Message& message1, const Envoy::Protobuf::Message& message2,
+                 const Envoy::Protobuf::FieldDescriptor* field,
+                 const std::vector<Envoy::Protobuf::util::MessageDifferencer::SpecificField>&
+                     parent_fields) override;
+
+  // Ignores an unknown field if its field number equals to the one provided to the
+  // constructor.
+  bool IsUnknownFieldIgnored(
+      const Envoy::Protobuf::Message& message1, const Envoy::Protobuf::Message& message2,
+      const Envoy::Protobuf::util::MessageDifferencer::SpecificField& field,
+      const std::vector<Envoy::Protobuf::util::MessageDifferencer::SpecificField>& parent_fields)
+      override;
+
+private:
+  const int ignored_field_number_;
+};
+
+// Compares two proto messages for equality.
+// Prints diff on failures.
+//
+// Example use:
+//   proto2::Message actual_proto;
+//   proto2::Message expected_proto;
+//
+//   EXPECT_THAT(actual_proto, EqualsProto(expected_proto));
+MATCHER_P(EqualsProto, expected_proto, "") {
+  std::string diff;
+  Envoy::Protobuf::util::MessageDifferencer differ;
+  differ.ReportDifferencesToString(&diff);
+
+  // Envoy proto messages have a well known field with this number that needs to
+  // be ignored in proto comparisons.
+  differ.AddIgnoreCriteria(
+      new IgnoreUnknownFieldsGloballyByNumber(Envoy::ProtobufWellKnown::OriginalTypeFieldNumber));
+
+  bool equal = differ.Compare(arg, expected_proto);
+  if (!equal) {
+    *result_listener << "\n"
+                     << "=======================Expected proto:===========================\n"
+                     << expected_proto.DebugString()
+                     << "------------------is not equal to actual proto:------------------\n"
+                     << arg.DebugString()
+                     << "------------------------the diff is:-----------------------------\n"
+                     << diff
+                     << "=================================================================\n";
+  }
+  return equal;
+}
+
+} // namespace Nighthawk


### PR DESCRIPTION
Having the code in its own library not only allows to test it, but it also provides documentation of how various Nighthawk options translate to the public Envoy API.

No functional changes in this PR except for changing the return value to absl::StatusOr (i.e. the code no longer throws).

Done here:

- adding a test utility that compares proto messages and prints diffs.
- moving the bootstrap generation code into its own library.
- adding unit tests for the major behaviors of the bootstrap generation code.

Works on #23 