### PR TITLE
Adding the test step into AZP

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -13,6 +13,8 @@ steps:
 - script: ci/run_envoy_docker.sh 'ci/do_ci.sh ${{ parameters.ciTarget }}'
   workingDirectory: $(Build.SourcesDirectory)
   displayName: "Run the CI script"
+  env:
+    BAZEL_REMOTE_CACHE: $(LocalBuildCache)
 
 - bash: |
     echo "disk space at end of build:"

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -15,6 +15,8 @@ stages:
       matrix:
         build:
           CI_TARGET: "build"
+        test:
+          CI_TARGET: "test"
     timeoutInMinutes: 120
     pool: "x64-large"
     steps:

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -241,11 +241,9 @@ if [ -n "$CIRCLECI" ]; then
         BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} \
           --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build"
     fi
-    echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
     BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --jobs=${NUM_CPUS}"
-else
-    echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
 fi
+echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
 
 export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
 --test_env=UBSAN_OPTIONS=print_stacktrace=1 \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -18,6 +18,7 @@ export BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS:=""}
 export SRCDIR=${SRCDIR:="${PWD}"}
 export CLANG_FORMAT=clang-format
 export NIGHTHAWK_BUILD_ARCH=$(uname -m)
+export BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:=""}
 
 # We build in steps to avoid running out of memory in CI.
 # This list doesn't have to be complete, execution of bazel test will build any
@@ -219,6 +220,10 @@ if grep 'docker\|lxc' /proc/1/cgroup; then
     export BAZEL="bazel"
 fi
 
+if [ -n "${BAZEL_REMOTE_CACHE}" ]; then
+  export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} --remote_cache=${BAZEL_REMOTE_CACHE}"
+fi
+
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"
 export BAZEL_BUILD_OPTIONS=" \
 --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
@@ -238,6 +243,8 @@ if [ -n "$CIRCLECI" ]; then
     fi
     echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
     BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --jobs=${NUM_CPUS}"
+else
+    echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
 fi
 
 export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \


### PR DESCRIPTION
Also enabling local bazel cache to carry state between the CI steps and printing out the full bazel command line for debugging.

Works on #820.

Signed-off-by: Jakub Sobon <mumak@google.com>