### PR TITLE
[QUIC 040]: Migrating off deprecated fields in the bootstrap.

### DIFF
--- a/docs/root/overview.md
+++ b/docs/root/overview.md
@@ -104,16 +104,12 @@ timing offsets to an underlying **RateLimiter**) and **LinearRampingRateLimiter*
 ### BenchmarkClient
 
 As of today, there’s a single implementation called **BenchmarkClientImpl**,
-which wraps Envoy’s **Upstream** concept and (slightly) customized H1/H2
+which wraps Envoy’s **Upstream** concept and (slightly) customized H1/H2/H3
 **Pool** concepts. For executing requests, the pool will be requested to create
 a **StreamEncoder**, and Nighthawk will pass its own **StreamDecoderImpl** into
 that as an argument. The integration surface between **BenchmarkClient** is
 defined via `BenchmarkClient::tryStartRequest()` and a callback specification
 which will be fired upon completion of a successfully started request.
-
-For H3, it is anticipated that it will fit into this model, but if all else
-fails, it will be entirely possible to wire in a new type of
-**BenchmarkClient**.
 
 ### RequestSource
 

--- a/extensions_build_config.bzl
+++ b/extensions_build_config.bzl
@@ -6,6 +6,7 @@ EXTENSIONS = {
     "envoy.filters.network.http_connection_manager": "//source/extensions/filters/network/http_connection_manager:config",
     "envoy.tracers.zipkin": "//source/extensions/tracers/zipkin:config",
     "envoy.transport_sockets.raw_buffer": "//source/extensions/transport_sockets/raw_buffer:config",
+    "envoy.access_loggers.file": "//source/extensions/access_loggers/file:config",
 }
 
 DISABLED_BY_DEFAULT_EXTENSIONS = {

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -8,6 +8,7 @@
 
 #include "external/envoy/source/common/common/statusor.h"
 #include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "external/envoy_api/envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.h"
 #include "external/envoy_api/envoy/extensions/upstreams/http/v3/http_protocol_options.pb.h"
 
 #include "source/client/sni_utility.h"
@@ -19,11 +20,13 @@ using ::envoy::config::bootstrap::v3::Bootstrap;
 using ::envoy::config::cluster::v3::CircuitBreakers;
 using ::envoy::config::cluster::v3::Cluster;
 using ::envoy::config::core::v3::Http2ProtocolOptions;
+using ::envoy::config::core::v3::Http3ProtocolOptions;
 using ::envoy::config::core::v3::SocketAddress;
 using ::envoy::config::core::v3::TransportSocket;
 using ::envoy::config::endpoint::v3::ClusterLoadAssignment;
 using ::envoy::config::endpoint::v3::LocalityLbEndpoints;
 using ::envoy::config::metrics::v3::StatsSink;
+using ::envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport;
 using ::envoy::extensions::transport_sockets::tls::v3::CommonTlsContext;
 using ::envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext;
 
@@ -77,7 +80,6 @@ absl::StatusOr<TransportSocket> createTransportSocket(const Client::Options& opt
   }
 
   TransportSocket transport_socket;
-  transport_socket.set_name("envoy.transport_sockets.tls");
 
   UpstreamTlsContext upstream_tls_context = options.tlsContext();
   const std::string sni_host =
@@ -88,16 +90,24 @@ absl::StatusOr<TransportSocket> createTransportSocket(const Client::Options& opt
 
   CommonTlsContext* common_tls_context = upstream_tls_context.mutable_common_tls_context();
   if (options.protocol() == Envoy::Http::Protocol::Http2) {
+    transport_socket.set_name("envoy.transport_sockets.tls");
     common_tls_context->add_alpn_protocols("h2");
+    transport_socket.mutable_typed_config()->PackFrom(upstream_tls_context);
 
   } else if (options.protocol() == Envoy::Http::Protocol::Http3) {
-    return absl::UnimplementedError("HTTP/3 Quic support isn't implemented yet.");
+    transport_socket.set_name("envoy.transport_sockets.quic");
+    common_tls_context->add_alpn_protocols("h3");
+
+    QuicUpstreamTransport quic_upstream_transport;
+    *quic_upstream_transport.mutable_upstream_tls_context() = upstream_tls_context;
+    transport_socket.mutable_typed_config()->PackFrom(quic_upstream_transport);
 
   } else {
+    transport_socket.set_name("envoy.transport_sockets.tls");
     common_tls_context->add_alpn_protocols("http/1.1");
+    transport_socket.mutable_typed_config()->PackFrom(upstream_tls_context);
   }
 
-  transport_socket.mutable_typed_config()->PackFrom(upstream_tls_context);
   return transport_socket;
 }
 
@@ -137,6 +147,13 @@ Cluster createNighthawkClusterForWorker(const Client::Options& options,
     Http2ProtocolOptions* http2_options =
         http_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
     http2_options->mutable_max_concurrent_streams()->set_value(options.maxConcurrentStreams());
+
+  } else if (options.protocol() == Envoy::Http::Protocol::Http3) {
+    Http3ProtocolOptions* http3_options =
+        http_options.mutable_explicit_http_config()->mutable_http3_protocol_options();
+    http3_options->mutable_quic_protocol_options()->mutable_max_concurrent_streams()->set_value(
+        options.maxConcurrentStreams());
+
   } else {
     http_options.mutable_explicit_http_config()->mutable_http_protocol_options();
   }

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -137,6 +137,8 @@ Cluster createNighthawkClusterForWorker(const Client::Options& options,
     Http2ProtocolOptions* http2_options =
         http_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
     http2_options->mutable_max_concurrent_streams()->set_value(options.maxConcurrentStreams());
+  } else {
+    http_options.mutable_explicit_http_config()->mutable_http_protocol_options();
   }
 
   (*cluster.mutable_typed_extension_protocol_options())

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -9,13 +9,15 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+filegroup(
+    name = "test_server_configs",
+    data = glob(["configurations/*"]),
+)
+
 py_library(
     name = "integration_test_base",
     data = [
-        "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_https_origin.yaml",
-        "configurations/nighthawk_track_timings.yaml",
-        "configurations/sni_origin.yaml",
+        ":test_server_configs",
         "//:nighthawk_client",
         "//:nighthawk_output_transform",
         "//:nighthawk_service",
@@ -38,9 +40,7 @@ py_library(
         "utility.py",
     ],
     data = [
-        "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_https_origin.yaml",
-        "configurations/sni_origin.yaml",
+        ":test_server_configs",
         "@envoy//test/config/integration/certs",
     ],
     deps = [

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -1,0 +1,58 @@
+admin:
+  access_log:
+    - name: envoy.access_loggers.file
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: $tmpdir/nighthawk-test-server-admin-access.log
+  profile_path: $tmpdir/nighthawk-test-server.prof
+  address:
+    socket_address: { address: $server_ip, port_value: 0 }
+static_resources:
+  listeners:
+    - name: listener_udp
+      address:
+        socket_address:
+          protocol: UDP
+          address: $server_ip
+          port_value: 0
+      udp_listener_config:
+        quic_options: {}
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                generate_request_id: false
+                codec_type: HTTP3
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: service
+                      domains:
+                        - "*"
+                http_filters:
+                  - name: dynamic-delay
+                  - name: test-server
+                    typed_config:
+                      "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+                      response_body_size: 10
+                      v3_response_headers:
+                        - { header: { key: "x-nh", value: "1" } }
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                      dynamic_stats: false
+          transport_socket:
+            name: envoy.transport_sockets.quic
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicDownstreamTransport
+              downstream_tls_context:
+                common_tls_context:
+                  tls_certificates:
+                    - certificate_chain:
+                          inline_string: |
+                            @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/servercert.pem
+                      private_key:
+                          inline_string: |
+                            @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -103,9 +103,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1) {
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -131,6 +128,18 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1) {
                     address: "127.0.0.1"
                     port_value: 80
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
                 }
               }
             }
@@ -166,9 +175,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithMultipleUris) 
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -209,6 +215,18 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithMultipleUris) 
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+            }
+          }
+        }
       }
     }
     stats_flush_interval {
@@ -237,9 +255,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithTls) {
         type: STATIC
         connect_timeout {
           seconds: 30
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -282,6 +297,18 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithTls) {
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+            }
+          }
+        }
       }
     }
     stats_flush_interval {
@@ -310,9 +337,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
         type: STATIC
         connect_timeout {
           seconds: 30
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -344,15 +368,24 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "1"
         type: STATIC
         connect_timeout {
           seconds: 30
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -379,6 +412,18 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
                     address: "127.0.0.1"
                     port_value: 80
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
                 }
               }
             }
@@ -413,9 +458,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -431,11 +473,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
             }
           }
         }
-        http2_protocol_options {
-          max_concurrent_streams {
-            value: 2147483647
-          }
-        }
         load_assignment {
           cluster_name: "0"
           endpoints {
@@ -445,6 +482,25 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2) {
                   socket_address {
                     address: "127.0.0.1"
                     port_value: 80
+                  }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http2_protocol_options {
+                  max_concurrent_streams {
+                    value: 2147483647
                   }
                 }
               }
@@ -480,9 +536,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -496,11 +549,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
             }
             max_retries {
             }
-          }
-        }
-        http2_protocol_options {
-          max_concurrent_streams {
-            value: 2147483647
           }
         }
         transport_socket {
@@ -523,6 +571,25 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
                   socket_address {
                     address: "127.0.0.1"
                     port_value: 443
+                  }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http2_protocol_options {
+                  max_concurrent_streams {
+                    value: 2147483647
                   }
                 }
               }
@@ -571,9 +638,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCus
         connect_timeout {
           seconds: 10
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -604,14 +668,24 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCus
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "0.requestsource"
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        http2_protocol_options {
         }
         load_assignment {
           cluster_name: "0.requestsource"
@@ -623,6 +697,17 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCus
                     address: "127.0.0.1"
                     port_value: 6000
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              explicit_http_config {
+                http2_protocol_options {
                 }
               }
             }
@@ -658,9 +743,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
         connect_timeout {
           seconds: 10
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -691,14 +773,24 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "0.requestsource"
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        http2_protocol_options {
         }
         load_assignment {
           cluster_name: "0.requestsource"
@@ -715,15 +807,23 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              explicit_http_config {
+                http2_protocol_options {
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "1"
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -755,14 +855,24 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+            }
+          }
+        }
       }
       clusters {
         name: "1.requestsource"
         type: STATIC
         connect_timeout {
           seconds: 10
-        }
-        http2_protocol_options {
         }
         load_assignment {
           cluster_name: "1.requestsource"
@@ -774,6 +884,17 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
                     address: "127.0.0.1"
                     port_value: 6000
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              explicit_http_config {
+                http2_protocol_options {
                 }
               }
             }
@@ -822,9 +943,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomOptions) {
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -869,6 +987,18 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomOptions) {
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+            }
+          }
+        }
       }
     }
     stats_sinks {
@@ -906,9 +1036,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeast
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -934,6 +1061,18 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeast
                     address: "127.0.0.1"
                     port_value: 80
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
                 }
               }
             }
@@ -978,9 +1117,6 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomTransportSock
         connect_timeout {
           seconds: 30
         }
-        max_requests_per_connection {
-          value: 4294937295
-        }
         circuit_breakers {
           thresholds {
             max_connections {
@@ -1023,6 +1159,18 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomTransportSock
             }
           }
         }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+            }
+          }
+        }
       }
     }
     stats_flush_interval {
@@ -1053,9 +1201,6 @@ TEST_F(CreateBootstrapConfigurationTest, DeterminesSniFromRequestHeader) {
         type: STATIC
         connect_timeout {
           seconds: 30
-        }
-        max_requests_per_connection {
-          value: 4294937295
         }
         circuit_breakers {
           thresholds {
@@ -1093,6 +1238,18 @@ TEST_F(CreateBootstrapConfigurationTest, DeterminesSniFromRequestHeader) {
                     address: "127.0.0.1"
                     port_value: 443
                   }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
                 }
               }
             }

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -143,6 +143,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1) {
                   value: 4294937295
                 }
               }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
             }
           }
         }
@@ -226,6 +230,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithMultipleUris) 
               common_http_protocol_options {
                 max_requests_per_connection {
                   value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }
@@ -313,6 +321,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1WithTls) {
                   value: 4294937295
                 }
               }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
             }
           }
         }
@@ -387,6 +399,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
                   value: 4294937295
                 }
               }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
             }
           }
         }
@@ -434,6 +450,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH1AndMultipleWorkers
               common_http_protocol_options {
                 max_requests_per_connection {
                   value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }
@@ -696,6 +716,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCus
                   value: 4294937295
                 }
               }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
             }
           }
         }
@@ -804,6 +828,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
                   value: 4294937295
                 }
               }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
             }
           }
         }
@@ -884,6 +912,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndMul
               common_http_protocol_options {
                 max_requests_per_connection {
                   value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }
@@ -1021,6 +1053,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomOptions) {
                   value: 4294937295
                 }
               }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
             }
           }
         }
@@ -1101,6 +1137,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapSetsMaxRequestToAtLeast
               common_http_protocol_options {
                 max_requests_per_connection {
                   value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }
@@ -1199,6 +1239,10 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithCustomTransportSock
                   value: 4294937295
                 }
               }
+              explicit_http_config {
+                http_protocol_options {
+                }
+              }
             }
           }
         }
@@ -1284,6 +1328,10 @@ TEST_F(CreateBootstrapConfigurationTest, DeterminesSniFromRequestHeader) {
               common_http_protocol_options {
                 max_requests_per_connection {
                   value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http_protocol_options {
                 }
               }
             }

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -649,16 +649,100 @@ TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH2WithTls) {
   Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
-TEST_F(CreateBootstrapConfigurationTest, FailsForUnimplementedH3) {
+TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapForH3) {
   uris_.push_back(std::make_unique<UriImpl>("https://www.example.org"));
   resolveAllUris();
 
   std::unique_ptr<Client::OptionsImpl> options = Client::TestUtility::createOptionsImpl(
       "nighthawk_client --protocol http3 https://www.example.org");
 
+  absl::StatusOr<Bootstrap> expected_bootstrap = parseBootstrapFromText(R"pb(
+    static_resources {
+      clusters {
+        name: "0"
+        type: STATIC
+        connect_timeout {
+          seconds: 30
+        }
+        circuit_breakers {
+          thresholds {
+            max_connections {
+              value: 100
+            }
+            max_pending_requests {
+              value: 1
+            }
+            max_requests {
+              value: 100
+            }
+            max_retries {
+            }
+          }
+        }
+        transport_socket {
+          name: "envoy.transport_sockets.quic"
+          typed_config {
+            [type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicUpstreamTransport] {
+              upstream_tls_context {
+                common_tls_context {
+                  alpn_protocols: "h3"
+                }
+                sni: "www.example.org"
+              }
+            }
+          }
+        }
+        load_assignment {
+          cluster_name: "0"
+          endpoints {
+            lb_endpoints {
+              endpoint {
+                address {
+                  socket_address {
+                    address: "127.0.0.1"
+                    port_value: 443
+                  }
+                }
+              }
+            }
+          }
+        }
+        typed_extension_protocol_options {
+          key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+          value {
+            [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions] {
+              common_http_protocol_options {
+                max_requests_per_connection {
+                  value: 4294937295
+                }
+              }
+              explicit_http_config {
+                http3_protocol_options {
+                  quic_protocol_options {
+                    max_concurrent_streams {
+                      value: 2147483647
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stats_flush_interval {
+      seconds: 5
+    }
+  )pb");
+  ASSERT_THAT(expected_bootstrap, StatusIs(absl::StatusCode::kOk));
+
   absl::StatusOr<Bootstrap> bootstrap =
       createBootstrapConfiguration(*options, uris_, request_source_uri_, number_of_workers_);
-  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kUnimplemented));
+  ASSERT_THAT(bootstrap, StatusIs(absl::StatusCode::kOk));
+  EXPECT_THAT(*bootstrap, EqualsProto(*expected_bootstrap));
+
+  // Ensure the generated bootstrap is valid.
+  Envoy::MessageUtil::validate(*bootstrap, Envoy::ProtobufMessage::getStrictValidationVisitor());
 }
 
 TEST_F(CreateBootstrapConfigurationTest, CreatesBootstrapWithRequestSourceAndCustomTimeout) {


### PR DESCRIPTION
Envoy marked two fields that we were using as deprecated:

1. The `http2_protocol_options` field is [deprecated](https://github.com/envoyproxy/envoy/blob/1260c5c2d1c5b85639a8e566a6b153198ddbf109/api/envoy/config/cluster/v3/cluster.proto#L801-L808) in favor of the common message `HttpProtocolOptions`. Migrating us to the new field simplifies the implementation of HTTP/3 Quic which also uses this message.

2. The `max_requests_per_connection` field is [deprecated](https://github.com/envoyproxy/envoy/blob/1260c5c2d1c5b85639a8e566a6b153198ddbf109/api/envoy/config/cluster/v3/cluster.proto#L751-L753) in favor of the `HttpProtocolOptions.max_requests_per_connection` field.

This PR contains no changes to functionality.

Works on #23