### PR TITLE
Relax connection constraints on H1 tests to reduce flakiness

### DIFF
--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -36,7 +36,8 @@ def test_http_h1(http_test_server_fixture):
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
   asserts.assertCounterEqual(counters, "upstream_cx_rx_bytes_total", 3400)
-  # # of upstream_cx > # of backend connections is possible for H1, as new connections will spawn if the existing clients cannot keep up with the RPS.
+  # It is possible that the # of upstream_cx > # of backend connections for H1
+  # as new connections will spawn if the existing clients cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_total", 1)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_tx_bytes_total", 500)
@@ -197,7 +198,7 @@ def test_http_concurrency(http_test_server_fixture):
   """Test that concurrency acts like a multiplier."""
   parsed_json, _ = http_test_server_fixture.runNighthawkClient([
       "--concurrency 4 --rps 100 --connections 1", "--duration", "100", "--termination-predicate",
-      "benchmark.http_2xx:24", "--prefetch-connections",
+      "benchmark.http_2xx:24",
       http_test_server_fixture.getTestServerRootUri()
   ])
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
@@ -205,7 +206,9 @@ def test_http_concurrency(http_test_server_fixture):
   # Quite a loose expectation, but this may fluctuate depending on server load.
   # Ideally we'd see 4 workers * 5 rps * 5s = 100 requests total
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 100)
-  # # of upstream_cx > # of backend connections is possible for H1, as new connections will spawn if the existing clients cannot keep up with the RPS.
+  # Assert that we at least have 1 connection for each event loop (1*4). It is possible that the # of
+  # upstream_cx > # of backend connections for H1 as new connections will spawn if the existing clients
+  # cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 4)
 
 
@@ -224,7 +227,8 @@ def test_https_h1(https_test_server_fixture):
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
   asserts.assertCounterEqual(counters, "upstream_cx_rx_bytes_total", 3400)
-  # # of upstream_cx > # of backend connections is possible for H1, as new connections will spawn if the existing clients cannot keep up with the RPS.
+  # It is possible that the # of upstream_cx > # of backend connections for H1 as new connections
+  # will spawn if the existing clients cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_total", 1)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_tx_bytes_total", 500)
@@ -541,14 +545,8 @@ def test_multiple_backends_http_h1(multi_http_test_server_fixture):
   checks statistics from both client and server.
   """
   nighthawk_client_args = [
-      "--multi-target-path",
-      "/",
-      "--duration",
-      "100",
-      "--termination-predicate",
-      "benchmark.http_2xx:24",
-      "--connections",
-      "3",
+      "--multi-target-path", "/", "--duration", "100", "--termination-predicate",
+      "benchmark.http_2xx:24"
   ]
   for uri in multi_http_test_server_fixture.getAllTestServerRootUris():
     nighthawk_client_args.append("--multi-target-endpoint")
@@ -558,7 +556,9 @@ def test_multiple_backends_http_h1(multi_http_test_server_fixture):
 
   counters = multi_http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
-  # # of upstream_cx > # of backend connections is possible for H1, as new connections will spawn if the existing clients cannot keep up with the RPS.
+  # Assert that we at least have 1 connection per backend. It is possible that
+  # the # of upstream_cx > # of backend connections for H1 as new connections
+  # will spawn if the existing clients cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 3)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_total", 3)
   asserts.assertCounterGreater(counters, "upstream_cx_rx_bytes_total", 0)
@@ -583,7 +583,7 @@ def test_multiple_backends_https_h1(multi_https_test_server_fixture):
   """
   nighthawk_client_args = [
       "--multi-target-use-https", "--multi-target-path", "/", "--duration", "100",
-      "--termination-predicate", "benchmark.http_2xx:24", "--connections", "3"
+      "--termination-predicate", "benchmark.http_2xx:24"
   ]
   for uri in multi_https_test_server_fixture.getAllTestServerRootUris():
     nighthawk_client_args.append("--multi-target-endpoint")
@@ -594,7 +594,9 @@ def test_multiple_backends_https_h1(multi_https_test_server_fixture):
   counters = multi_https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterEqual(counters, "benchmark.http_2xx", 25)
   asserts.assertCounterGreater(counters, "upstream_cx_rx_bytes_total", 0)
-  # # of upstream_cx > # of backend connections is possible for H1, as new connections will spawn if the existing clients cannot keep up with the RPS.
+  # Assert that we at least have 1 connection per backend. It is possible that
+  # the # of upstream_cx > # of backend connections for H1 as new connections
+  # will spawn if the existing clients cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 3)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_total", 3)
   asserts.assertCounterGreater(counters, "upstream_cx_tx_bytes_total", 0)
@@ -621,7 +623,8 @@ def test_https_h1_sni(https_test_server_fixture):
   ])
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterGreaterEqual(counters, "benchmark.http_2xx", 1)
-  # # of upstream_cx > # of backend connections is possible for H1, as new connections will spawn if the existing clients cannot keep up with the RPS.
+  # It is possible that the # of upstream_cx > # of backend connections for H1
+  # as new connections will spawn if the existing clients cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertCounterGreaterEqual(counters, "ssl.handshake", 1)
 
@@ -639,7 +642,8 @@ def test_https_h1_sni(https_test_server_fixture):
 
   counters = https_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
   asserts.assertCounterGreaterEqual(counters, "benchmark.http_2xx", 1)
-  # # of upstream_cx > # of backend connections is possible for H1, as new connections will spawn if the existing clients cannot keep up with the RPS.
+  # It is possible that the # of upstream_cx > # of backend connections for H1
+  # as new connections will spawn if the existing clients cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertNotIn("ssl.handshake", counters)
 

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -539,7 +539,7 @@ def test_multiple_backends_http_h1(multi_http_test_server_fixture):
   """
   nighthawk_client_args = [
       "--multi-target-path", "/", "--duration", "100", "--termination-predicate",
-      "benchmark.http_2xx:24"
+      "benchmark.http_2xx:24", "--connections", "3"
   ]
   for uri in multi_http_test_server_fixture.getAllTestServerRootUris():
     nighthawk_client_args.append("--multi-target-endpoint")
@@ -573,7 +573,7 @@ def test_multiple_backends_https_h1(multi_https_test_server_fixture):
   """
   nighthawk_client_args = [
       "--multi-target-use-https", "--multi-target-path", "/", "--duration", "100",
-      "--termination-predicate", "benchmark.http_2xx:24"
+      "--termination-predicate", "benchmark.http_2xx:24", "--connections", "3"
   ]
   for uri in multi_https_test_server_fixture.getAllTestServerRootUris():
     nighthawk_client_args.append("--multi-target-endpoint")

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -41,7 +41,7 @@ def test_http_h1(http_test_server_fixture):
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_total", 1)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_tx_bytes_total", 500)
-  asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 1)
+  asserts.assertCounterGreaterEqual(counters, "upstream_rq_pending_total", 1)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 1)
 
@@ -232,7 +232,7 @@ def test_https_h1(https_test_server_fixture):
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 1)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_total", 1)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_tx_bytes_total", 500)
-  asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 1)
+  asserts.assertCounterGreaterEqual(counters, "upstream_rq_pending_total", 1)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "ssl.ciphers.ECDHE-RSA-AES128-GCM-SHA256", 1)
   asserts.assertCounterEqual(counters, "ssl.curves.X25519", 1)
@@ -561,9 +561,9 @@ def test_multiple_backends_http_h1(multi_http_test_server_fixture):
   # will spawn if the existing clients cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 3)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_total", 3)
+  asserts.assertCounterGreaterEqual(counters, "upstream_rq_pending_total", 3)
   asserts.assertCounterGreater(counters, "upstream_cx_rx_bytes_total", 0)
   asserts.assertCounterGreater(counters, "upstream_cx_tx_bytes_total", 0)
-  asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 3)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 3)
   for parsed_server_json in multi_http_test_server_fixture.getAllTestServerStatisticsJsons():
@@ -599,8 +599,8 @@ def test_multiple_backends_https_h1(multi_https_test_server_fixture):
   # will spawn if the existing clients cannot keep up with the RPS.
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_http1_total", 3)
   asserts.assertCounterGreaterEqual(counters, "upstream_cx_total", 3)
+  asserts.assertCounterGreaterEqual(counters, "upstream_rq_pending_total", 3)
   asserts.assertCounterGreater(counters, "upstream_cx_tx_bytes_total", 0)
-  asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 3)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 3)
   total_2xx = 0

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -603,13 +603,11 @@ def test_multiple_backends_https_h1(multi_https_test_server_fixture):
   asserts.assertCounterGreater(counters, "upstream_cx_tx_bytes_total", 0)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 3)
-  total_2xx = 0
-  for parsed_server_json in multi_https_test_server_fixture.getAllTestServerStatisticsJsons():
-    single_2xx = multi_https_test_server_fixture.getServerStatFromJson(
+  for parsed_server_json in multi_http_test_server_fixture.getAllTestServerStatisticsJsons():
+    single_2xx = multi_http_test_server_fixture.getServerStatFromJson(
         parsed_server_json, "http.ingress_http.downstream_rq_2xx")
-    asserts.assertBetweenInclusive(single_2xx, 8, 9)
-    total_2xx += single_2xx
-  asserts.assertBetweenInclusive(total_2xx, 24, 25)
+    # Confirm that each backend receives some traffic
+    asserts.assertGreaterEqual(single_2xx, 1)
 
 
 @pytest.mark.parametrize('server_config',

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -603,8 +603,8 @@ def test_multiple_backends_https_h1(multi_https_test_server_fixture):
   asserts.assertCounterGreater(counters, "upstream_cx_tx_bytes_total", 0)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 3)
-  for parsed_server_json in multi_http_test_server_fixture.getAllTestServerStatisticsJsons():
-    single_2xx = multi_http_test_server_fixture.getServerStatFromJson(
+  for parsed_server_json in multi_https_test_server_fixture.getAllTestServerStatisticsJsons():
+    single_2xx = multi_https_test_server_fixture.getServerStatFromJson(
         parsed_server_json, "http.ingress_http.downstream_rq_2xx")
     # Confirm that each backend receives some traffic
     asserts.assertGreaterEqual(single_2xx, 1)


### PR DESCRIPTION
Some H1 tests currently fail due to having more connections than expected.  

Example: https://circleci.com/api/v1.1/project/github/envoyproxy/nighthawk/30668/output/102/0?file=true&allocation-id=61aa3f06f34d7762fa437b4c-0-build%2F25476C95

Relaxing constraints as for H1, new connections maybe created if clients cannot keep up with the existing request rate. 
See https://github.com/tomjzzhang/envoy/blob/a6fc192705b7a55ebef5b534cfac522a6c54af83/source/common/conn_pool/conn_pool_base.cc#L245

Also relaxing constraints in test_multiple_backends_https_h1 to match test_multiple_backends_http_h1 as fully equitable round robin is not guaranteed by nighthawk. 

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>