### PR TITLE
Update Envoy to b57827c (Aug 10, 2021)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "a066b5ed9a06f2bed18fff9fc52d34c50948dcdd"  # August 03, 2021
-ENVOY_SHA = "67b56a8edb0340c7ed1d65cc9fceaf012c5c5fa71132634618c20da0d4b71c6c"
+ENVOY_COMMIT = "b57827c202613fa7c2a4731b94e6928629e67478"  # Aug 10, 2021
+ENVOY_SHA = "ab61f6eb341bf2b791af7e97eebff48381c42a769c4a5aa33b1de4839f30ea70"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
Simplest possible update:
- No code changes
- No change to Envoy's .bazelrc: Latest commit 2ba5bed 11 days ago

Signed-off-by: eric846 <56563761+eric846@users.noreply.github.com>