### PR TITLE
Increase duration of TLS tests and remove h2 deprecation warning

### DIFF
--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -350,10 +350,12 @@ def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2)
       "ECDHE-RSA-AES128-SHA",
       "ECDHE-RSA-CHACHA20-POLY1305",
   ]:
-    parsed_json, _ = https_test_server_fixture.runNighthawkClient((["--h2"] if use_h2 else []) + [
-        "--termination-predicate", "benchmark.http_2xx:0", cli_parameter, json_template % cipher,
-        https_test_server_fixture.getTestServerRootUri()
-    ])
+    parsed_json, _ = https_test_server_fixture.runNighthawkClient(
+        (["--protocol", "http2"] if use_h2 else []) + [
+            "--duration", "10", "--termination-predicate", "benchmark.http_2xx:0", cli_parameter,
+            json_template % cipher,
+            https_test_server_fixture.getTestServerRootUri()
+        ])
     counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
     asserts.assertCounterGreaterEqual(counters, "ssl.ciphers.%s" % cipher, 1)
 


### PR DESCRIPTION
Tests are failing without sending traffic. Increasing the duration of the test to allow more time for nighthawk to get started. In an ideal environment, increase duration should not increase the necessary test time as nighthawk should terminate once it receives a single 2xx response.

closes #775 

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>