### PR TITLE
Loosen requirements on test_multiple_backends_http_h1

### DIFF
--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -554,13 +554,11 @@ def test_multiple_backends_http_h1(multi_http_test_server_fixture):
   asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 3)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 3)
-  total_2xx = 0
   for parsed_server_json in multi_http_test_server_fixture.getAllTestServerStatisticsJsons():
     single_2xx = multi_http_test_server_fixture.getServerStatFromJson(
         parsed_server_json, "http.ingress_http.downstream_rq_2xx")
-    asserts.assertBetweenInclusive(single_2xx, 8, 9)
-    total_2xx += single_2xx
-  asserts.assertBetweenInclusive(total_2xx, 24, 25)
+    # Confirm that each backend receives some traffic
+    asserts.assertGreaterEqual(single_2xx, 1)
 
 
 @pytest.mark.parametrize('server_config',


### PR DESCRIPTION
At low resources, nighthawk is not guaranteed to distribute requests evenly among all backends. Loosens requirement to all backends must receive some traffic. 

In addition, removed the total_2xx constraint as that is verifying the same behavior as test_http_h1_termination_predicate.

closes #766 

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>