### PR TITLE
Support specifying a custom upstream bind config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ Time interval (in seconds) between flushes to configured stats sinks.
 Default: 5.
 
 --stats-sinks <string>  (accepted multiple times)
-Stats sinks (in json or compact yaml) where Nighthawk metrics will be
-flushed. This argument is intended to be specified multiple times.
-Example (json): {name:"envoy.stat_sinks.statsd"
+Stats sinks (in json) where Nighthawk metrics will be flushed. This
+argument is intended to be specified multiple times. Example (json):
+{name:"envoy.stat_sinks.statsd"
 ,typed_config:{"@type":"type.googleapis.com/envoy.config.metrics.v3.St
 atsdSink",tcp_cluster_name:"statsd"}}
 
@@ -122,8 +122,8 @@ Nighthawk writes to the output. Default is false.
 --request-source-plugin-config <string>
 [Request
 Source](https://github.com/envoyproxy/nighthawk/blob/main/docs/root/ov
-erview.md#requestsource) plugin configuration in json or compact yaml.
-Mutually exclusive with --request-source. Example (json):
+erview.md#requestsource) plugin configuration in json. Mutually
+exclusive with --request-source. Example (json):
 {name:"nighthawk.stub-request-source-plugin"
 ,typed_config:{"@type":"type.googleapis.com/nighthawk.request_source.S
 tubPluginConfig",test_value:"3"}}
@@ -208,25 +208,22 @@ Max pending requests (default: 0, no client side queuing. Specifying
 any other value will allow client-side queuing of requests).
 
 --transport-socket <string>
-Transport socket configuration in json or compact yaml. Mutually
-exclusive with --tls-context. Example (json):
-{name:"envoy.transport_sockets.tls"
+Transport socket configuration in json. Mutually exclusive with
+--tls-context. Example (json): {name:"envoy.transport_sockets.tls"
 ,typed_config:{"@type":"type.googleapis.com/envoy.extensions.transport
 _sockets.tls.v3.UpstreamTlsContext"
 ,common_tls_context:{tls_params:{cipher_suites:["-ALL:ECDHE-RSA-AES128
 -SHA"]}}}}
 
 --upstream-bind-config <string>
-BindConfig in json or compact yaml. If specified, this configuration
-is used to bind newly established upstream connections. Allows
-selecting the source address, port and socket options used when
-sending requests. Example (json): {source_address:{address:"127.0.0.1"
-,port_value:0}}
+BindConfig in json. If specified, this configuration is used to bind
+newly established upstream connections. Allows selecting the source
+address, port and socket options used when sending requests. Example
+(json): {source_address:{address:"127.0.0.1",port_value:0}}
 
 --tls-context <string>
-DEPRECATED, use --transport-socket instead. Tls context configuration
-in json or compact yaml. Mutually exclusive with --transport-socket.
-Example (json):
+DEPRECATED, use --transport-socket instead. TlS context configuration
+in json. Mutually exclusive with --transport-socket. Example (json):
 {common_tls_context:{tls_params:{cipher_suites:["-ALL:ECDHE-RSA-AES128
 -SHA"]}}}
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ format>] [--sequencer-idle-strategy <spin
 <uint32_t>] [--max-active-requests
 <uint32_t>] [--max-pending-requests
 <uint32_t>] [--transport-socket <string>]
+[--upstream-bind-config <string>]
 [--tls-context <string>]
 [--request-body-size <uint32_t>]
 [--request-header <string>] ...
@@ -214,6 +215,13 @@ exclusive with --tls-context. Example (json):
 _sockets.tls.v3.UpstreamTlsContext"
 ,common_tls_context:{tls_params:{cipher_suites:["-ALL:ECDHE-RSA-AES128
 -SHA"]}}}}
+
+--upstream-bind-config <string>
+BindConfig in json or compact yaml. If specified, this configuration
+is used to bind newly established upstream connections. Allows
+selecting the source address, port and socket options used when
+sending requests. Example (json): {source_address:{address:"127.0.0.1"
+,port_value:0}}
 
 --tls-context <string>
 DEPRECATED, use --transport-socket instead. Tls context configuration

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -5,6 +5,7 @@ package nighthawk.client;
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
+import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/metrics/v3/stats.proto";
 import "envoy/extensions/transport_sockets/tls/v3/cert.proto";
@@ -126,7 +127,7 @@ message Protocol {
 
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
-// Highest unused number is 109.
+// Highest unused number is 110.
 message CommandLineOptions {
   // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
@@ -249,8 +250,14 @@ message CommandLineOptions {
 
   // Label. Allows specifying multiple labels which will be persisted in structured output formats.
   repeated string labels = 28;
-  // TransportSocket configuration to use in every request
+
+  // Optional configuration used to bind newly established upstream connections.
+  // Allows selecting the source address, port and socket options used when sending
+  // requests.
+  envoy.config.core.v3.BindConfig upstream_bind_config = 109;
+  // TransportSocket configuration to use in every request.
   envoy.config.core.v3.TransportSocket transport_socket = 27;
+
   // Perform a simple single warmup request (per worker) before starting
   // execution. Note that this will be reflected in the counters that
   // Nighthawk writes to the output. Default is false.

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -8,6 +8,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/core/v3/address.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/metrics/v3/stats.pb.h"
 #include "envoy/http/protocol.h"
@@ -52,6 +53,8 @@ public:
   virtual uint32_t requestBodySize() const PURE;
   virtual const envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&
   tlsContext() const PURE;
+  virtual const absl::optional<envoy::config::core::v3::BindConfig>&
+  upstreamBindConfig() const PURE;
   virtual const absl::optional<envoy::config::core::v3::TransportSocket>&
   transportSocket() const PURE;
   virtual uint32_t maxPendingRequests() const PURE;

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -150,14 +150,14 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::ValueArg<std::string> tls_context(
       "", "tls-context",
       "DEPRECATED, use --transport-socket instead. "
-      "Tls context configuration in json or compact yaml. "
+      "TlS context configuration in json. "
       "Mutually exclusive with --transport-socket. Example (json): "
       "{common_tls_context:{tls_params:{cipher_suites:[\"-ALL:ECDHE-RSA-AES128-SHA\"]}}}",
       false, "", "string", cmd);
 
   TCLAP::ValueArg<std::string> upstream_bind_config(
       "", "upstream-bind-config",
-      "BindConfig in json or compact yaml. If specified, this configuration is used to bind newly "
+      "BindConfig in json. If specified, this configuration is used to bind newly "
       "established upstream connections. "
       "Allows selecting the source address, port and socket options used when sending requests. "
       "Example (json): "
@@ -166,7 +166,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
 
   TCLAP::ValueArg<std::string> transport_socket(
       "", "transport-socket",
-      "Transport socket configuration in json or compact yaml. "
+      "Transport socket configuration in json. "
       "Mutually exclusive with --tls-context. Example (json): "
       "{name:\"envoy.transport_sockets.tls\",typed_config:{"
       "\"@type\":\"type.googleapis.com/"
@@ -302,7 +302,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "", "request-source-plugin-config",
       "[Request "
       "Source](https://github.com/envoyproxy/nighthawk/blob/main/docs/root/"
-      "overview.md#requestsource) plugin configuration in json or compact yaml. "
+      "overview.md#requestsource) plugin configuration in json. "
       "Mutually exclusive with --request-source. Example (json): "
       "{name:\"nighthawk.stub-request-source-plugin\",typed_config:{"
       "\"@type\":\"type.googleapis.com/nighthawk.request_source.StubPluginConfig\","
@@ -321,7 +321,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       cmd);
   TCLAP::MultiArg<std::string> stats_sinks(
       "", "stats-sinks",
-      "Stats sinks (in json or compact yaml) where Nighthawk "
+      "Stats sinks (in json) where Nighthawk "
       "metrics will be flushed. This argument is intended to "
       "be specified multiple times. Example (json): "
       "{name:\"envoy.stat_sinks.statsd\",typed_config:{\"@type\":\"type."

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -54,6 +54,9 @@ public:
   tlsContext() const override {
     return tls_context_;
   };
+  const absl::optional<envoy::config::core::v3::BindConfig>& upstreamBindConfig() const override {
+    return upstream_bind_config_;
+  }
   const absl::optional<envoy::config::core::v3::TransportSocket>& transportSocket() const override {
     return transport_socket_;
   }
@@ -128,6 +131,7 @@ private:
   std::vector<std::string> request_headers_;
   uint32_t request_body_size_{0};
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context_;
+  absl::optional<envoy::config::core::v3::BindConfig> upstream_bind_config_;
   absl::optional<envoy::config::core::v3::TransportSocket> transport_socket_;
   absl::optional<envoy::config::core::v3::TypedExtensionConfig> request_source_plugin_config_;
 

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -256,6 +256,11 @@ absl::StatusOr<Bootstrap> createBootstrapConfiguration(
   }
   bootstrap.mutable_stats_flush_interval()->set_seconds(options.statsFlushInterval());
 
+  if (options.upstreamBindConfig().has_value()) {
+    *bootstrap.mutable_cluster_manager()->mutable_upstream_bind_config() =
+        options.upstreamBindConfig().value();
+  }
+
   return bootstrap;
 }
 

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -31,6 +31,8 @@ public:
   MOCK_METHOD(uint32_t, requestBodySize, (), (const, override));
   MOCK_METHOD(envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&, tlsContext, (),
               (const, override));
+  MOCK_METHOD(absl::optional<envoy::config::core::v3::BindConfig>&, upstreamBindConfig, (),
+              (const, override));
   MOCK_METHOD(absl::optional<envoy::config::core::v3::TransportSocket>&, transportSocket, (),
               (const, override));
   MOCK_METHOD(uint32_t, maxPendingRequests, (), (const, override));


### PR DESCRIPTION
Allows Nighthawk users to specify a custom upstream bind config, i.e. to indicate the source address, port and socket options to be used when sending requests.

Signed-off-by: Jakub Sobon <mumak@google.com>