### PR TITLE
test: More MOCK_METHOD modernization.

### DIFF
--- a/test/mocks/adaptive_load/mock_metrics_evaluator.h
+++ b/test/mocks/adaptive_load/mock_metrics_evaluator.h
@@ -24,23 +24,27 @@ public:
    */
   MockMetricsEvaluator();
 
-  MOCK_CONST_METHOD3(EvaluateMetric,
-                     absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>(
-                         const nighthawk::adaptive_load::MetricSpec& metric_spec,
-                         MetricsPlugin& metrics_plugin,
-                         const nighthawk::adaptive_load::ThresholdSpec* threshold_spec));
+  MOCK_METHOD(absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>,
+              EvaluateMetric,
+              (const nighthawk::adaptive_load::MetricSpec& metric_spec,
+               MetricsPlugin& metrics_plugin,
+               const nighthawk::adaptive_load::ThresholdSpec* threshold_spec),
+              (const, override));
 
-  MOCK_CONST_METHOD1(ExtractMetricSpecs,
-                     const std::vector<std::pair<const nighthawk::adaptive_load::MetricSpec*,
-                                                 const nighthawk::adaptive_load::ThresholdSpec*>>(
-                         const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec));
+  MOCK_METHOD((const std::vector<
+                  std::pair<const nighthawk::adaptive_load::MetricSpec*,
+                            const nighthawk::adaptive_load::ThresholdSpec*>>),
+              ExtractMetricSpecs,
+              (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec),
+              (const, override));
 
-  MOCK_CONST_METHOD3(
-      AnalyzeNighthawkBenchmark,
-      absl::StatusOr<nighthawk::adaptive_load::BenchmarkResult>(
-          const nighthawk::client::ExecutionResponse& execution_response,
-          const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec,
-          const absl::flat_hash_map<std::string, MetricsPluginPtr>& name_to_custom_plugin_map));
+  MOCK_METHOD(absl::StatusOr<nighthawk::adaptive_load::BenchmarkResult>,
+              AnalyzeNighthawkBenchmark,
+              (const nighthawk::client::ExecutionResponse& execution_response,
+               const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec,
+               (const absl::flat_hash_map<std::string, MetricsPluginPtr>&
+                    name_to_custom_plugin_map)),
+              (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/adaptive_load/mock_metrics_evaluator.h
+++ b/test/mocks/adaptive_load/mock_metrics_evaluator.h
@@ -24,27 +24,23 @@ public:
    */
   MockMetricsEvaluator();
 
-  MOCK_METHOD(absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>,
-              EvaluateMetric,
+  MOCK_METHOD(absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>, EvaluateMetric,
               (const nighthawk::adaptive_load::MetricSpec& metric_spec,
                MetricsPlugin& metrics_plugin,
                const nighthawk::adaptive_load::ThresholdSpec* threshold_spec),
               (const, override));
 
-  MOCK_METHOD((const std::vector<
-                  std::pair<const nighthawk::adaptive_load::MetricSpec*,
-                            const nighthawk::adaptive_load::ThresholdSpec*>>),
-              ExtractMetricSpecs,
-              (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec),
+  MOCK_METHOD((const std::vector<std::pair<const nighthawk::adaptive_load::MetricSpec*,
+                                           const nighthawk::adaptive_load::ThresholdSpec*>>),
+              ExtractMetricSpecs, (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec),
               (const, override));
 
-  MOCK_METHOD(absl::StatusOr<nighthawk::adaptive_load::BenchmarkResult>,
-              AnalyzeNighthawkBenchmark,
-              (const nighthawk::client::ExecutionResponse& execution_response,
-               const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec,
-               (const absl::flat_hash_map<std::string, MetricsPluginPtr>&
-                    name_to_custom_plugin_map)),
-              (const, override));
+  MOCK_METHOD(
+      absl::StatusOr<nighthawk::adaptive_load::BenchmarkResult>, AnalyzeNighthawkBenchmark,
+      (const nighthawk::client::ExecutionResponse& execution_response,
+       const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec,
+       (const absl::flat_hash_map<std::string, MetricsPluginPtr>& name_to_custom_plugin_map)),
+      (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/adaptive_load/mock_session_spec_proto_helper.h
+++ b/test/mocks/adaptive_load/mock_session_spec_proto_helper.h
@@ -32,11 +32,13 @@ public:
    */
   MockAdaptiveLoadSessionSpecProtoHelper();
 
-  MOCK_CONST_METHOD1(SetSessionSpecDefaults,
-                     nighthawk::adaptive_load::AdaptiveLoadSessionSpec(
-                         const nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec));
-  MOCK_CONST_METHOD1(CheckSessionSpec,
-                     absl::Status(const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec));
+  MOCK_METHOD(nighthawk::adaptive_load::AdaptiveLoadSessionSpec,
+              SetSessionSpecDefaults,
+              (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec),
+              (const, override));
+  MOCK_METHOD(absl::Status, CheckSessionSpec,
+              (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec),
+              (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/adaptive_load/mock_session_spec_proto_helper.h
+++ b/test/mocks/adaptive_load/mock_session_spec_proto_helper.h
@@ -32,13 +32,10 @@ public:
    */
   MockAdaptiveLoadSessionSpecProtoHelper();
 
-  MOCK_METHOD(nighthawk::adaptive_load::AdaptiveLoadSessionSpec,
-              SetSessionSpecDefaults,
-              (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec),
-              (const, override));
+  MOCK_METHOD(nighthawk::adaptive_load::AdaptiveLoadSessionSpec, SetSessionSpecDefaults,
+              (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec), (const, override));
   MOCK_METHOD(absl::Status, CheckSessionSpec,
-              (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec),
-              (const, override));
+              (const nighthawk::adaptive_load::AdaptiveLoadSessionSpec& spec), (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client.h
+++ b/test/mocks/client/mock_benchmark_client.h
@@ -17,9 +17,8 @@ public:
   MOCK_METHOD(bool, tryStartRequest, (Client::CompletionCallback), (override));
   MOCK_METHOD(Envoy::Stats::Scope&, scope, (), (const, override));
   MOCK_METHOD(bool, shouldMeasureLatencies, (), (const, override));
-  MOCK_METHOD(const Envoy::Http::RequestHeaderMap&, requestHeaders, (),
-              (const));
+  MOCK_METHOD(const Envoy::Http::RequestHeaderMap&, requestHeaders, (), (const));
 };
 
 } // namespace Client
-}  // namespace Nighthawk
+} // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client.h
+++ b/test/mocks/client/mock_benchmark_client.h
@@ -11,14 +11,15 @@ class MockBenchmarkClient : public BenchmarkClient {
 public:
   MockBenchmarkClient();
 
-  MOCK_METHOD(void, terminate, ());
-  MOCK_METHOD(void, setShouldMeasureLatencies, (bool));
-  MOCK_METHOD(StatisticPtrMap, statistics, (), (const));
-  MOCK_METHOD(bool, tryStartRequest, (Client::CompletionCallback));
-  MOCK_METHOD(Envoy::Stats::Scope&, scope, (), (const));
-  MOCK_METHOD(bool, shouldMeasureLatencies, (), (const));
-  MOCK_METHOD(const Envoy::Http::RequestHeaderMap&, requestHeaders, (), (const));
+  MOCK_METHOD(void, terminate, (), (override));
+  MOCK_METHOD(void, setShouldMeasureLatencies, (bool), (override));
+  MOCK_METHOD(StatisticPtrMap, statistics, (), (const, override));
+  MOCK_METHOD(bool, tryStartRequest, (Client::CompletionCallback), (override));
+  MOCK_METHOD(Envoy::Stats::Scope&, scope, (), (const, override));
+  MOCK_METHOD(bool, shouldMeasureLatencies, (), (const, override));
+  MOCK_METHOD(const Envoy::Http::RequestHeaderMap&, requestHeaders, (),
+              (const));
 };
 
 } // namespace Client
-} // namespace Nighthawk
+}  // namespace Nighthawk

--- a/test/mocks/client/mock_benchmark_client_factory.h
+++ b/test/mocks/client/mock_benchmark_client_factory.h
@@ -15,10 +15,9 @@ class MockBenchmarkClientFactory : public BenchmarkClientFactory {
 public:
   MockBenchmarkClientFactory();
   MOCK_METHOD(BenchmarkClientPtr, create,
-              (Envoy::Api::Api&, Envoy::Event::Dispatcher&,
-               Envoy::Stats::Scope&, Envoy::Upstream::ClusterManagerPtr&,
-               Envoy::Tracing::HttpTracerSharedPtr&, absl::string_view, int,
-               RequestSource& request_generator),
+              (Envoy::Api::Api&, Envoy::Event::Dispatcher&, Envoy::Stats::Scope&,
+               Envoy::Upstream::ClusterManagerPtr&, Envoy::Tracing::HttpTracerSharedPtr&,
+               absl::string_view, int, RequestSource& request_generator),
               (const, override));
 };
 

--- a/test/mocks/client/mock_benchmark_client_factory.h
+++ b/test/mocks/client/mock_benchmark_client_factory.h
@@ -14,11 +14,12 @@ namespace Client {
 class MockBenchmarkClientFactory : public BenchmarkClientFactory {
 public:
   MockBenchmarkClientFactory();
-  MOCK_CONST_METHOD8(create,
-                     BenchmarkClientPtr(Envoy::Api::Api&, Envoy::Event::Dispatcher&,
-                                        Envoy::Stats::Scope&, Envoy::Upstream::ClusterManagerPtr&,
-                                        Envoy::Tracing::HttpTracerSharedPtr&, absl::string_view,
-                                        int, RequestSource& request_generator));
+  MOCK_METHOD(BenchmarkClientPtr, create,
+              (Envoy::Api::Api&, Envoy::Event::Dispatcher&,
+               Envoy::Stats::Scope&, Envoy::Upstream::ClusterManagerPtr&,
+               Envoy::Tracing::HttpTracerSharedPtr&, absl::string_view, int,
+               RequestSource& request_generator),
+              (const, override));
 };
 
 } // namespace Client

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -11,54 +11,68 @@ namespace Client {
 class MockOptions : public Options {
 public:
   MockOptions();
-  MOCK_CONST_METHOD0(requestsPerSecond, uint32_t());
-  MOCK_CONST_METHOD0(connections, uint32_t());
-  MOCK_CONST_METHOD0(duration, std::chrono::seconds());
-  MOCK_CONST_METHOD0(timeout, std::chrono::seconds());
-  MOCK_CONST_METHOD0(uri, absl::optional<std::string>());
-  MOCK_CONST_METHOD0(protocol, Envoy::Http::Protocol());
-  MOCK_CONST_METHOD0(concurrency, std::string());
-  MOCK_CONST_METHOD0(verbosity, nighthawk::client::Verbosity::VerbosityOptions());
-  MOCK_CONST_METHOD0(outputFormat, nighthawk::client::OutputFormat::OutputFormatOptions());
-  MOCK_CONST_METHOD0(prefetchConnections, bool());
-  MOCK_CONST_METHOD0(burstSize, uint32_t());
-  MOCK_CONST_METHOD0(addressFamily, nighthawk::client::AddressFamily::AddressFamilyOptions());
-  MOCK_CONST_METHOD0(requestMethod, envoy::config::core::v3::RequestMethod());
-  MOCK_CONST_METHOD0(requestHeaders, std::vector<std::string>());
-  MOCK_CONST_METHOD0(requestBodySize, uint32_t());
-  MOCK_CONST_METHOD0(tlsContext,
-                     envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&());
-  MOCK_CONST_METHOD0(transportSocket, absl::optional<envoy::config::core::v3::TransportSocket>&());
-  MOCK_CONST_METHOD0(maxPendingRequests, uint32_t());
-  MOCK_CONST_METHOD0(maxActiveRequests, uint32_t());
-  MOCK_CONST_METHOD0(maxRequestsPerConnection, uint32_t());
-  MOCK_CONST_METHOD0(maxConcurrentStreams, uint32_t());
-  MOCK_CONST_METHOD0(toCommandLineOptions, CommandLineOptionsPtr());
-  MOCK_CONST_METHOD0(sequencerIdleStrategy,
-                     nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions());
-  MOCK_CONST_METHOD0(requestSource, std::string());
-  MOCK_CONST_METHOD0(requestSourcePluginConfig,
-                     absl::optional<envoy::config::core::v3::TypedExtensionConfig>&());
-  MOCK_CONST_METHOD0(trace, std::string());
-  MOCK_CONST_METHOD0(
-      h1ConnectionReuseStrategy,
-      nighthawk::client::H1ConnectionReuseStrategy::H1ConnectionReuseStrategyOptions());
-  MOCK_CONST_METHOD0(terminationPredicates, TerminationPredicateMap());
-  MOCK_CONST_METHOD0(failurePredicates, TerminationPredicateMap());
-  MOCK_CONST_METHOD0(openLoop, bool());
-  MOCK_CONST_METHOD0(jitterUniform, std::chrono::nanoseconds());
-  MOCK_CONST_METHOD0(nighthawkService, std::string());
-  MOCK_CONST_METHOD0(multiTargetEndpoints, std::vector<nighthawk::client::MultiTarget::Endpoint>());
-  MOCK_CONST_METHOD0(multiTargetPath, std::string());
-  MOCK_CONST_METHOD0(multiTargetUseHttps, bool());
-  MOCK_CONST_METHOD0(labels, std::vector<std::string>());
-  MOCK_CONST_METHOD0(simpleWarmup, bool());
-  MOCK_CONST_METHOD0(noDuration, bool());
-  MOCK_CONST_METHOD0(statsSinks, std::vector<envoy::config::metrics::v3::StatsSink>());
-  MOCK_CONST_METHOD0(statsFlushInterval, uint32_t());
-  MOCK_CONST_METHOD0(responseHeaderWithLatencyInput, std::string());
-  MOCK_CONST_METHOD0(scheduled_start, absl::optional<Envoy::SystemTime>());
-  MOCK_CONST_METHOD0(executionId, absl::optional<std::string>());
+  MOCK_METHOD(uint32_t, requestsPerSecond, (), (const, override));
+  MOCK_METHOD(uint32_t, connections, (), (const, override));
+  MOCK_METHOD(std::chrono::seconds, duration, (), (const, override));
+  MOCK_METHOD(std::chrono::seconds, timeout, (), (const, override));
+  MOCK_METHOD(absl::optional<std::string>, uri, (), (const, override));
+  MOCK_METHOD(bool, h2, (), (const, override));
+  MOCK_METHOD(std::string, concurrency, (), (const, override));
+  MOCK_METHOD(nighthawk::client::Verbosity::VerbosityOptions, verbosity, (),
+              (const, override));
+  MOCK_METHOD(nighthawk::client::OutputFormat::OutputFormatOptions,
+              outputFormat, (), (const, override));
+  MOCK_METHOD(bool, prefetchConnections, (), (const, override));
+  MOCK_METHOD(uint32_t, burstSize, (), (const, override));
+  MOCK_METHOD(nighthawk::client::AddressFamily::AddressFamilyOptions,
+              addressFamily, (), (const, override));
+  MOCK_METHOD(envoy::config::core::v3::RequestMethod, requestMethod, (),
+              (const, override));
+  MOCK_METHOD(std::vector<std::string>, requestHeaders, (), (const, override));
+  MOCK_METHOD(uint32_t, requestBodySize, (), (const, override));
+  MOCK_METHOD(
+      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&,
+      tlsContext, (), (const, override));
+  MOCK_METHOD(absl::optional<envoy::config::core::v3::TransportSocket>&,
+              transportSocket, (), (const, override));
+  MOCK_METHOD(uint32_t, maxPendingRequests, (), (const, override));
+  MOCK_METHOD(uint32_t, maxActiveRequests, (), (const, override));
+  MOCK_METHOD(uint32_t, maxRequestsPerConnection, (), (const, override));
+  MOCK_METHOD(CommandLineOptionsPtr, toCommandLineOptions, (),
+              (const, override));
+  MOCK_METHOD(
+      nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions,
+      sequencerIdleStrategy, (), (const, override));
+  MOCK_METHOD(std::string, requestSource, (), (const, override));
+  MOCK_METHOD(absl::optional<envoy::config::core::v3::TypedExtensionConfig>&,
+              requestSourcePluginConfig, (), (const, override));
+  MOCK_METHOD(std::string, trace, (), (const, override));
+  MOCK_METHOD(nighthawk::client::H1ConnectionReuseStrategy::
+                  H1ConnectionReuseStrategyOptions,
+              h1ConnectionReuseStrategy, (), (const, override));
+  MOCK_METHOD(TerminationPredicateMap, terminationPredicates, (),
+              (const, override));
+  MOCK_METHOD(TerminationPredicateMap, failurePredicates, (),
+              (const, override));
+  MOCK_METHOD(bool, openLoop, (), (const, override));
+  MOCK_METHOD(std::chrono::nanoseconds, jitterUniform, (), (const, override));
+  MOCK_METHOD(std::string, nighthawkService, (), (const, override));
+  MOCK_METHOD(bool, h2UseMultipleConnections, (), (const, override));
+  MOCK_METHOD(std::vector<nighthawk::client::MultiTarget::Endpoint>,
+              multiTargetEndpoints, (), (const, override));
+  MOCK_METHOD(std::string, multiTargetPath, (), (const, override));
+  MOCK_METHOD(bool, multiTargetUseHttps, (), (const, override));
+  MOCK_METHOD(std::vector<std::string>, labels, (), (const, override));
+  MOCK_METHOD(bool, simpleWarmup, (), (const, override));
+  MOCK_METHOD(bool, noDuration, (), (const, override));
+  MOCK_METHOD(std::vector<envoy::config::metrics::v3::StatsSink>, statsSinks,
+              (), (const, override));
+  MOCK_METHOD(uint32_t, statsFlushInterval, (), (const, override));
+  MOCK_METHOD(std::string, responseHeaderWithLatencyInput, (),
+              (const, override));
+  MOCK_METHOD(bool, allowEnvoyDeprecatedV2Api, (), (const, override));
+  MOCK_METHOD(absl::optional<Envoy::SystemTime>, scheduled_start, (),
+              (const, override));
 };
 
 } // namespace Client

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -16,7 +16,8 @@ public:
   MOCK_METHOD(std::chrono::seconds, duration, (), (const, override));
   MOCK_METHOD(std::chrono::seconds, timeout, (), (const, override));
   MOCK_METHOD(absl::optional<std::string>, uri, (), (const, override));
-  MOCK_METHOD(bool, h2, (), (const, override));
+  MOCK_METHOD(bool, h2, (), (const));
+  MOCK_METHOD(Envoy::Http::Protocol, protocol, (), (const, override));
   MOCK_METHOD(std::string, concurrency, (), (const, override));
   MOCK_METHOD(nighthawk::client::Verbosity::VerbosityOptions, verbosity, (), (const, override));
   MOCK_METHOD(nighthawk::client::OutputFormat::OutputFormatOptions, outputFormat, (),
@@ -35,6 +36,7 @@ public:
   MOCK_METHOD(uint32_t, maxPendingRequests, (), (const, override));
   MOCK_METHOD(uint32_t, maxActiveRequests, (), (const, override));
   MOCK_METHOD(uint32_t, maxRequestsPerConnection, (), (const, override));
+  MOCK_METHOD(uint32_t, maxConcurrentStreams, (), (const, override));
   MOCK_METHOD(CommandLineOptionsPtr, toCommandLineOptions, (), (const, override));
   MOCK_METHOD(nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions,
               sequencerIdleStrategy, (), (const, override));
@@ -49,7 +51,7 @@ public:
   MOCK_METHOD(bool, openLoop, (), (const, override));
   MOCK_METHOD(std::chrono::nanoseconds, jitterUniform, (), (const, override));
   MOCK_METHOD(std::string, nighthawkService, (), (const, override));
-  MOCK_METHOD(bool, h2UseMultipleConnections, (), (const, override));
+  MOCK_METHOD(bool, h2UseMultipleConnections, (), (const));
   MOCK_METHOD(std::vector<nighthawk::client::MultiTarget::Endpoint>, multiTargetEndpoints, (),
               (const, override));
   MOCK_METHOD(std::string, multiTargetPath, (), (const, override));
@@ -61,8 +63,9 @@ public:
               (const, override));
   MOCK_METHOD(uint32_t, statsFlushInterval, (), (const, override));
   MOCK_METHOD(std::string, responseHeaderWithLatencyInput, (), (const, override));
-  MOCK_METHOD(bool, allowEnvoyDeprecatedV2Api, (), (const, override));
+  MOCK_METHOD(bool, allowEnvoyDeprecatedV2Api, (), (const));
   MOCK_METHOD(absl::optional<Envoy::SystemTime>, scheduled_start, (), (const, override));
+  MOCK_METHOD(absl::optional<std::string>, executionId, (), (const, override));
 };
 
 } // namespace Client

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -18,61 +18,51 @@ public:
   MOCK_METHOD(absl::optional<std::string>, uri, (), (const, override));
   MOCK_METHOD(bool, h2, (), (const, override));
   MOCK_METHOD(std::string, concurrency, (), (const, override));
-  MOCK_METHOD(nighthawk::client::Verbosity::VerbosityOptions, verbosity, (),
+  MOCK_METHOD(nighthawk::client::Verbosity::VerbosityOptions, verbosity, (), (const, override));
+  MOCK_METHOD(nighthawk::client::OutputFormat::OutputFormatOptions, outputFormat, (),
               (const, override));
-  MOCK_METHOD(nighthawk::client::OutputFormat::OutputFormatOptions,
-              outputFormat, (), (const, override));
   MOCK_METHOD(bool, prefetchConnections, (), (const, override));
   MOCK_METHOD(uint32_t, burstSize, (), (const, override));
-  MOCK_METHOD(nighthawk::client::AddressFamily::AddressFamilyOptions,
-              addressFamily, (), (const, override));
-  MOCK_METHOD(envoy::config::core::v3::RequestMethod, requestMethod, (),
+  MOCK_METHOD(nighthawk::client::AddressFamily::AddressFamilyOptions, addressFamily, (),
               (const, override));
+  MOCK_METHOD(envoy::config::core::v3::RequestMethod, requestMethod, (), (const, override));
   MOCK_METHOD(std::vector<std::string>, requestHeaders, (), (const, override));
   MOCK_METHOD(uint32_t, requestBodySize, (), (const, override));
-  MOCK_METHOD(
-      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&,
-      tlsContext, (), (const, override));
-  MOCK_METHOD(absl::optional<envoy::config::core::v3::TransportSocket>&,
-              transportSocket, (), (const, override));
+  MOCK_METHOD(envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&, tlsContext, (),
+              (const, override));
+  MOCK_METHOD(absl::optional<envoy::config::core::v3::TransportSocket>&, transportSocket, (),
+              (const, override));
   MOCK_METHOD(uint32_t, maxPendingRequests, (), (const, override));
   MOCK_METHOD(uint32_t, maxActiveRequests, (), (const, override));
   MOCK_METHOD(uint32_t, maxRequestsPerConnection, (), (const, override));
-  MOCK_METHOD(CommandLineOptionsPtr, toCommandLineOptions, (),
-              (const, override));
-  MOCK_METHOD(
-      nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions,
-      sequencerIdleStrategy, (), (const, override));
+  MOCK_METHOD(CommandLineOptionsPtr, toCommandLineOptions, (), (const, override));
+  MOCK_METHOD(nighthawk::client::SequencerIdleStrategy::SequencerIdleStrategyOptions,
+              sequencerIdleStrategy, (), (const, override));
   MOCK_METHOD(std::string, requestSource, (), (const, override));
   MOCK_METHOD(absl::optional<envoy::config::core::v3::TypedExtensionConfig>&,
               requestSourcePluginConfig, (), (const, override));
   MOCK_METHOD(std::string, trace, (), (const, override));
-  MOCK_METHOD(nighthawk::client::H1ConnectionReuseStrategy::
-                  H1ConnectionReuseStrategyOptions,
+  MOCK_METHOD(nighthawk::client::H1ConnectionReuseStrategy::H1ConnectionReuseStrategyOptions,
               h1ConnectionReuseStrategy, (), (const, override));
-  MOCK_METHOD(TerminationPredicateMap, terminationPredicates, (),
-              (const, override));
-  MOCK_METHOD(TerminationPredicateMap, failurePredicates, (),
-              (const, override));
+  MOCK_METHOD(TerminationPredicateMap, terminationPredicates, (), (const, override));
+  MOCK_METHOD(TerminationPredicateMap, failurePredicates, (), (const, override));
   MOCK_METHOD(bool, openLoop, (), (const, override));
   MOCK_METHOD(std::chrono::nanoseconds, jitterUniform, (), (const, override));
   MOCK_METHOD(std::string, nighthawkService, (), (const, override));
   MOCK_METHOD(bool, h2UseMultipleConnections, (), (const, override));
-  MOCK_METHOD(std::vector<nighthawk::client::MultiTarget::Endpoint>,
-              multiTargetEndpoints, (), (const, override));
+  MOCK_METHOD(std::vector<nighthawk::client::MultiTarget::Endpoint>, multiTargetEndpoints, (),
+              (const, override));
   MOCK_METHOD(std::string, multiTargetPath, (), (const, override));
   MOCK_METHOD(bool, multiTargetUseHttps, (), (const, override));
   MOCK_METHOD(std::vector<std::string>, labels, (), (const, override));
   MOCK_METHOD(bool, simpleWarmup, (), (const, override));
   MOCK_METHOD(bool, noDuration, (), (const, override));
-  MOCK_METHOD(std::vector<envoy::config::metrics::v3::StatsSink>, statsSinks,
-              (), (const, override));
+  MOCK_METHOD(std::vector<envoy::config::metrics::v3::StatsSink>, statsSinks, (),
+              (const, override));
   MOCK_METHOD(uint32_t, statsFlushInterval, (), (const, override));
-  MOCK_METHOD(std::string, responseHeaderWithLatencyInput, (),
-              (const, override));
+  MOCK_METHOD(std::string, responseHeaderWithLatencyInput, (), (const, override));
   MOCK_METHOD(bool, allowEnvoyDeprecatedV2Api, (), (const, override));
-  MOCK_METHOD(absl::optional<Envoy::SystemTime>, scheduled_start, (),
-              (const, override));
+  MOCK_METHOD(absl::optional<Envoy::SystemTime>, scheduled_start, (), (const, override));
 };
 
 } // namespace Client

--- a/test/mocks/common/mock_nighthawk_service_client.h
+++ b/test/mocks/common/mock_nighthawk_service_client.h
@@ -23,8 +23,7 @@ public:
    */
   MockNighthawkServiceClient();
 
-  MOCK_METHOD(absl::StatusOr<nighthawk::client::ExecutionResponse>,
-              PerformNighthawkBenchmark,
+  MOCK_METHOD(absl::StatusOr<nighthawk::client::ExecutionResponse>, PerformNighthawkBenchmark,
               (nighthawk::client::NighthawkService::StubInterface * stub,
                const nighthawk::client::CommandLineOptions& options),
               (const, override));

--- a/test/mocks/common/mock_nighthawk_service_client.h
+++ b/test/mocks/common/mock_nighthawk_service_client.h
@@ -23,10 +23,11 @@ public:
    */
   MockNighthawkServiceClient();
 
-  MOCK_CONST_METHOD2(PerformNighthawkBenchmark,
-                     absl::StatusOr<nighthawk::client::ExecutionResponse>(
-                         nighthawk::client::NighthawkService::StubInterface* stub,
-                         const nighthawk::client::CommandLineOptions& options));
+  MOCK_METHOD(absl::StatusOr<nighthawk::client::ExecutionResponse>,
+              PerformNighthawkBenchmark,
+              (nighthawk::client::NighthawkService::StubInterface * stub,
+               const nighthawk::client::CommandLineOptions& options),
+              (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_platform_util.h
+++ b/test/mocks/common/mock_platform_util.h
@@ -10,8 +10,8 @@ class MockPlatformUtil : public PlatformUtil {
 public:
   MockPlatformUtil();
 
-  MOCK_CONST_METHOD0(yieldCurrentThread, void());
-  MOCK_CONST_METHOD1(sleep, void(std::chrono::microseconds));
+  MOCK_METHOD(void, yieldCurrentThread, (), (const, override));
+  MOCK_METHOD(void, sleep, (std::chrono::microseconds), (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_rate_limiter.h
+++ b/test/mocks/common/mock_rate_limiter.h
@@ -10,19 +10,20 @@ class MockRateLimiter : public RateLimiter {
 public:
   MockRateLimiter();
 
-  MOCK_METHOD(bool, tryAcquireOne, ());
-  MOCK_METHOD(void, releaseOne, ());
-  MOCK_METHOD(Envoy::TimeSource&, timeSource, ());
-  MOCK_METHOD(std::chrono::nanoseconds, elapsed, ());
-  MOCK_METHOD(absl::optional<Envoy::SystemTime>, firstAcquisitionTime, (), (const));
+  MOCK_METHOD(bool, tryAcquireOne, (), (override));
+  MOCK_METHOD(void, releaseOne, (), (override));
+  MOCK_METHOD(Envoy::TimeSource&, timeSource, (), (override));
+  MOCK_METHOD(std::chrono::nanoseconds, elapsed, (), (override));
+  MOCK_METHOD(absl::optional<Envoy::SystemTime>, firstAcquisitionTime, (),
+              (const, override));
 };
 
 class MockDiscreteNumericDistributionSampler : public DiscreteNumericDistributionSampler {
 public:
   MockDiscreteNumericDistributionSampler();
-  MOCK_METHOD(uint64_t, getValue, ());
-  MOCK_METHOD(uint64_t, min, (), (const));
-  MOCK_METHOD(uint64_t, max, (), (const));
+  MOCK_METHOD(uint64_t, getValue, (), (override));
+  MOCK_METHOD(uint64_t, min, (), (const, override));
+  MOCK_METHOD(uint64_t, max, (), (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_rate_limiter.h
+++ b/test/mocks/common/mock_rate_limiter.h
@@ -14,8 +14,7 @@ public:
   MOCK_METHOD(void, releaseOne, (), (override));
   MOCK_METHOD(Envoy::TimeSource&, timeSource, (), (override));
   MOCK_METHOD(std::chrono::nanoseconds, elapsed, (), (override));
-  MOCK_METHOD(absl::optional<Envoy::SystemTime>, firstAcquisitionTime, (),
-              (const, override));
+  MOCK_METHOD(absl::optional<Envoy::SystemTime>, firstAcquisitionTime, (), (const, override));
 };
 
 class MockDiscreteNumericDistributionSampler : public DiscreteNumericDistributionSampler {

--- a/test/mocks/common/mock_request_source.h
+++ b/test/mocks/common/mock_request_source.h
@@ -9,9 +9,8 @@ namespace Nighthawk {
 class MockRequestSource : public RequestSource {
 public:
   MockRequestSource();
-  MOCK_METHOD(RequestGenerator, get, ());
-  MOCK_METHOD(void, initOnThread, ());
-  MOCK_METHOD(void, destroyOnThread, ());
+  MOCK_METHOD(RequestGenerator, get, (), (override));
+  MOCK_METHOD(void, initOnThread, (), (override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_request_source.h
+++ b/test/mocks/common/mock_request_source.h
@@ -11,6 +11,7 @@ public:
   MockRequestSource();
   MOCK_METHOD(RequestGenerator, get, (), (override));
   MOCK_METHOD(void, initOnThread, (), (override));
+  MOCK_METHOD(void, destroyOnThread, (), (override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_request_source_factory.h
+++ b/test/mocks/common/mock_request_source_factory.h
@@ -9,11 +9,11 @@ namespace Nighthawk {
 class MockRequestSourceFactory : public RequestSourceFactory {
 public:
   MockRequestSourceFactory();
-  MOCK_CONST_METHOD4(create,
-                     RequestSourcePtr(const Envoy::Upstream::ClusterManagerPtr& cluster_manager,
-                                      Envoy::Event::Dispatcher& dispatcher,
-                                      Envoy::Stats::Scope& scope,
-                                      absl::string_view service_cluster_name));
+  MOCK_METHOD(RequestSourcePtr, create,
+              (const Envoy::Upstream::ClusterManagerPtr& cluster_manager,
+               Envoy::Event::Dispatcher& dispatcher, Envoy::Stats::Scope& scope,
+               absl::string_view service_cluster_name),
+              (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_sequencer.h
+++ b/test/mocks/common/mock_sequencer.h
@@ -14,8 +14,7 @@ public:
   MOCK_METHOD(void, start, (), (override));
   MOCK_METHOD(void, waitForCompletion, (), (override));
   MOCK_METHOD(double, completionsPerSecond, (), (const, override));
-  MOCK_METHOD(std::chrono::nanoseconds, executionDuration, (),
-              (const, override));
+  MOCK_METHOD(std::chrono::nanoseconds, executionDuration, (), (const, override));
   MOCK_METHOD(StatisticPtrMap, statistics, (), (const, override));
   MOCK_METHOD(void, cancel, ());
   MOCK_METHOD(RateLimiter&, rate_limiter, (), (const, override));

--- a/test/mocks/common/mock_sequencer.h
+++ b/test/mocks/common/mock_sequencer.h
@@ -11,13 +11,14 @@ class MockSequencer : public Sequencer {
 public:
   MockSequencer();
 
-  MOCK_METHOD(void, start, ());
-  MOCK_METHOD(void, waitForCompletion, ());
-  MOCK_METHOD(double, completionsPerSecond, (), (const));
-  MOCK_METHOD(std::chrono::nanoseconds, executionDuration, (), (const));
-  MOCK_METHOD(StatisticPtrMap, statistics, (), (const));
+  MOCK_METHOD(void, start, (), (override));
+  MOCK_METHOD(void, waitForCompletion, (), (override));
+  MOCK_METHOD(double, completionsPerSecond, (), (const, override));
+  MOCK_METHOD(std::chrono::nanoseconds, executionDuration, (),
+              (const, override));
+  MOCK_METHOD(StatisticPtrMap, statistics, (), (const, override));
   MOCK_METHOD(void, cancel, ());
-  MOCK_METHOD(RateLimiter&, rate_limiter, (), (const));
+  MOCK_METHOD(RateLimiter&, rate_limiter, (), (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_sequencer_factory.h
+++ b/test/mocks/common/mock_sequencer_factory.h
@@ -10,11 +10,9 @@ class MockSequencerFactory : public SequencerFactory {
 public:
   MockSequencerFactory();
   MOCK_METHOD(SequencerPtr, create,
-              (Envoy::TimeSource & time_source,
-               Envoy::Event::Dispatcher& dispatcher,
+              (Envoy::TimeSource & time_source, Envoy::Event::Dispatcher& dispatcher,
                const SequencerTarget& sequencer_target,
-               TerminationPredicatePtr&& termination_predicate,
-               Envoy::Stats::Scope& scope,
+               TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope,
                const Envoy::MonotonicTime scheduled_starting_time),
               (const, override));
 };

--- a/test/mocks/common/mock_sequencer_factory.h
+++ b/test/mocks/common/mock_sequencer_factory.h
@@ -9,12 +9,14 @@ namespace Nighthawk {
 class MockSequencerFactory : public SequencerFactory {
 public:
   MockSequencerFactory();
-  MOCK_CONST_METHOD6(create, SequencerPtr(Envoy::TimeSource& time_source,
-                                          Envoy::Event::Dispatcher& dispatcher,
-                                          const SequencerTarget& sequencer_target,
-                                          TerminationPredicatePtr&& termination_predicate,
-                                          Envoy::Stats::Scope& scope,
-                                          const Envoy::MonotonicTime scheduled_starting_time));
+  MOCK_METHOD(SequencerPtr, create,
+              (Envoy::TimeSource & time_source,
+               Envoy::Event::Dispatcher& dispatcher,
+               const SequencerTarget& sequencer_target,
+               TerminationPredicatePtr&& termination_predicate,
+               Envoy::Stats::Scope& scope,
+               const Envoy::MonotonicTime scheduled_starting_time),
+              (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -9,10 +9,8 @@ namespace Nighthawk {
 class MockTerminationPredicate : public TerminationPredicate {
 public:
   MockTerminationPredicate();
-  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr &&),
-              (override));
-  MOCK_METHOD(TerminationPredicate&, appendToChain,
-              (TerminationPredicatePtr &&), (override));
+  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr &&), (override));
+  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr &&), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluateChain, (), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluate, (), (override));
 };

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -9,10 +9,12 @@ namespace Nighthawk {
 class MockTerminationPredicate : public TerminationPredicate {
 public:
   MockTerminationPredicate();
-  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr && p));
-  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr && p));
-  MOCK_METHOD(TerminationPredicate::Status, evaluateChain, ());
-  MOCK_METHOD(TerminationPredicate::Status, evaluate, ());
+  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr &&),
+              (override));
+  MOCK_METHOD(TerminationPredicate&, appendToChain,
+              (TerminationPredicatePtr &&), (override));
+  MOCK_METHOD(TerminationPredicate::Status, evaluateChain, (), (override));
+  MOCK_METHOD(TerminationPredicate::Status, evaluate, (), (override));
 };
 
 } // namespace Nighthawk

--- a/test/mocks/common/mock_termination_predicate_factory.h
+++ b/test/mocks/common/mock_termination_predicate_factory.h
@@ -9,10 +9,10 @@ namespace Nighthawk {
 class MockTerminationPredicateFactory : public TerminationPredicateFactory {
 public:
   MockTerminationPredicateFactory();
-  MOCK_CONST_METHOD3(create,
-                     TerminationPredicatePtr(Envoy::TimeSource& time_source,
-                                             Envoy::Stats::Scope& scope,
-                                             const Envoy::MonotonicTime scheduled_starting_time));
+  MOCK_METHOD(TerminationPredicatePtr, create,
+              (Envoy::TimeSource & time_source, Envoy::Stats::Scope& scope,
+               const Envoy::MonotonicTime scheduled_starting_time),
+              (const, override));
 };
 
 } // namespace Nighthawk

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -34,7 +34,7 @@ public:
 
 class MockSequencerTarget : public FakeSequencerTarget {
 public:
-  MOCK_METHOD(bool, callback, (OperationCallback));
+ MOCK_METHOD(bool, callback, (OperationCallback), (override));
 };
 
 class SequencerTestBase : public testing::Test {

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -34,7 +34,7 @@ public:
 
 class MockSequencerTarget : public FakeSequencerTarget {
 public:
- MOCK_METHOD(bool, callback, (OperationCallback), (override));
+  MOCK_METHOD(bool, callback, (OperationCallback), (override));
 };
 
 class SequencerTestBase : public testing::Test {


### PR DESCRIPTION
* Use more `MOCK_METHOD` instead of `MOCK_METHODn`.
* Add the `override` qualifier where appropriate.

This PR is based on some automated changes suggested by @mum4k with tweaks to remove some `override`s that failed to build.

Co-authored-by: Jakub Sobon <mumak@google.com>