### PR TITLE
A collection of fixes that simplify import of Nighthawk into Google.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,6 +6,8 @@ load(
 
 licenses(["notice"])  # Apache 2
 
+exports_files(["LICENSE"])
+
 envoy_package()
 
 filegroup(

--- a/api/request_source/BUILD
+++ b/api/request_source/BUILD
@@ -24,8 +24,8 @@ api_cc_py_proto_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//api/client:base",
         "@envoy_api//envoy/config/core/v3:pkg",
-        "@nighthawk//api/client:base",
     ],
 )
 

--- a/include/nighthawk/distributor/BUILD
+++ b/include/nighthawk/distributor/BUILD
@@ -13,7 +13,7 @@ envoy_basic_cc_library(
     hdrs = [
         "nighthawk_distributor_client.h",
     ],
-    include_prefix = "nighthawk/common",
+    include_prefix = "nighthawk/distributor",
     deps = [
         "//api/distributor:distributor_cc_proto",
         "//api/distributor:distributor_grpc_lib",

--- a/source/distributor/nighthawk_distributor_client_impl.h
+++ b/source/distributor/nighthawk_distributor_client_impl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "nighthawk/common/nighthawk_distributor_client.h"
+#include "nighthawk/distributor/nighthawk_distributor_client.h"
 
 namespace Nighthawk {
 

--- a/test/server/configuration_test.cc
+++ b/test/server/configuration_test.cc
@@ -106,7 +106,7 @@ nighthawk::server::ResponseOptions createTestConfiguration(EnvoyApiVersion api_v
     header3->mutable_header()->set_key("key1");
     header3->mutable_header()->set_value("header3_value");
     if (add_mode == AppendOnDuplicateKey) {
-      header3->mutable_append()->set_value("true");
+      header3->mutable_append()->set_value(true);
     }
   } else if (api_version == EnvoyApiV3) {
     envoy::config::core::v3::HeaderValueOption* header1 = configuration.add_v3_response_headers();
@@ -121,7 +121,7 @@ nighthawk::server::ResponseOptions createTestConfiguration(EnvoyApiVersion api_v
     header3->mutable_header()->set_key("key1");
     header3->mutable_header()->set_value("header3_value");
     if (add_mode == AppendOnDuplicateKey) {
-      header3->mutable_append()->set_value("true");
+      header3->mutable_append()->set_value(true);
     }
   }
   return configuration;


### PR DESCRIPTION
Done here:

- exporting the main LICENSES file.
- not referring to Nighthawk's code as if it was external.
- fixing bad include prefix and import of Nighthawk's distributor API.
- removing implicit conversions of strings to booleans.