### PR TITLE
Decrease the amount of memory bazel uses.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -44,6 +44,7 @@ BUILD_PARTS=(
 function run_on_build_parts() {
     local command="$1"
     for part in ${BUILD_PARTS[@]}; do
+        echo "run_on_build_parts: running command $command $part"
         eval "$command $part"
         if (( $? != 0 )); then
             echo "Error executing $command $part."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -29,7 +29,15 @@ BUILD_PARTS=(
     "//source/server/..."
     "//source/request_source/..."
     "//source/adaptive_load/..."
+    "//test/adaptive_load/..."
+    "//test/client/..."
+    "//test/common/..."
+    "//test/distributor/..."
     "//test/mocks/..."
+    "//test/request_source/..."
+    "//test/server/..."
+    "//test/sink/..."
+    "//test/integration/..."
     "//test/..."
 )
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -29,15 +29,7 @@ BUILD_PARTS=(
     "//source/server/..."
     "//source/request_source/..."
     "//source/adaptive_load/..."
-    "//test/adaptive_load/..."
-    "//test/client/..."
-    "//test/common/..."
-    "//test/distributor/..."
     "//test/mocks/..."
-    "//test/request_source/..."
-    "//test/server/..."
-    "//test/sink/..."
-    "//test/integration/..."
     "//test/..."
 )
 
@@ -240,7 +232,8 @@ if [ -n "$CIRCLECI" ]; then
     NUM_CPUS=8
     if [[ "$1" == "test_gcc" ]]; then
         NUM_CPUS=2
-        BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --jobs=${NUM_CPUS} --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build"
+        BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} \
+          --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build"
     fi
     echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
     BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --jobs=${NUM_CPUS}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -239,9 +239,10 @@ if [ -n "$CIRCLECI" ]; then
     fi
     NUM_CPUS=8
     if [[ "$1" == "test_gcc" ]]; then
-        NUM_CPUS=4
+        NUM_CPUS=2
+        BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --jobs=${NUM_CPUS} --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build"
     fi
-    echo "Running with ${NUM_CPUS} cpus"
+    echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
     BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --jobs=${NUM_CPUS}"
 fi
 


### PR DESCRIPTION
This prevents OOM when running `test_gcc`.

Also log the currently executed command in `run_on_build_parts` which helps with debugging of these errors.