### PR TITLE
Update Envoy to 54b686b (Oct 4th 2021).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -178,17 +178,17 @@ build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
 build:rbe-toolchain --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 build:rbe-toolchain-clang --config=rbe-toolchain
-build:rbe-toolchain-clang --platforms=@rbe_ubuntu_clang//config:platform
-build:rbe-toolchain-clang --host_platform=@rbe_ubuntu_clang//config:platform
-build:rbe-toolchain-clang --crosstool_top=@rbe_ubuntu_clang//cc:toolchain
-build:rbe-toolchain-clang --extra_toolchains=@rbe_ubuntu_clang//config:cc-toolchain
+build:rbe-toolchain-clang --platforms=@envoy_build_tools//toolchains:rbe_linux_clang_platform
+build:rbe-toolchain-clang --host_platform=@envoy_build_tools//toolchains:rbe_linux_clang_platform
+build:rbe-toolchain-clang --crosstool_top=@envoy_build_tools//toolchains/configs/linux/clang/cc:toolchain
+build:rbe-toolchain-clang --extra_toolchains=@envoy_build_tools//toolchains/configs/linux/clang/config:cc-toolchain
 build:rbe-toolchain-clang --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/opt/llvm/bin
 
 build:rbe-toolchain-clang-libc++ --config=rbe-toolchain
-build:rbe-toolchain-clang-libc++ --platforms=@rbe_ubuntu_clang_libcxx//config:platform
-build:rbe-toolchain-clang-libc++ --host_platform=@rbe_ubuntu_clang_libcxx//config:platform
-build:rbe-toolchain-clang-libc++ --crosstool_top=@rbe_ubuntu_clang_libcxx//cc:toolchain
-build:rbe-toolchain-clang-libc++ --extra_toolchains=@rbe_ubuntu_clang_libcxx//config:cc-toolchain
+build:rbe-toolchain-clang-libc++ --platforms=@envoy_build_tools//toolchains:rbe_linux_clang_libcxx_platform
+build:rbe-toolchain-clang-libc++ --host_platform=@envoy_build_tools//toolchains:rbe_linux_clang_libcxx_platform
+build:rbe-toolchain-clang-libc++ --crosstool_top=@envoy_build_tools//toolchains/configs/linux/clang_libcxx/cc:toolchain
+build:rbe-toolchain-clang-libc++ --extra_toolchains=@envoy_build_tools//toolchains/configs/linux/clang_libcxx/config:cc-toolchain
 build:rbe-toolchain-clang-libc++ --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/opt/llvm/bin
 build:rbe-toolchain-clang-libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --action_env=LDFLAGS=-stdlib=libc++
@@ -213,20 +213,20 @@ build:rbe-toolchain-tsan --linkopt=-Wl,-rpath,/opt/libcxx_tsan/lib
 build:rbe-toolchain-tsan --config=clang-tsan
 
 build:rbe-toolchain-gcc --config=rbe-toolchain
-build:rbe-toolchain-gcc --platforms=@rbe_ubuntu_gcc//config:platform
-build:rbe-toolchain-gcc --host_platform=@rbe_ubuntu_gcc//config:platform
-build:rbe-toolchain-gcc --crosstool_top=@rbe_ubuntu_gcc//cc:toolchain
-build:rbe-toolchain-gcc --extra_toolchains=@rbe_ubuntu_gcc//config:cc-toolchain
+build:rbe-toolchain-gcc --platforms=@envoy_build_tools//toolchains:rbe_linux_gcc_platform
+build:rbe-toolchain-gcc --host_platform=@envoy_build_tools//toolchains:rbe_linux_gcc_platform
+build:rbe-toolchain-gcc --crosstool_top=@envoy_build_tools//toolchains/configs/linux/gcc/cc:toolchain
+build:rbe-toolchain-gcc --extra_toolchains=@envoy_build_tools//toolchains/configs/linux/gcc/config:cc-toolchain
 
-build:rbe-toolchain-msvc-cl --host_platform=@rbe_windows_msvc_cl//config:platform
-build:rbe-toolchain-msvc-cl --platforms=@rbe_windows_msvc_cl//config:platform
-build:rbe-toolchain-msvc-cl --crosstool_top=@rbe_windows_msvc_cl//cc:toolchain
-build:rbe-toolchain-msvc-cl --extra_toolchains=@rbe_windows_msvc_cl//config:cc-toolchain
+build:rbe-toolchain-msvc-cl --host_platform=@envoy_build_tools//toolchains:rbe_windows_msvc_cl_platform
+build:rbe-toolchain-msvc-cl --platforms=@envoy_build_tools//toolchains:rbe_windows_msvc_cl_platform
+build:rbe-toolchain-msvc-cl --crosstool_top=@envoy_build_tools//toolchains/configs/windows/msvc-cl/cc:toolchain
+build:rbe-toolchain-msvc-cl --extra_toolchains=@envoy_build_tools//toolchains/configs/windows/msvc-cl/config:cc-toolchain
 
-build:rbe-toolchain-clang-cl --host_platform=@rbe_windows_clang_cl//config:platform
-build:rbe-toolchain-clang-cl --platforms=@rbe_windows_clang_cl//config:platform
-build:rbe-toolchain-clang-cl --crosstool_top=@rbe_windows_clang_cl//cc:toolchain
-build:rbe-toolchain-clang-cl --extra_toolchains=@rbe_windows_clang_cl//config:cc-toolchain
+build:rbe-toolchain-clang-cl --host_platform=@envoy_build_tools//toolchains:rbe_windows_clang_cl_platform
+build:rbe-toolchain-clang-cl --platforms=@envoy_build_tools//toolchains:rbe_windows_clang_cl_platform
+build:rbe-toolchain-clang-cl --crosstool_top=@envoy_build_tools//toolchains/configs/windows/clang-cl/cc:toolchain
+build:rbe-toolchain-clang-cl --extra_toolchains=@envoy_build_tools//toolchains/configs/windows/clang-cl/config:cc-toolchain
 
 build:remote --spawn_strategy=remote,sandboxed,local
 build:remote --strategy=Javac=remote,sandboxed,local
@@ -276,7 +276,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:55d9e4719d2bd0accce8f829b44dab70cd42112a
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:81a93046060dbe5620d5b3aa92632090a9ee4da6
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
-  envoy-build-image: &envoy-build-image # May 10th, 2021
-    envoyproxy/envoy-build-ubuntu:55d9e4719d2bd0accce8f829b44dab70cd42112a
+  envoy-build-image: &envoy-build-image
+    envoyproxy/envoy-build-ubuntu:81a93046060dbe5620d5b3aa92632090a9ee4da6
 version: 2
 jobs:
   build:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies,-modernize-use-trailing-return-type,-modernize-avoid-bind,-modernize-use-nodiscard,-modernize-concat-nested-namespaces'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,modernize-*,performance-*,readability-redundant-*,readability-braces-around-statements,-abseil-no-internal-dependencies,-modernize-use-trailing-return-type,-modernize-avoid-bind,-modernize-use-nodiscard,-modernize-concat-nested-namespaces,-bugprone-narrowing-conversions'
 
 WarningsAsErrors:  '*'
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "6e5facc3a9c66edff6ba2cff8a684aa5747671e5"  # Sep 27, 2021
-ENVOY_SHA = "8efdf02412c215b8323060ab462dfaa0cde598fca25899a9c2b8d35548c56bb8"
+ENVOY_COMMIT = "54b686bb5f16cae0d506293fbefb82ab5588c3d3"  # Oct 4, 2021
+ENVOY_SHA = "c4be23253422521ae51f800095e9fe7ee4ebd7f8158f251710d07f92f7ab2c2c"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -91,10 +91,15 @@ function filter_excludes() {
 }
 
 function run_clang_tidy() {
+  # *: Enable all default checks.
+  # TODO(#750): Re-enable bugprone-narrowing-conversions.
+  ENABLED_CHECKS="*,-bugprone-narrowing-conversions"
+
   python3 "${LLVM_PREFIX}/share/clang/run-clang-tidy.py" \
     -clang-tidy-binary="${CLANG_TIDY}" \
     -clang-apply-replacements-binary="${CLANG_APPLY_REPLACEMENTS}" \
     -export-fixes=${FIX_YAML} -j "${NUM_CPUS:-0}" -p "${SRCDIR}" -quiet \
+    -checks=${ENABLED_CHECKS} \
     ${APPLY_CLANG_TIDY_FIXES:+-fix} "$@"
 }
 

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -91,14 +91,10 @@ function filter_excludes() {
 }
 
 function run_clang_tidy() {
-  # TODO(#750): Re-enable bugprone-narrowing-conversions.
-  ENABLED_CHECKS="default,-bugprone-narrowing-conversions"
-
   python3 "${LLVM_PREFIX}/share/clang/run-clang-tidy.py" \
     -clang-tidy-binary="${CLANG_TIDY}" \
     -clang-apply-replacements-binary="${CLANG_APPLY_REPLACEMENTS}" \
     -export-fixes=${FIX_YAML} -j "${NUM_CPUS:-0}" -p "${SRCDIR}" -quiet \
-    -checks=${ENABLED_CHECKS} \
     ${APPLY_CLANG_TIDY_FIXES:+-fix} "$@"
 }
 

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -91,9 +91,8 @@ function filter_excludes() {
 }
 
 function run_clang_tidy() {
-  # *: Enable all default checks.
   # TODO(#750): Re-enable bugprone-narrowing-conversions.
-  ENABLED_CHECKS="*,-bugprone-narrowing-conversions"
+  ENABLED_CHECKS="default,-bugprone-narrowing-conversions"
 
   python3 "${LLVM_PREFIX}/share/clang/run-clang-tidy.py" \
     -clang-tidy-binary="${CLANG_TIDY}" \

--- a/test/integration/configurations/sni_origin.yaml
+++ b/test/integration/configurations/sni_origin.yaml
@@ -14,7 +14,7 @@ static_resources:
         address: $server_ip
         port_value: 0
     listener_filters:
-    - name: "envoy.listener.tls_inspector"
+    - name: "envoy.filters.listener.tls_inspector"
       typed_config: {}
     filter_chains:
     - filter_chain_match:
@@ -32,7 +32,7 @@ static_resources:
                   inline_string: |
                     @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem
     listener_filters:
-    - name: "envoy.listener.tls_inspector"
+    - name: "envoy.filters.listener.tls_inspector"
       typed_config: {}
     filter_chains:
     - filter_chain_match:


### PR DESCRIPTION
- synced changes in `.bazelrc`.
- updated the `envoyproxy/envoy-build-ubuntu` in `.circleci/config.yml`.
- no changes in `.bazelversion` or `run_envoy_docker.sh`.
- renamed deprecated 'envoy.listener.tls_inspector' to 'envoy.filters.listener.tls_inspector' in the integration test configuration.
- removed date from `.circleci/config.yml` since it is outdated and likely to get outdated again on future updates. It is unclear what value it adds since the version is just mechanically synced from the Envoy repository.
- disabling the `bugprone-narrowing-conversions` clang-tidy check which started reporting errors at this PR and filing https://github.com/envoyproxy/nighthawk/issues/750.