### PR TITLE
Disable test_http_request_release_timing in circle CI 

### DIFF
--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -684,7 +684,9 @@ def duration_parameterization_fixture(request):
   yield param
 
 
-@pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable in sanitizer runs")
+@pytest.mark.skipif(utility.isSanitizerRun() or utility.isRunningInCircleCi(),
+                    reason="Unstable in sanitizer runs. "
+                    "Unstable in CircleCI. See https://github.com/envoyproxy/nighthawk/issues/773")
 def test_http_request_release_timing(http_test_server_fixture, qps_parameterization_fixture,
                                      duration_parameterization_fixture):
   """Test latency-sample-, query- and reply- counts in various configurations."""


### PR DESCRIPTION
Disabling the test due to #773. Proper fix would entail fixing execution_duration code to properly measure time where traffic was generated.

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>