### PR TITLE
Update Envoy to aa29229 (Jan 31, 2022)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "4b38a99f385baebc0de5ead44c11a45ca8cf61f5"  # Jan 25, 2022
-ENVOY_SHA = "c4c45b128319c7e8f0ec372797e6e1947f93e8d24d77d2dcabbd73fbf15cb392"
+ENVOY_COMMIT = "aa29229b144ec9b59606e81f730eae143c9282a4"  # Jan 31, 2022
+ENVOY_SHA = "8e23ac6fa359565cccf4c4548057dcdf3e7be972a6c4710b6531a9413fd9c31d"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
This was a simple update. 

Confirmed that Envoy's .bazelrc is unchanged since `commit 4f58f018007d9752b67e9b00c5713f862a4fa77c Date:   Thu Jan 13 15:59:27 2022 -0500`.

Signed-off-by: eric846 <56563761+eric846@users.noreply.github.com>