### PR TITLE
Add a CLI flag --stats-flush-interval-duration to allow specifying stats flush interval in Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ time between request arrivals. Default: ""
 
 --stats-flush-interval-duration <duration>
 Time interval (in Duration) between flushes to configured stats sinks.
-Mutually exclusive with --stats-flush-interval.
+For example '1s' or '1.000000001s'. Mutually exclusive with
+--stats-flush-interval.
 
 --stats-flush-interval <uint32_t>
 Time interval (in seconds) between flushes to configured stats sinks.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ bazel build -c opt //:nighthawk
 USAGE:
 
 bazel-bin/nighthawk_client  [--latency-response-header-name <string>]
+[--stats-flush-interval-duration <duration>]
 [--stats-flush-interval <uint32_t>]
 [--stats-sinks <string>] ... [--no-duration]
 [--simple-warmup]
@@ -99,9 +100,13 @@ tandem with the test server's response option
 "emit_previous_request_delta_in_response_header" to record elapsed
 time between request arrivals. Default: ""
 
+--stats-flush-interval-duration <duration>
+Time interval (in Duration) between flushes to configured stats sinks.
+Mutually exclusive with --stats-flush-interval.
+
 --stats-flush-interval <uint32_t>
 Time interval (in seconds) between flushes to configured stats sinks.
-Default: 5.
+Mutually exclusive with --stats-flush-interval-duration. Default: 5.
 
 --stats-sinks <string>  (accepted multiple times)
 Stats sinks (in json) where Nighthawk metrics will be flushed. This

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -127,7 +127,7 @@ message Protocol {
 
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
-// Highest unused number is 110.
+// Highest unused number is 111.
 message CommandLineOptions {
   // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
@@ -264,10 +264,20 @@ message CommandLineOptions {
   google.protobuf.BoolValue simple_warmup = 32;
   // Optional set of stat sinks where Nighthawk metrics will be flushed to.
   repeated envoy.config.metrics.v3.StatsSink stats_sinks = 34;
-  // Time interval (number of seconds) between periodical flushes to configured stats sinks. If not
-  // specified the default is 5 seconds. Time interval must be at least 1s and at most 300s.
-  google.protobuf.UInt32Value stats_flush_interval = 35
-      [(validate.rules).uint32 = {gte: 1, lte: 300}];
+
+  oneof oneof_stats_flush_interval {
+    // Time interval (number of seconds) between periodical flushes to
+    // configured stats sinks. If not specified the default is 5 seconds.
+    // stats_flush_interval must be at least 1s and at most 300s.
+    google.protobuf.UInt32Value stats_flush_interval = 35
+        [(validate.rules).uint32 = {gte: 1, lte: 300}];
+
+    // Time interval in Duration between periodical flushes to configured stats
+    // sinks.
+    google.protobuf.Duration stats_flush_interval_duration = 110
+        [(validate.rules).duration.gte.nanos = 0];
+  }
+
   // Set an optional header name that will be returned in responses, whose values will be tracked in
   // a latency histogram if set. Can be used in tandem with the test server's response option
   // "emit_previous_request_delta_in_response_header" to record elapsed time between request

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -275,7 +275,7 @@ message CommandLineOptions {
     // Time interval in Duration between periodical flushes to configured stats
     // sinks.
     google.protobuf.Duration stats_flush_interval_duration = 110
-        [(validate.rules).duration.gte.nanos = 0];
+        [(validate.rules).duration = {gte {seconds: 0 nanos: 0}}];
   }
 
   // Set an optional header name that will be returned in responses, whose values will be tracked in

--- a/include/nighthawk/client/BUILD
+++ b/include/nighthawk/client/BUILD
@@ -20,6 +20,7 @@ envoy_basic_cc_library(
         "@envoy//envoy/common:time_interface",
         "@envoy//envoy/http:protocol_interface_with_external_headers",
         "@envoy//source/common/common:minimal_logger_lib_with_external_headers",
+        "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
     ],

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -15,6 +15,8 @@
 
 #include "nighthawk/common/termination_predicate.h"
 
+#include "external/envoy/source/common/protobuf/protobuf.h"
+
 #include "api/client/options.pb.h"
 
 #include "absl/types/optional.h"
@@ -86,6 +88,7 @@ public:
   virtual bool noDuration() const PURE;
   virtual std::vector<envoy::config::metrics::v3::StatsSink> statsSinks() const PURE;
   virtual uint32_t statsFlushInterval() const PURE;
+  virtual Envoy::ProtobufWkt::Duration statsFlushIntervalDuration() const PURE;
   virtual std::string responseHeaderWithLatencyInput() const PURE;
 
   virtual absl::optional<Envoy::SystemTime> scheduled_start() const PURE;

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -339,8 +339,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       false, 5, "uint32_t", cmd);
   TCLAP::ValueArg<std::string> stats_flush_interval_duration(
       "", "stats-flush-interval-duration",
-      "Time interval (in Duration) between flushes to configured stats sinks. Mutually exclusive "
-      "with --stats-flush-interval.",
+      "Time interval (in Duration) between flushes to configured stats sinks. For example '1s' or "
+      "'1.000000001s'. Mutually exclusive with --stats-flush-interval.",
       false, "", "duration", cmd);
 
   TCLAP::ValueArg<std::string> latency_response_header_name(

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -9,6 +9,7 @@
 #include "nighthawk/common/exception.h"
 
 #include "external/envoy/source/common/common/logger.h"
+#include "external/envoy/source/common/protobuf/protobuf.h"
 
 #include "absl/types/optional.h"
 #include "tclap/CmdLine.h"
@@ -98,6 +99,9 @@ public:
     return stats_sinks_;
   }
   uint32_t statsFlushInterval() const override { return stats_flush_interval_; }
+  Envoy::ProtobufWkt::Duration statsFlushIntervalDuration() const override {
+    return stats_flush_interval_duration_;
+  }
   std::string responseHeaderWithLatencyInput() const override {
     return latency_response_header_name_;
   };
@@ -161,6 +165,7 @@ private:
   bool no_duration_{false};
   std::vector<envoy::config::metrics::v3::StatsSink> stats_sinks_;
   uint32_t stats_flush_interval_{5};
+  Envoy::ProtobufWkt::Duration stats_flush_interval_duration_;
   std::string latency_response_header_name_;
   absl::optional<Envoy::SystemTime> scheduled_start_;
   absl::optional<std::string> execution_id_;

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -254,7 +254,13 @@ absl::StatusOr<Bootstrap> createBootstrapConfiguration(
   for (const StatsSink& stats_sink : options.statsSinks()) {
     *bootstrap.add_stats_sinks() = stats_sink;
   }
-  bootstrap.mutable_stats_flush_interval()->set_seconds(options.statsFlushInterval());
+
+  if (options.statsFlushIntervalDuration().seconds() > 0 ||
+      options.statsFlushIntervalDuration().nanos() > 0) {
+    *bootstrap.mutable_stats_flush_interval() = options.statsFlushIntervalDuration();
+  } else {
+    bootstrap.mutable_stats_flush_interval()->set_seconds(options.statsFlushInterval());
+  }
 
   if (options.upstreamBindConfig().has_value()) {
     *bootstrap.mutable_cluster_manager()->mutable_upstream_bind_config() =

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -64,6 +64,7 @@ public:
   MOCK_METHOD(std::vector<envoy::config::metrics::v3::StatsSink>, statsSinks, (),
               (const, override));
   MOCK_METHOD(uint32_t, statsFlushInterval, (), (const, override));
+  MOCK_METHOD(Envoy::ProtobufWkt::Duration, statsFlushIntervalDuration, (), (const, override));
   MOCK_METHOD(std::string, responseHeaderWithLatencyInput, (), (const, override));
   MOCK_METHOD(bool, allowEnvoyDeprecatedV2Api, (), (const));
   MOCK_METHOD(absl::optional<Envoy::SystemTime>, scheduled_start, (), (const, override));

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -84,11 +84,78 @@ TEST_F(OptionsImplTest, DurationAndNoDurationSanity) {
   EXPECT_TRUE(cmd->no_duration().value());
 }
 
+TEST_F(OptionsImplTest, StatsFlushIntervalAndStatsFlushIntervalDurationAreMutuallyExclusive) {
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(
+          fmt::format("{} --stats-flush-interval 5 --stats-flush-interval-duration 1s http://foo",
+                      client_name_)),
+      MalformedArgvException, "mutually exclusive");
+}
+
 TEST_F(OptionsImplTest, StatsSinksMustBeSetWhenStatsFlushIntervalSet) {
   EXPECT_THROW_WITH_REGEX(
       TestUtility::createOptionsImpl(fmt::format("{} --stats-flush-interval 10", client_name_)),
       MalformedArgvException,
-      "if --stats-flush-interval is set, then --stats-sinks must also be set");
+      "if --stats-flush-interval or --stats-flush-interval-duration is set, then --stats-sinks "
+      "must also be set");
+}
+
+TEST_F(OptionsImplTest, StatsSinksMustBeSetWhenStatsFlushIntervalDurationSet) {
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
+                              "{} --stats-flush-interval-duration 1.000000001s", client_name_)),
+                          MalformedArgvException,
+                          "if --stats-flush-interval or --stats-flush-interval-duration is set, "
+                          "then --stats-sinks must also be set");
+}
+
+TEST_F(OptionsImplTest, InvalidStatsFlushIntervalDuration) {
+  const std::string sink_json =
+      "{name:\"envoy.stat_sinks.statsd\",typed_config:{\"@type\":\"type."
+      "googleapis.com/"
+      "envoy.config.metrics.v3.StatsdSink\",tcp_cluster_name:\"statsd\"}}";
+
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(fmt::format(
+          "{} --stats-flush-interval-duration invalid-duration --stats-sinks {} http://foo",
+          client_name_, sink_json)),
+      MalformedArgvException, "Invalid value for --stats-flush-interval-duration");
+}
+
+TEST_F(OptionsImplTest, OutOfRangeStatsFlushIntervalDuration) {
+  const std::string sink_json =
+      "{name:\"envoy.stat_sinks.statsd\",typed_config:{\"@type\":\"type."
+      "googleapis.com/"
+      "envoy.config.metrics.v3.StatsdSink\",tcp_cluster_name:\"statsd\"}}";
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(fmt::format(
+          "{} --stats-flush-interval-duration -1.000000001s --stats-sinks {} http://foo",
+          client_name_, sink_json)),
+      MalformedArgvException, "--stats-flush-interval-duration is out of range");
+}
+
+TEST_F(OptionsImplTest, StatsFlushIntervalAndStatsFlushIntervalDurationSanity) {
+  const std::string sink_json =
+      "{name:\"envoy.stat_sinks.statsd\",typed_config:{\"@type\":\"type."
+      "googleapis.com/"
+      "envoy.config.metrics.v3.StatsdSink\",tcp_cluster_name:\"statsd\"}}";
+  std::unique_ptr<OptionsImpl> options =
+      TestUtility::createOptionsImpl(fmt::format("{} http://foo", client_name_));
+  EXPECT_EQ(5, options->statsFlushInterval());
+  EXPECT_EQ(0, options->statsFlushIntervalDuration().seconds());
+  EXPECT_EQ(0, options->statsFlushIntervalDuration().nanos());
+
+  CommandLineOptionsPtr cmd = options->toCommandLineOptions();
+  EXPECT_FALSE(cmd->has_stats_flush_interval_duration());
+  ASSERT_TRUE(cmd->has_stats_flush_interval());
+  EXPECT_EQ(5, cmd->stats_flush_interval().value());
+
+  options = TestUtility::createOptionsImpl(
+      fmt::format("{} --stats-flush-interval-duration 1.000000001s --stats-sinks {} http://foo",
+                  client_name_, sink_json));
+  cmd = options->toCommandLineOptions();
+  ASSERT_TRUE(cmd->has_stats_flush_interval_duration());
+  EXPECT_EQ(1, cmd->stats_flush_interval_duration().seconds());
+  EXPECT_EQ(1, cmd->stats_flush_interval_duration().nanos());
 }
 
 // This test should cover every option we offer, except some mutually exclusive ones that


### PR DESCRIPTION
New flag --stats-flush-interval-duration is mutually exclusive with --stats-flush-interval.