### PR TITLE
Defining our first Azure Pipeline.

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -1,0 +1,22 @@
+parameters:
+- name: ciTarget
+  displayName: "CI target"
+  type: string
+  default: build 
+
+- bash: |
+    echo "disk space at beginning of build:"
+    df -h
+  displayName: "Check disk space at beginning"
+
+- script: ci/run_envoy_docker.sh 'ci/do_ci.sh ${{ parameters.ciTarget }}'
+  workingDirectory: $(Build.SourcesDirectory)
+  displayName: "Run the CI script"
+
+- bash: |
+    echo "disk space at end of build:"
+    df -h
+    # Cleanup offending files with unicode names
+    rm -rf $(Build.StagingDirectory)/tmp/*/*/external/go_sdk/test/fixedbugs
+  displayName: "Check disk space at end"
+  condition: always()

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -4,6 +4,7 @@ parameters:
   type: string
   default: build 
 
+steps:
 - bash: |
     echo "disk space at beginning of build:"
     df -h

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -1,0 +1,23 @@
+trigger:
+  branches:
+    include:
+    - "main"
+
+stages:
+- stage: check
+  dependsOn: []
+  jobs:
+  - job: bazel
+    displayName: "do_ci.sh"
+    dependsOn: []
+    strategy:
+      maxParallel: 1
+      matrix:
+        build:
+          CI_TARGET: "build"
+    timeoutInMinutes: 120
+    pool: "x64-large"
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)


### PR DESCRIPTION
This is first of a few PRs that will migrate Nighthawk's CI to Azure Pipelines. This is what Envoy uses currently and this is where we can get more resources which will enable the integration tests to pass again.

This defines a single step `build` that will execute in our `nighthawk-presubmit` pipeline.

Works on #820.

Signed-off-by: Jakub Sobon <mumak@google.com>