### PR TITLE
[QUIC 060]: Adding an e2e test that uses HTTP/3 Quic.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -44,6 +44,7 @@ BUILD_PARTS=(
 function run_on_build_parts() {
     local command="$1"
     for part in ${BUILD_PARTS[@]}; do
+        echo "run_on_build_parts: running command $command $part"
         eval "$command $part"
         if (( $? != 0 )); then
             echo "Error executing $command $part."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -44,7 +44,6 @@ BUILD_PARTS=(
 function run_on_build_parts() {
     local command="$1"
     for part in ${BUILD_PARTS[@]}; do
-        echo "run_on_build_parts: running command $command $part"
         eval "$command $part"
         if (( $? != 0 )); then
             echo "Error executing $command $part."

--- a/extensions_build_config.bzl
+++ b/extensions_build_config.bzl
@@ -6,6 +6,7 @@ EXTENSIONS = {
     "envoy.filters.network.http_connection_manager": "//source/extensions/filters/network/http_connection_manager:config",
     "envoy.tracers.zipkin": "//source/extensions/tracers/zipkin:config",
     "envoy.transport_sockets.raw_buffer": "//source/extensions/transport_sockets/raw_buffer:config",
+    "envoy.access_loggers.file": "//source/extensions/access_loggers/file:config",
 }
 
 DISABLED_BY_DEFAULT_EXTENSIONS = {

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -9,13 +9,15 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+filegroup(
+    name = "test_server_configs",
+    data = glob(["configurations/*"]),
+)
+
 py_library(
     name = "integration_test_base",
     data = [
-        "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_https_origin.yaml",
-        "configurations/nighthawk_track_timings.yaml",
-        "configurations/sni_origin.yaml",
+        ":test_server_configs",
         "//:nighthawk_client",
         "//:nighthawk_output_transform",
         "//:nighthawk_service",
@@ -38,9 +40,7 @@ py_library(
         "utility.py",
     ],
     data = [
-        "configurations/nighthawk_http_origin.yaml",
-        "configurations/nighthawk_https_origin.yaml",
-        "configurations/sni_origin.yaml",
+        ":test_server_configs",
         "@envoy//test/config/integration/certs",
     ],
     deps = [

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -1,0 +1,60 @@
+admin:
+  access_log:
+    - name: envoy.access_loggers.file
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: $tmpdir/nighthawk-test-server-admin-access.log
+  profile_path: $tmpdir/nighthawk-test-server.prof
+  address:
+    socket_address: { address: $server_ip, port_value: 0 }
+static_resources:
+  listeners:
+    - name: listener_udp
+      address:
+        socket_address:
+          protocol: UDP
+          address: $server_ip
+          port_value: 0
+      udp_listener_config:
+        quic_options: {}
+        downstream_socket_config:
+          prefer_gro: true
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                generate_request_id: false
+                codec_type: HTTP3
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: service
+                      domains:
+                        - "*"
+                http_filters:
+                  - name: dynamic-delay
+                  - name: test-server
+                    typed_config:
+                      "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+                      response_body_size: 10
+                      v3_response_headers:
+                        - { header: { key: "x-nh", value: "1" } }
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                      dynamic_stats: false
+          transport_socket:
+            name: envoy.transport_sockets.quic
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicDownstreamTransport
+              downstream_tls_context:
+                common_tls_context:
+                  tls_certificates:
+                    - certificate_chain:
+                          inline_string: |
+                            @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/servercert.pem
+                      private_key:
+                          inline_string: |
+                            @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -17,8 +17,6 @@ static_resources:
           port_value: 0
       udp_listener_config:
         quic_options: {}
-        downstream_socket_config:
-          prefer_gro: true
       filter_chains:
         - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -81,7 +81,7 @@ class IntegrationTestBase():
     self.request = request
     self.ip_version = request.param
     assert self.ip_version != IpVersion.UNKNOWN
-    self.server_ip = "::" if self.ip_version == IpVersion.IPV6 else "0.0.0.0"
+    self.server_ip = "::1" if self.ip_version == IpVersion.IPV6 else "127.0.0.1"
     self.server_ip = os.getenv("TEST_SERVER_EXTERNAL_IP", self.server_ip)
     self.tag = ""
     self.parameters = {}
@@ -251,7 +251,7 @@ class IntegrationTestBase():
       args.append("--address-family v6")
     if as_json:
       args.append("--output-format json")
-    logging.info("Nighthawk client popen() args: [%s]" % args)
+    logging.info("Nighthawk client popen() args: %s" % str.join(" ", args))
     client_process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = client_process.communicate()
     logs = stderr.decode('utf-8')

--- a/test/integration/integration_test_fixtures.py
+++ b/test/integration/integration_test_fixtures.py
@@ -81,7 +81,7 @@ class IntegrationTestBase():
     self.request = request
     self.ip_version = request.param
     assert self.ip_version != IpVersion.UNKNOWN
-    self.server_ip = "::1" if self.ip_version == IpVersion.IPV6 else "127.0.0.1"
+    self.server_ip = "::" if self.ip_version == IpVersion.IPV6 else "0.0.0.0"
     self.server_ip = os.getenv("TEST_SERVER_EXTERNAL_IP", self.server_ip)
     self.tag = ""
     self.parameters = {}
@@ -350,6 +350,16 @@ class HttpsIntegrationTestBase(IntegrationTestBase):
     return super(HttpsIntegrationTestBase, self).getTestServerRootUri(True)
 
 
+class QuicIntegrationTestBase(HttpsIntegrationTestBase):
+  """Base for Quic tests against the Nighthawk test server."""
+
+  def __init__(self, request, server_config_quic):
+    """See base class."""
+    super(QuicIntegrationTestBase, self).__init__(request, server_config_quic)
+    # Quic tests require specific IP rather than "all IPs" as the target.
+    self.server_ip = "::1" if self.ip_version == IpVersion.IPV6 else "127.0.0.1"
+
+
 class SniIntegrationTestBase(HttpsIntegrationTestBase):
   """Base for https/sni tests against the Nighthawk test server."""
 
@@ -388,6 +398,16 @@ def server_config():
   yield "nighthawk/test/integration/configurations/nighthawk_http_origin.yaml"
 
 
+@pytest.fixture()
+def server_config_quic():
+  """Fixture which yields the path to a server configuration with Quic listener.
+
+  Yields:
+      String: Path to the stock server configuration.
+  """
+  yield "nighthawk/test/integration/configurations/nighthawk_https_origin_quic.yaml"
+
+
 @pytest.fixture(params=determineIpVersionsFromEnvironment())
 def http_test_server_fixture(request, server_config, caplog):
   """Fixture for setting up a test environment with the stock http server configuration.
@@ -409,6 +429,19 @@ def https_test_server_fixture(request, server_config, caplog):
       HttpsIntegrationTestBase: A fully set up instance. Tear down will happen automatically.
   """
   f = HttpsIntegrationTestBase(request, server_config)
+  f.setUp()
+  yield f
+  f.tearDown(caplog)
+
+
+@pytest.fixture(params=determineIpVersionsFromEnvironment())
+def quic_test_server_fixture(request, server_config_quic, caplog):
+  """Fixture for setting up a test environment with a server that has a Quic listener.
+
+  Yields:
+      QuicIntegrationTestBase: A fully set up instance. Tear down will happen automatically.
+  """
+  f = QuicIntegrationTestBase(request, server_config_quic)
   f.setUp()
   yield f
   f.tearDown(caplog)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -303,7 +303,7 @@ def test_h3_quic(https_test_server_fixture):
   checks statistics from both client and server.
   """
   parsed_json, _ = https_test_server_fixture.runNighthawkClient([
-      "--h3",
+      "--upstream-protocol http3",
       https_test_server_fixture.getTestServerRootUri(),
       "--rps",
       "100",

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -294,8 +294,8 @@ def test_https_h2_multiple_connections(https_test_server_fixture):
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http2_total", 10)
 
 
-@pytest.mark.parametrize('server_config',
-                         ["nighthawk/test/integration/configurations/nighthawk_https_origin_quic.yaml"])
+@pytest.mark.parametrize(
+    'server_config', ["nighthawk/test/integration/configurations/nighthawk_https_origin_quic.yaml"])
 def test_h3_quic(https_test_server_fixture):
   """Test http3 quic.
 
@@ -304,12 +304,20 @@ def test_h3_quic(https_test_server_fixture):
   """
   parsed_json, _ = https_test_server_fixture.runNighthawkClient([
       "--h3",
-      https_test_server_fixture.getTestServerRootUri(), "--rps", "100", "--duration", "100",
-      "--termination-predicate", "benchmark.http_2xx:24", "--max-active-requests", "1",
+      https_test_server_fixture.getTestServerRootUri(),
+      "--rps",
+      "100",
+      "--duration",
+      "100",
+      "--termination-predicate",
+      "benchmark.http_2xx:24",
+      "--max-active-requests",
+      "1",
       # Envoy doesn't support disabling certificate verification on Quic
       # connections, so the host in our requests has to match the hostname in
       # the leaf certificate.
-      "--request-header", "Host:www.lyft.com"
+      "--request-header",
+      "Host:www.lyft.com"
   ])
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -13,7 +13,8 @@ from threading import Thread
 from test.integration.common import IpVersion
 from test.integration.integration_test_fixtures import (
     http_test_server_fixture, https_test_server_fixture, https_test_server_fixture,
-    multi_http_test_server_fixture, multi_https_test_server_fixture, server_config)
+    multi_http_test_server_fixture, multi_https_test_server_fixture, quic_test_server_fixture,
+    server_config, server_config_quic)
 from test.integration import asserts
 from test.integration import utility
 
@@ -294,17 +295,15 @@ def test_https_h2_multiple_connections(https_test_server_fixture):
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http2_total", 10)
 
 
-@pytest.mark.parametrize(
-    'server_config', ["nighthawk/test/integration/configurations/nighthawk_https_origin_quic.yaml"])
-def test_h3_quic(https_test_server_fixture):
+def test_h3_quic(quic_test_server_fixture):
   """Test http3 quic.
 
   Runs the CLI configured to use HTTP/3 Quic against our test server, and sanity
   checks statistics from both client and server.
   """
-  parsed_json, _ = https_test_server_fixture.runNighthawkClient([
+  parsed_json, _ = quic_test_server_fixture.runNighthawkClient([
       "--protocol http3",
-      https_test_server_fixture.getTestServerRootUri(),
+      quic_test_server_fixture.getTestServerRootUri(),
       "--rps",
       "100",
       "--duration",
@@ -319,7 +318,7 @@ def test_h3_quic(https_test_server_fixture):
       "--request-header",
       "Host:www.lyft.com"
   ])
-  counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
+  counters = quic_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
   asserts.assertCounterEqual(counters, "upstream_cx_http3_total", 1)
   asserts.assertCounterEqual(counters, "upstream_cx_total", 1)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -303,7 +303,7 @@ def test_h3_quic(https_test_server_fixture):
   checks statistics from both client and server.
   """
   parsed_json, _ = https_test_server_fixture.runNighthawkClient([
-      "--upstream-protocol http3",
+      "--protocol http3",
       https_test_server_fixture.getTestServerRootUri(),
       "--rps",
       "100",


### PR DESCRIPTION
Done here:
- Creating a Quic specific test fixture that changes the target IP address used by the Nighthawk client in e2e tests to loopback to avoid the following Quic error:
```
[01:33:37.413994][1494720][I] Client: Error: QUIC_DECRYPTION_FAILURE detail: Unable to decrypt ENCRYPTION_HANDSHAKE header protection (missing key).
```
- Improving how the Nighthawk client arguments are logged in e2e tests to simplify copy&pasting while debugging.
- Defining a single BUILD filegroup that contains all the test server configs and adding `nighthawk_https_origin_quic.yaml` for the HTTP/3 Quic e2e test.
- Adding the `envoy.access_loggers.file` extension to the Nighthawk build, this  extension is required to avoid a deprecation warning about the  `admin/access_log_path` field in the new test server config.

Works on #23.