### PR TITLE
Update Envoy to 1143dd7 (Nov 29, 2021)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "d79a3ab49f1aa522d0a465385425e3e00c8db147"  # Nov 22nd, 2021
-ENVOY_SHA = "41ecb1e9bef3765dcac73f499ae56d8b5d94c7c0ece4c2f8a226870e9848f3fc"
+ENVOY_COMMIT = "1143dd703229843f12a4ed0e12c85b39bea0cf75"  # Nov 29, 2021
+ENVOY_SHA = "41029e7bf0642cfb18a87face2e190063ce76ef9a032372f1a371ad8dab4b0f3"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
Simple update
- .bazelrc not updated since Nov 12

Signed-off-by: eric846 <56563761+eric846@users.noreply.github.com>