### PR TITLE
Reduce dependency on time in test_drain integration test

### DIFF
--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -806,7 +806,7 @@ def test_drain(https_test_server_fixture):
   expect to observe no replies. Termination should be cut short by the drain timeout, which means
   that we should have results in approximately execution duration + drain timeout = 35 seconds.
   (the pool drain timeout is hard coded to 5 seconds as of writing this). 
-  If drain timeout is reached, a message will be logged to the user. 
+  If drain timeout is reached, a message will be logged to the user.
   """
   parsed_json, logs = https_test_server_fixture.runNighthawkClient([
       https_test_server_fixture.getTestServerRootUri(), "--rps", "100", "--duration", "20",

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -802,19 +802,18 @@ def test_client_cli_bad_uri(http_test_server_fixture):
 def test_drain(https_test_server_fixture):
   """Test that the pool drain timeout is effective, and we terminate in a timely fashion.
 
-  Sets up the test server to delay replies 100 seconds. Our execution will only last 3 seconds, so we
+  Sets up the test server to delay replies 100 seconds. Our execution will only last 30 seconds, so we
   expect to observe no replies. Termination should be cut short by the drain timeout, which means
-  that we should have results in approximately execution duration + drain timeout = 8 seconds.
-  (the pool drain timeout is hard coded to 5 seconds as of writing this).
+  that we should have results in approximately execution duration + drain timeout = 35 seconds.
+  (the pool drain timeout is hard coded to 5 seconds as of writing this). 
+  If drain timeout is reached, a message will be logged to the user. 
   """
-  t0 = time.time()
-  parsed_json, _ = https_test_server_fixture.runNighthawkClient([
-      https_test_server_fixture.getTestServerRootUri(), "--rps", "100", "--duration", "3",
+  parsed_json, logs = https_test_server_fixture.runNighthawkClient([
+      https_test_server_fixture.getTestServerRootUri(), "--rps", "100", "--duration", "20",
       "--request-header", "x-nighthawk-test-server-config: {static_delay: \"100s\"}"
   ])
-  t1 = time.time()
-  time_delta = t1 - t0
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
-  assert time_delta < 40  # *lots* of slack to avoid failure in slow CI executions.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertNotIn("benchmark.http_2xx", counters)
+  asserts.assertIn("Wait for the connection pool drain timed out, proceeding to hard shutdown",
+                   logs)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -805,7 +805,7 @@ def test_drain(https_test_server_fixture):
   Sets up the test server to delay replies 100 seconds. Our execution will only last 30 seconds, so we
   expect to observe no replies. Termination should be cut short by the drain timeout, which means
   that we should have results in approximately execution duration + drain timeout = 35 seconds.
-  (the pool drain timeout is hard coded to 5 seconds as of writing this). 
+  (the pool drain timeout is hard coded to 5 seconds as of writing this).
   If drain timeout is reached, a message will be logged to the user.
   """
   parsed_json, logs = https_test_server_fixture.runNighthawkClient([


### PR DESCRIPTION
Changed the test to check logs for evidence of drain timeout. 

Also increased the execution time to 30 seconds as 3 seconds  has historically been short in CI and might risk no client being sent out. 

Note that this approach isn't perfect. We are relying on the evidence of logs which is brittle and we are relying on always hitting the drain timeout. It is possible that the pool drains fast enough to not produce the log message. 

closes #771 

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>