### PR TITLE
Update Envoy to d3bd9bb (Mar 7th 2022).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "4ce48c4a89c3aad09949287679ba06a92ca1c540"  # Feb 28, 2022
-ENVOY_SHA = "bcfa1c291749de3d30771a713df73d908ec3bf850fdae31eb1c77ddd36a2dc5c"
+ENVOY_COMMIT = "d3bd9bbef64abbf1c02fe91231eac8841901131d"  # Mar 7, 2022
+ENVOY_SHA = "258f5ca02b22331f4d39334509f38992537a6214a6e9e20b68e65c6f321dee3c"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -2,17 +2,24 @@
 
 set -e
 
-TO_CHECK="${2:-$PWD}"
+# Using a path like ./../nighthawk is a workaround that allows us to skip Envoy
+# specific code checks performed by @envoy//tools/code_format:check_format.py.
+# TODO(https://github.com/envoyproxy/nighthawk/issues/815): Replace this
+# workaround with a permanent solution.
+CURRENT_DIRECTORY=${PWD##*/}
+FULL_CHECK="./../$CURRENT_DIRECTORY"
+
+TO_CHECK="${2:-$FULL_CHECK}"
 # TODO(https://github.com/envoyproxy/nighthawk/issues/165): fully excluding everything
 # from the build fixer isn't ideal.
 bazel run @envoy//tools/code_format:check_format.py -- \
   --skip_envoy_build_rule_check  --namespace_check Nighthawk \
-  --build_fixer_check_excluded_paths=$(realpath ".") \
+  --build_fixer_check_excluded_paths=$TO_CHECK \
   --include_dir_order envoy,nighthawk,external/source/envoy,external,api,common,source,exe,server,client,distributor,sink,grpcpp,request_source,test_common,test \
   $1 $TO_CHECK
 
 # The include checker doesn't support per-file checking, so we only
 # run it when a full check is requested.
-if [ $PWD == $TO_CHECK ]; then
+if [ $FULL_CHECK == $TO_CHECK ]; then
   bazel run //tools:check_envoy_includes.py
 fi


### PR DESCRIPTION
- no changes in `.bazelrc`, `.bazelversion`, `ci/run_envoy_docker.sh` or `tools/gen_compilation_database.py`.
- introducing a workaround for our use of the Envoy's `check_format.py` after https://github.com/envoyproxy/envoy/pull/20108. See https://github.com/envoyproxy/nighthawk/issues/815 for details.

Signed-off-by: Jakub Sobon <mumak@google.com>