### PR TITLE
Update Envoy to 569f239 (Apr 18th 2022).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,13 @@ build --incompatible_strict_action_env
 build --host_force_python=PY3
 build --java_runtime_version=remotejdk_11
 build --tool_java_runtime_version=remotejdk_11
+#build --platform_mappings=""                                                               # unique
+
+# Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
+build --action_env=CC
+build --action_env=CXX
+build --action_env=LLVM_CONFIG
+build --action_env=PATH
 
 build --enable_platform_specific_config
 
@@ -46,12 +53,6 @@ build:linux --action_env=BAZEL_LINKOPTS=-lm
 
 # We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
 build --define absl=1
-
-# Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
-build --action_env=CC
-build --action_env=CXX
-build --action_env=LLVM_CONFIG
-build --action_env=PATH
 
 # Disable ICU linking for googleurl.
 build --@com_googlesource_googleurl//build_config:system_icu=0

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "03efacf2f9bc10bf92c61491274c4ba9ff0ad1bd"
-ENVOY_SHA = "4cd1a1b44dd0f16dde993b0209d38298eb860654fabf8a38aff4e74c6ba2af62"
+ENVOY_COMMIT = "569f23993160c01bd07af94f2d8e1bb973933c0a"
+ENVOY_SHA = "827786a4b7e0963a7303e44af7ffffe11d2ed8289bee80291f0a6acc40b368c8"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -387,8 +387,8 @@ def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2)
         "common_tls_context:{tls_params:{cipher_suites:[\"-ALL:%s\"]}}}}")
 
   for cipher in [
-      "ECDHE-RSA-AES128-SHA",
-      "ECDHE-RSA-CHACHA20-POLY1305",
+      "AES128-GCM-SHA256",
+      "ECDHE-RSA-AES256-GCM-SHA384",
   ]:
     parsed_json, _ = https_test_server_fixture.runNighthawkClient(
         (["--protocol", "http2"] if use_h2 else []) + [


### PR DESCRIPTION
- updated `.bazelrc` based on https://github.com/envoyproxy/envoy/pull/20852 and https://github.com/envoyproxy/envoy/pull/20813. Disabling platform mappings in our configuration, since we don't need them.
- no changes in `.bazelversion`, `ci/run_envoy_docker.sh` or `tools/gen_compilation_database.py`.
- switching integration tests that verify custom TLS configuration to another two ciphers that are supported in the default Envoy server configuration after https://github.com/envoyproxy/envoy/pull/20643.