### PR TITLE
Relax unnecessarily strict counter assertion

### DIFF
--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -67,7 +67,7 @@ def test_http_h1(http_test_server_fixture):
   asserts.assertEqual(
       int(global_histograms["benchmark_http_client.response_header_size"]["raw_pstdev"]), 0)
 
-  asserts.assertEqual(len(counters), 12)
+  asserts.assertGreaterEqual(len(counters), 12)
 
 
 def _mini_stress_test(fixture, args):
@@ -191,7 +191,7 @@ def test_http_h2(http_test_server_fixture):
   asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 1)
   asserts.assertCounterEqual(counters, "upstream_rq_total", 25)
   asserts.assertCounterEqual(counters, "default.total_match_count", 1)
-  asserts.assertEqual(len(counters), 12)
+  asserts.assertGreaterEqual(len(counters), 12)
 
 
 def test_http_concurrency(http_test_server_fixture):


### PR DESCRIPTION
Noticed that some runs are failing due to not receiving the expected amount of counters. 

Example:
https://app.circleci.com/pipelines/github/envoyproxy/nighthawk/3411/workflows/4f3cc2a5-8f41-4cf0-b75c-183c63a1eb8d/jobs/31198

Expected 12, Received 14.  The two unaccounted counters are benchmark.pool_overflow and upstream_rq_pending_overflow which is an acceptable outcome of the test. Therefore relaxing test constraints. 

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>