### PR TITLE
[QUIC 050]: Adding bootstrap generation support for HTTP/3 Quic.

### DIFF
--- a/docs/root/overview.md
+++ b/docs/root/overview.md
@@ -104,16 +104,12 @@ timing offsets to an underlying **RateLimiter**) and **LinearRampingRateLimiter*
 ### BenchmarkClient
 
 As of today, there’s a single implementation called **BenchmarkClientImpl**,
-which wraps Envoy’s **Upstream** concept and (slightly) customized H1/H2
+which wraps Envoy’s **Upstream** concept and (slightly) customized H1/H2/H3
 **Pool** concepts. For executing requests, the pool will be requested to create
 a **StreamEncoder**, and Nighthawk will pass its own **StreamDecoderImpl** into
 that as an argument. The integration surface between **BenchmarkClient** is
 defined via `BenchmarkClient::tryStartRequest()` and a callback specification
 which will be fired upon completion of a successfully started request.
-
-For H3, it is anticipated that it will fit into this model, but if all else
-fails, it will be entirely possible to wire in a new type of
-**BenchmarkClient**.
 
 ### RequestSource
 

--- a/extensions_build_config.bzl
+++ b/extensions_build_config.bzl
@@ -6,6 +6,7 @@ EXTENSIONS = {
     "envoy.filters.network.http_connection_manager": "//source/extensions/filters/network/http_connection_manager:config",
     "envoy.tracers.zipkin": "//source/extensions/tracers/zipkin:config",
     "envoy.transport_sockets.raw_buffer": "//source/extensions/transport_sockets/raw_buffer:config",
+    "envoy.access_loggers.file": "//source/extensions/access_loggers/file:config",
 }
 
 DISABLED_BY_DEFAULT_EXTENSIONS = {

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -8,6 +8,7 @@
 
 #include "external/envoy/source/common/common/statusor.h"
 #include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "external/envoy_api/envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.h"
 #include "external/envoy_api/envoy/extensions/upstreams/http/v3/http_protocol_options.pb.h"
 
 #include "source/client/sni_utility.h"
@@ -19,11 +20,13 @@ using ::envoy::config::bootstrap::v3::Bootstrap;
 using ::envoy::config::cluster::v3::CircuitBreakers;
 using ::envoy::config::cluster::v3::Cluster;
 using ::envoy::config::core::v3::Http2ProtocolOptions;
+using ::envoy::config::core::v3::Http3ProtocolOptions;
 using ::envoy::config::core::v3::SocketAddress;
 using ::envoy::config::core::v3::TransportSocket;
 using ::envoy::config::endpoint::v3::ClusterLoadAssignment;
 using ::envoy::config::endpoint::v3::LocalityLbEndpoints;
 using ::envoy::config::metrics::v3::StatsSink;
+using ::envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport;
 using ::envoy::extensions::transport_sockets::tls::v3::CommonTlsContext;
 using ::envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext;
 
@@ -77,7 +80,6 @@ absl::StatusOr<TransportSocket> createTransportSocket(const Client::Options& opt
   }
 
   TransportSocket transport_socket;
-  transport_socket.set_name("envoy.transport_sockets.tls");
 
   UpstreamTlsContext upstream_tls_context = options.tlsContext();
   const std::string sni_host = Client::SniUtility::computeSniHost(uris, options.requestHeaders(),
@@ -88,16 +90,24 @@ absl::StatusOr<TransportSocket> createTransportSocket(const Client::Options& opt
 
   CommonTlsContext* common_tls_context = upstream_tls_context.mutable_common_tls_context();
   if (options.upstreamProtocol() == Envoy::Http::Protocol::Http2) {
+    transport_socket.set_name("envoy.transport_sockets.tls");
     common_tls_context->add_alpn_protocols("h2");
+    transport_socket.mutable_typed_config()->PackFrom(upstream_tls_context);
 
   } else if (options.upstreamProtocol() == Envoy::Http::Protocol::Http3) {
-    return absl::UnimplementedError("HTTP/3 Quic support isn't implemented yet.");
+    transport_socket.set_name("envoy.transport_sockets.quic");
+    common_tls_context->add_alpn_protocols("h3");
+
+    QuicUpstreamTransport quic_upstream_transport;
+    *quic_upstream_transport.mutable_upstream_tls_context() = upstream_tls_context;
+    transport_socket.mutable_typed_config()->PackFrom(quic_upstream_transport);
 
   } else {
+    transport_socket.set_name("envoy.transport_sockets.tls");
     common_tls_context->add_alpn_protocols("http/1.1");
+    transport_socket.mutable_typed_config()->PackFrom(upstream_tls_context);
   }
 
-  transport_socket.mutable_typed_config()->PackFrom(upstream_tls_context);
   return transport_socket;
 }
 
@@ -137,6 +147,13 @@ Cluster createNighthawkClusterForWorker(const Client::Options& options,
     Http2ProtocolOptions* http2_options =
         http_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
     http2_options->mutable_max_concurrent_streams()->set_value(options.maxConcurrentStreams());
+
+  } else if (options.upstreamProtocol() == Envoy::Http::Protocol::Http3) {
+    Http3ProtocolOptions* http3_options =
+        http_options.mutable_explicit_http_config()->mutable_http3_protocol_options();
+    http3_options->mutable_quic_protocol_options()->mutable_max_concurrent_streams()->set_value(
+        options.maxConcurrentStreams());
+
   } else {
     http_options.mutable_explicit_http_config()->mutable_http_protocol_options();
   }

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -9,13 +9,15 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+filegroup(
+    name = "test_server_configs",
+    data = glob(["configurations/*"]),
+)
+
 py_library(
     name = "integration_test_base",
     data = [
-        "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_https_origin.yaml",
-        "configurations/nighthawk_track_timings.yaml",
-        "configurations/sni_origin.yaml",
+        ":test_server_configs",
         "//:nighthawk_client",
         "//:nighthawk_output_transform",
         "//:nighthawk_service",
@@ -38,9 +40,7 @@ py_library(
         "utility.py",
     ],
     data = [
-        "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_https_origin.yaml",
-        "configurations/sni_origin.yaml",
+        ":test_server_configs",
         "@envoy//test/config/integration/certs",
     ],
     deps = [

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -1,0 +1,58 @@
+admin:
+  access_log:
+    - name: envoy.access_loggers.file
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: $tmpdir/nighthawk-test-server-admin-access.log
+  profile_path: $tmpdir/nighthawk-test-server.prof
+  address:
+    socket_address: { address: $server_ip, port_value: 0 }
+static_resources:
+  listeners:
+    - name: listener_udp
+      address:
+        socket_address:
+          protocol: UDP
+          address: $server_ip
+          port_value: 0
+      udp_listener_config:
+        quic_options: {}
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                generate_request_id: false
+                codec_type: HTTP3
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: service
+                      domains:
+                        - "*"
+                http_filters:
+                  - name: dynamic-delay
+                  - name: test-server
+                    typed_config:
+                      "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+                      response_body_size: 10
+                      v3_response_headers:
+                        - { header: { key: "x-nh", value: "1" } }
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                      dynamic_stats: false
+          transport_socket:
+            name: envoy.transport_sockets.quic
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicDownstreamTransport
+              downstream_tls_context:
+                common_tls_context:
+                  tls_certificates:
+                    - certificate_chain:
+                          inline_string: |
+                            @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/servercert.pem
+                      private_key:
+                          inline_string: |
+                            @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem


### PR DESCRIPTION
Nitghhawk now generates correct bootstrap configuration when HTTP/3 Quic is requested as the upstream protocol.

Integration tests will be added in the next PR. Quic functionality was verified locally at this PR.

Works on #23