### PR TITLE
Split test_h1_pool_strategy into LRU and MRU tests and relax constraints

### DIFF
--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -118,7 +118,7 @@ def test_h1_pool_strategy_mru(http_test_server_fixture):
       http_test_server_fixture.getTestServerRootUri()
   ])
 
-  # Expect the second connection to send any messages
+  # Expect the second connection to not send any messages
   asserts.assertNotIn("[C1] message complete", logs)
   # Expect that we sent some traffic through the first connection
   asserts.assertGreater(_count_log_lines_with_substring(logs, "[C0] message complete"), 0)

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -109,7 +109,7 @@ def test_http_h2_connection_management_single_request_per_conn_1(http_test_serve
 def test_h1_pool_strategy_mru(http_test_server_fixture):
   """Test connection re-use strategies of the http 1 connection pool.
 
-  Test that with the "mru" strategy only the first created connection gets to send requests.
+  Test that with the "most recently used" (mru) strategy only the first created connection gets to send requests.
   """
   _, logs = http_test_server_fixture.runNighthawkClient([
       "--rps 5", "-v", "trace", "--duration", "20", "--connections", "2", "--prefetch-connections",
@@ -127,7 +127,7 @@ def test_h1_pool_strategy_mru(http_test_server_fixture):
 def test_h1_pool_strategy_lru(http_test_server_fixture):
   """Test connection re-use strategies of the http 1 connection pool.
 
-  Test that with the "lru" strategy, we expect all connections to be used and have roughly equal distribution.
+  Test that with the "least recently used" (lru) strategy all connections are used with roughly equal distribution.
   """
   requests = 12
   connections = 3

--- a/test/integration/test_connection_management.py
+++ b/test/integration/test_connection_management.py
@@ -111,7 +111,6 @@ def test_h1_pool_strategy_mru(http_test_server_fixture):
 
   Test that with the "mru" strategy only the first created connection gets to send requests.
   """
-
   _, logs = http_test_server_fixture.runNighthawkClient([
       "--rps 5", "-v", "trace", "--duration", "20", "--connections", "2", "--prefetch-connections",
       "--experimental-h1-connection-reuse-strategy", "mru", "--termination-predicate",

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -554,13 +554,11 @@ def test_multiple_backends_http_h1(multi_http_test_server_fixture):
   asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 3)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 3)
-  total_2xx = 0
   for parsed_server_json in multi_http_test_server_fixture.getAllTestServerStatisticsJsons():
     single_2xx = multi_http_test_server_fixture.getServerStatFromJson(
         parsed_server_json, "http.ingress_http.downstream_rq_2xx")
-    asserts.assertBetweenInclusive(single_2xx, 8, 9)
-    total_2xx += single_2xx
-  asserts.assertBetweenInclusive(total_2xx, 24, 25)
+    # Confirm that each backend receives some traffic
+    asserts.assertGreaterEqual(single_2xx, 1)
 
 
 @pytest.mark.parametrize('server_config',

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -350,10 +350,12 @@ def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2)
       "ECDHE-RSA-AES128-SHA",
       "ECDHE-RSA-CHACHA20-POLY1305",
   ]:
-    parsed_json, _ = https_test_server_fixture.runNighthawkClient((["--h2"] if use_h2 else []) + [
-        "--termination-predicate", "benchmark.http_2xx:0", cli_parameter, json_template % cipher,
-        https_test_server_fixture.getTestServerRootUri()
-    ])
+    parsed_json, _ = https_test_server_fixture.runNighthawkClient(
+        (["--protocol", "http2"] if use_h2 else []) + [
+            "--duration", "10", "--termination-predicate", "benchmark.http_2xx:0", cli_parameter,
+            json_template % cipher,
+            https_test_server_fixture.getTestServerRootUri()
+        ])
     counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
     asserts.assertCounterGreaterEqual(counters, "ssl.ciphers.%s" % cipher, 1)
 

--- a/test/integration/unit_tests/test_utility.py
+++ b/test/integration/unit_tests/test_utility.py
@@ -40,5 +40,17 @@ def test_get_execution_duration_from_global_result_json_missing_suffix():
     utility.get_execution_duration_from_global_result_json(global_result_json)
 
 
+def test_count_log_lines_with_substring_counts_only_lines_with_substring():
+  """Test that only lines with substring are counted."""
+  logs = """
+  DEBUG: log example 1 \r\n
+  ERROR: log example 2 \r\n
+  ERROR: log example 3 \r\n
+  INFO: log example 1 \r\n
+  """
+  count = utility.count_log_lines_with_substring(logs, "ERROR")
+  assert count == 2
+
+
 if __name__ == "__main__":
   raise SystemExit(pytest.main([__file__]))

--- a/test/integration/unit_tests/test_utility.py
+++ b/test/integration/unit_tests/test_utility.py
@@ -52,5 +52,24 @@ def test_count_log_lines_with_substring_counts_only_lines_with_substring():
   assert count == 2
 
 
+def test_count_log_lines_with_substring_returns_zero_for_no_matches():
+  """Test that returns zero if there are no matching lines."""
+  logs = """
+  DEBUG: log example 1 \r\n
+  ERROR: log example 2 \r\n
+  ERROR: log example 3 \r\n
+  INFO: log example 1 \r\n
+  """
+  count = utility.count_log_lines_with_substring(logs, "log example 4")
+  assert count == 0
+
+
+def test_count_log_lines_with_substring_returns_zero_with_empty_logs():
+  """Test that returns zero if there are no logs."""
+  logs = """"""
+  count = utility.count_log_lines_with_substring(logs, "log example 4")
+  assert count == 0
+
+
 if __name__ == "__main__":
   raise SystemExit(pytest.main([__file__]))

--- a/test/integration/unit_tests/test_utility.py
+++ b/test/integration/unit_tests/test_utility.py
@@ -66,7 +66,7 @@ def test_count_log_lines_with_substring_returns_zero_for_no_matches():
 
 def test_count_log_lines_with_substring_returns_zero_with_empty_logs():
   """Test that returns zero if there are no logs."""
-  logs = """"""
+  logs = ""
   count = utility.count_log_lines_with_substring(logs, "log example 4")
   assert count == 0
 

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -82,6 +82,6 @@ def count_log_lines_with_substring(logs, substring):
     substring: the substring to search for.
 
   Returns:
-    the number of log entries that countain the substring.
+    the number of log entries that contain the substring.
   """
   return len([line for line in logs.split(os.linesep) if substring in line])

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -78,10 +78,10 @@ def count_log_lines_with_substring(logs, substring):
   """Count the number of log lines containing the supplied substring.
 
   Args:
-    logs: Nighthawk client log output.
-    substring: the substring to search for.
+    logs: A string, Nighthawk client log output.
+    substring: A string, the substring to search for.
 
   Returns:
-    the number of log entries that contain the substring.
+    An integer, the number of log entries that contain the substring.
   """
   return len([line for line in logs.split(os.linesep) if substring in line])

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -72,3 +72,16 @@ def get_execution_duration_from_global_result_json(global_result_json):
         "the execution_duration '{} doesn't end with the expected suffix 's' for seconds".format(
             duration_json_string))
   return float(duration_json_string.rstrip('s'))
+
+
+def count_log_lines_with_substring(logs, substring):
+  """Count the number of log lines containing the supplied substring.
+
+  Args:
+    logs: Nighthawk client log output.
+    substring: the substring to search for.
+
+  Returns:
+    the number of log entries that countain the substring.
+  """
+  return len([line for line in logs.split(os.linesep) if substring in line])


### PR DESCRIPTION
Splits test_h1_pool_strategy integration test into two separate tests for better granularity. 

Relax the constraints of each test to be more resilient to a variation of requests sent while still verifying the behavior of the connection pool strategies. 

Increased the duration of each test to also improve the overall stability of traffic sent by nighthawk. 

closes #769 

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>