### PR TITLE
Simplify locking related to the start of a benchmark.

### DIFF
--- a/source/client/service_impl.cc
+++ b/source/client/service_impl.cc
@@ -13,16 +13,6 @@ namespace Nighthawk {
 namespace Client {
 
 void ServiceImpl::handleExecutionRequest(const nighthawk::client::ExecutionRequest& request) {
-  std::unique_ptr<Envoy::Thread::LockGuard> busy_lock;
-  {
-    // Lock accepted_lock, in case we get here before accepted_event_.wait() is entered.
-    auto accepted_lock = std::make_unique<Envoy::Thread::LockGuard>(accepted_lock_);
-    // Acquire busy_lock_, and signal that we did so, allowing the service to continue
-    // processing inbound requests on the stream.
-    busy_lock = std::make_unique<Envoy::Thread::LockGuard>(busy_lock_);
-    accepted_event_.notifyOne();
-  }
-
   nighthawk::client::ExecutionResponse response;
   OptionsPtr options;
   try {
@@ -70,10 +60,14 @@ void ServiceImpl::handleExecutionRequest(const nighthawk::client::ExecutionReque
   }
   *(response.mutable_output()) = output_collector.toProto();
   process->shutdown();
-  // We release before writing the response to avoid a race with the client's follow up request
-  // coming in before we release the lock, which would lead up to us declining service when
-  // we should not.
-  busy_lock.reset();
+  // We indicate the benchmark ended before writing the response to avoid a race
+  // with the client's follow up request coming in which might be the request to
+  // start the next benchmark. This only applies if the client chooses to run
+  // multiple benchmarks within the same gRPC stream.
+  {
+    Envoy::Thread::LockGuard lock(lock_);
+    benchmark_in_progress_ = false;
+  }
   writeResponse(response);
 }
 
@@ -108,24 +102,22 @@ grpc::Status ServiceImpl::ExecutionStream(
 
   while (stream->Read(&request)) {
     ENVOY_LOG(debug, "Read ExecutionRequest data {}", request.DebugString());
-    if (request.has_start_request()) {
-      // If busy_lock_ is held we can't start a new benchmark run because one is active already.
-      if (busy_lock_.tryLock()) {
-        busy_lock_.unlock();
-        Envoy::Thread::LockGuard accepted_lock(accepted_lock_);
-        // We pass in std::launch::async to avoid lazy evaluation, as we want this to run
-        // asap. See: https://en.cppreference.com/w/cpp/thread/async
-        future_ = std::future<void>(
-            std::async(std::launch::async, &ServiceImpl::handleExecutionRequest, this, request));
-        // Block until the thread associated to the future has acquired busy_lock_
-        accepted_event_.wait(accepted_lock_);
-      } else {
+    if (!request.has_start_request()) {
+      return finishGrpcStream(false, "Only requests with start_request are supported for now.");
+    }
+
+    {
+      // Critical section that holds lock_ in order to check if we are busy.
+      Envoy::Thread::LockGuard lock(lock_);
+      if (benchmark_in_progress_) {
         return finishGrpcStream(false, "Only a single benchmark session is allowed at a time.");
       }
-    } else if (request.has_update_request() || request.has_cancellation_request()) {
-      return finishGrpcStream(false, "Request is not supported yet.");
-    } else {
-      PANIC("not reached");
+
+      benchmark_in_progress_ = true;
+      // We pass in std::launch::async to avoid lazy evaluation, as we want this to run
+      // asap. See: https://en.cppreference.com/w/cpp/thread/async
+      future_ = std::future<void>(
+          std::async(std::launch::async, &ServiceImpl::handleExecutionRequest, this, request));
     }
   }
   return finishGrpcStream(true);

--- a/source/client/service_impl.cc
+++ b/source/client/service_impl.cc
@@ -61,8 +61,8 @@ void ServiceImpl::handleExecutionRequest(const nighthawk::client::ExecutionReque
   *(response.mutable_output()) = output_collector.toProto();
   process->shutdown();
   // We indicate the benchmark ended before writing the response to avoid a race
-  // with the client's follow up request coming in which might be the request to
-  // start the next benchmark. This only applies if the client chooses to run
+  // with the client's follow up request coming in, which might be a request to
+  // start the next benchmark. This is only relevant if the client chooses to run
   // multiple benchmarks within the same gRPC stream.
   {
     Envoy::Thread::LockGuard lock(lock_);
@@ -113,6 +113,7 @@ grpc::Status ServiceImpl::ExecutionStream(
         return finishGrpcStream(false, "Only a single benchmark session is allowed at a time.");
       }
 
+      // Gets set back to false in ServiceImpl::handleExecutionRequest.
       benchmark_in_progress_ = true;
       // We pass in std::launch::async to avoid lazy evaluation, as we want this to run
       // asap. See: https://en.cppreference.com/w/cpp/thread/async


### PR DESCRIPTION
Simplifies the locking code to make it easier to reason about. This is intended to help when troubleshooting an error where a new benchmark is rejected with `Only a single benchmark session is allowed at a time.`, while the previous benchmark already finished and the client has closed the gRPC stream. I suspect this was related to the use of `TryLock` method on the Mutex.

Done here:
- using a single lock to protect a single boolean `benchmark_in_progress_`.
- simplifying the main method with a few early checks and returns (avoids nested if statements).
- the `benchmark_in_progress_` value now determines if we are busy.
- the `benchmark_in_progress_` value is set to true by the thread that first manages the acquire the lock and the same thread then starts the benchmark using the `future`.
- the `future` sets the the `benchmark_in_progress_` value to false just before it writes the response.

Signed-off-by: Jakub Sobon <mumak@google.com>