### PR TITLE
fix nighthawk crash error when run server with concurrency >1

### DIFF
--- a/source/server/http_dynamic_delay_filter.cc
+++ b/source/server/http_dynamic_delay_filter.cc
@@ -57,7 +57,7 @@ HttpDynamicDelayDecoderFilter::decodeHeaders(Envoy::Http::RequestHeaderMap& head
 
 Envoy::Http::FilterDataStatus
 HttpDynamicDelayDecoderFilter::decodeData(Envoy::Buffer::Instance& buffer, bool end_stream) {
-  if (effective_config_.ok()) {
+  if (!effective_config_.ok()) {
     if (end_stream) {
       config_->validateOrSendError(effective_config_, *decoder_callbacks_);
       return Envoy::Http::FilterDataStatus::StopIterationNoBuffer;

--- a/source/server/http_dynamic_delay_filter.cc
+++ b/source/server/http_dynamic_delay_filter.cc
@@ -40,14 +40,14 @@ void HttpDynamicDelayDecoderFilter::onDestroy() {
 Envoy::Http::FilterHeadersStatus
 HttpDynamicDelayDecoderFilter::decodeHeaders(Envoy::Http::RequestHeaderMap& headers,
                                              bool end_stream) {
-  config_->computeEffectiveConfiguration(headers);
-  if (config_->getEffectiveConfiguration().ok()) {
-    const absl::optional<int64_t> delay_ms = computeDelayMs(
-        *config_->getEffectiveConfiguration().value(), config_->approximateFilterInstances());
+  effective_config_ = config_->computeEffectiveConfiguration(headers);
+  if (effective_config_.ok()) {
+    const absl::optional<int64_t> delay_ms =
+        computeDelayMs(*effective_config_.value(), config_->approximateFilterInstances());
     maybeRequestFaultFilterDelay(delay_ms, headers);
   } else {
     if (end_stream) {
-      config_->validateOrSendError(*decoder_callbacks_);
+      config_->validateOrSendError(effective_config_, *decoder_callbacks_);
       return Envoy::Http::FilterHeadersStatus::StopIteration;
     }
     return Envoy::Http::FilterHeadersStatus::Continue;
@@ -57,9 +57,9 @@ HttpDynamicDelayDecoderFilter::decodeHeaders(Envoy::Http::RequestHeaderMap& head
 
 Envoy::Http::FilterDataStatus
 HttpDynamicDelayDecoderFilter::decodeData(Envoy::Buffer::Instance& buffer, bool end_stream) {
-  if (!config_->getEffectiveConfiguration().ok()) {
+  if (effective_config_.ok()) {
     if (end_stream) {
-      config_->validateOrSendError(*decoder_callbacks_);
+      config_->validateOrSendError(effective_config_, *decoder_callbacks_);
       return Envoy::Http::FilterDataStatus::StopIterationNoBuffer;
     }
     return Envoy::Http::FilterDataStatus::Continue;

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -160,6 +160,7 @@ public:
 
 private:
   const HttpDynamicDelayDecoderFilterConfigSharedPtr config_;
+  absl::StatusOr<EffectiveFilterConfigurationPtr> effective_config_;
   Envoy::Http::StreamDecoderFilterCallbacks* decoder_callbacks_;
   bool destroyed_{false};
 };

--- a/source/server/http_filter_config_base.h
+++ b/source/server/http_filter_config_base.h
@@ -42,28 +42,22 @@ public:
    * any configuration provided via request headers.
    *
    * @param request_headers Full set of request headers to be inspected for configuration.
+   * @return const absl::StatusOr<EffectiveFilterConfigurationPtr> The effective configuration, or
+   * an error status.
    */
-  void computeEffectiveConfiguration(const Envoy::Http::RequestHeaderMap& request_headers);
+  const absl::StatusOr<EffectiveFilterConfigurationPtr>
+  computeEffectiveConfiguration(const Envoy::Http::RequestHeaderMap& request_headers);
 
   /**
    * Send an error reply based on status of the effective configuration. For example, when dynamic
    * configuration delivered via request headers could not be parsed or was out of spec.
    *
+   * @param effective_config Effective filter configuration.
    * @param decoder_callbacks Decoder used to generate the reply.
    * @return true iff an error reply was generated.
    */
-  bool validateOrSendError(Envoy::Http::StreamDecoderFilterCallbacks& decoder_callbacks) const;
-
-  /**
-   * @brief Get the effective configuration. Depending on state ,this could be one of static
-   * configuration, dynamic configuration, or an error status.
-   *
-   * @return const absl::StatusOr<EffectiveFilterConfigurationPtr> The effective configuration, or
-   * an error status.
-   */
-  const absl::StatusOr<EffectiveFilterConfigurationPtr> getEffectiveConfiguration() const {
-    return effective_config_;
-  }
+  bool validateOrSendError(absl::StatusOr<EffectiveFilterConfigurationPtr>& effective_config,
+                           Envoy::Http::StreamDecoderFilterCallbacks& decoder_callbacks) const;
 
   /**
    * @return absl::string_view Name of the filter that constructed this instance.
@@ -73,7 +67,6 @@ public:
 private:
   const std::string filter_name_;
   const std::shared_ptr<nighthawk::server::ResponseOptions> server_config_;
-  absl::StatusOr<EffectiveFilterConfigurationPtr> effective_config_;
 };
 
 } // namespace Server

--- a/source/server/http_test_server_filter.h
+++ b/source/server/http_test_server_filter.h
@@ -36,6 +36,7 @@ public:
 private:
   void sendReply(const nighthawk::server::ResponseOptions& options);
   const HttpTestServerDecoderFilterConfigSharedPtr config_;
+  absl::StatusOr<EffectiveFilterConfigurationPtr> effective_config_;
   Envoy::Http::StreamDecoderFilterCallbacks* decoder_callbacks_;
   absl::optional<std::string> request_headers_dump_;
 };

--- a/source/server/http_time_tracking_filter.h
+++ b/source/server/http_time_tracking_filter.h
@@ -68,6 +68,7 @@ public:
 
 private:
   const HttpTimeTrackingFilterConfigSharedPtr config_;
+  absl::StatusOr<EffectiveFilterConfigurationPtr> effective_config_;
   uint64_t last_request_delta_ns_;
 };
 

--- a/test/server/http_test_server_filter_integration_test.cc
+++ b/test/server/http_test_server_filter_integration_test.cc
@@ -258,8 +258,10 @@ TEST(HttpTestServerDecoderFilterTest, HeaderMerge) {
       std::make_shared<Server::HttpTestServerDecoderFilterConfig>(initial_options);
   Server::HttpTestServerDecoderFilter f(config);
 
+  Envoy::Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/"}, {":authority", "test.com"}, {"foo", "bar2"}};
   absl::StatusOr<Server::EffectiveFilterConfigurationPtr> options_or =
-      config->getEffectiveConfiguration();
+      config->computeEffectiveConfiguration(request_headers);
   ASSERT_TRUE(options_or.ok());
   nighthawk::server::ResponseOptions options = *options_or.value();
   EXPECT_EQ(1, options.response_headers_size());


### PR DESCRIPTION
Signed-off-by: wbpcode <wbphub@live.com>

To address #808.

The filter config is shared by mutiple filter instances in different workers. In the original logic, the `computeEffectiveConfiguration` may updates the `effective_config_` field of filter config. This operations are unsafe for mutiple threads scenarios.