### PR TITLE
Update envoy to 7174c14 (January 19, 2022).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,6 +35,7 @@ common --experimental_allow_tags_propagation
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
 build:linux --copt=-fPIC
+build:linux --copt=-Wno-deprecated-declarations
 build:linux --cxxopt=-std=c++17
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ USAGE:
 
 bazel-bin/nighthawk_client  [--latency-response-header-name <string>]
 [--stats-flush-interval <uint32_t>]
-[--stats-sinks <string>] ...
-[--no-duration] [--simple-warmup]
+[--stats-sinks <string>] ... [--no-duration]
+[--simple-warmup]
 [--request-source-plugin-config <string>]
 [--request-source <uri format>] [--label
 <string>] ... [--multi-target-use-https]

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 ENVOY_COMMIT = "7174c148a0763f2ed5863c3ab341d4a9ce01c54b"  # Jan 19, 2022
-ENVOY_SHA = ""
+ENVOY_SHA = "57d3c09f5ede76dbe12773f8b171434a619abfefadc345ac8c4b0fb6e65941fd"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "f67be30ff5d031d9faec094bb056196f2d3cbde1"  # Jan 10, 2022
-ENVOY_SHA = "5eed7189fb315e349b443a1cf86178e14f9679268d27d12532330480dedd760d"
+ENVOY_COMMIT = "7174c148a0763f2ed5863c3ab341d4a9ce01c54b"  # Jan 19, 2022
+ENVOY_SHA = ""
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
- syncing `.bazelrc` from Envoy (https://github.com/envoyproxy/envoy/pull/19468).
- no changes in `.bazelversion`, `run_envoy_docker.sh`, `gen_compilation_database.py`.

Signed-off-by: Jakub Sobon <mumak@google.com>