### PR TITLE
Adopt Envoy's formatting in tools/gen_compilation_database.py.

### DIFF
--- a/tools/format_python_tools.py
+++ b/tools/format_python_tools.py
@@ -5,14 +5,18 @@ import sys
 
 from yapf.yapflib.yapf_api import FormatFile
 
-EXCLUDE_LIST = ['generated', 'venv', ".cache"]
+# Directories in which we don't format files.
+EXCLUDE_DIRECTORIES = ['generated', 'venv', ".cache"]
+
+# Files that are excluded from formatting.
+EXCLUDE_FILES = ['gen_compilation_database.py']
 
 
 def collectFiles():
   """Collect all Python files in the tools directory.
 
   Returns: A collection of python files in the tools directory excluding
-    any directories in the EXCLUDE_LIST constant.
+    any directories in the EXCLUDE_DIRECTORIES constant.
   """
   # TODO: Add ability to collect a specific file or files.
   matches = []
@@ -21,8 +25,10 @@ def collectFiles():
   if path_parts[-1] == 'tools':
     dirname = '/'.join(path_parts[:-1])
   for root, dirnames, filenames in os.walk(dirname):
-    dirnames[:] = [d for d in dirnames if d not in EXCLUDE_LIST]
+    dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRECTORIES]
     for filename in fnmatch.filter(filenames, '*.py'):
+      if filename in EXCLUDE_FILES:
+        continue
       matches.append(os.path.join(root, filename))
   return matches
 

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -12,105 +12,110 @@ from pathlib import Path
 
 # This method is equivalent to https://github.com/grailbio/bazel-compilation-database/blob/master/generate.py
 def generate_compilation_database(args):
-  # We need to download all remote outputs for generated source code. This option lives here to override those
-  # specified in bazelrc.
-  bazel_options = shlex.split(os.environ.get("BAZEL_BUILD_OPTIONS", "")) + [
-      "--config=compdb",
-      "--remote_download_outputs=all",
-  ]
+    # We need to download all remote outputs for generated source code. This option lives here to override those
+    # specified in bazelrc.
+    bazel_options = shlex.split(os.environ.get("BAZEL_BUILD_OPTIONS", "")) + [
+        "--config=compdb",
+        "--remote_download_outputs=all",
+    ]
 
-  subprocess.check_call(["bazel", "build"] + bazel_options + [
-      "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
-      "--output_groups=compdb_files,header_files"
-  ] + args.bazel_targets)
+    subprocess.check_call(["bazel", "build"] + bazel_options + [
+        "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
+        "--output_groups=compdb_files,header_files"
+    ] + args.bazel_targets)
 
-  execroot = subprocess.check_output(["bazel", "info", "execution_root"] +
-                                     bazel_options).decode().strip()
+    execroot = subprocess.check_output(["bazel", "info", "execution_root"]
+                                       + bazel_options).decode().strip()
 
-  db_entries = []
-  for db in Path(execroot).glob('**/*.compile_commands.json'):
-    db_entries.extend(json.loads(db.read_text()))
+    db_entries = []
+    for db in Path(execroot).glob('**/*.compile_commands.json'):
+        db_entries.extend(json.loads(db.read_text()))
 
-  def replace_execroot_marker(db_entry):
-    if 'directory' in db_entry and db_entry['directory'] == '__EXEC_ROOT__':
-      db_entry['directory'] = execroot
-    if 'command' in db_entry:
-      db_entry['command'] = (db_entry['command'].replace('-isysroot __BAZEL_XCODE_SDKROOT__', ''))
-    return db_entry
+    def replace_execroot_marker(db_entry):
+        if 'directory' in db_entry and db_entry['directory'] == '__EXEC_ROOT__':
+            db_entry['directory'] = execroot
+        if 'command' in db_entry:
+            db_entry['command'] = (
+                db_entry['command'].replace('-isysroot __BAZEL_XCODE_SDKROOT__', ''))
+        return db_entry
 
-  return list(map(replace_execroot_marker, db_entries))
+    return list(map(replace_execroot_marker, db_entries))
 
 
 def is_header(filename):
-  for ext in (".h", ".hh", ".hpp", ".hxx"):
-    if filename.endswith(ext):
-      return True
-  return False
+    for ext in (".h", ".hh", ".hpp", ".hxx"):
+        if filename.endswith(ext):
+            return True
+    return False
 
 
 def is_compile_target(target, args):
-  filename = target["file"]
-  if is_header(filename):
-    if args.include_all:
-      return True
-    if not args.include_headers:
-      return False
+    filename = target["file"]
+    if is_header(filename):
+        if args.include_all:
+            return True
+        if not args.include_headers:
+            return False
 
-  if filename.startswith("bazel-out/"):
-    if args.include_all:
-      return True
-    if not args.include_genfiles:
-      return False
+    if filename.startswith("bazel-out/"):
+        if args.include_all:
+            return True
+        if not args.include_genfiles:
+            return False
 
-  if filename.startswith("external/"):
-    if args.include_all:
-      return True
-    if not args.include_external:
-      return False
+    if filename.startswith("external/"):
+        if args.include_all:
+            return True
+        if not args.include_external:
+            return False
 
-  return True
+    return True
 
 
 def modify_compile_command(target, args):
-  cc, options = target["command"].split(" ", 1)
+    cc, options = target["command"].split(" ", 1)
 
-  # Workaround for bazel added C++11 options, those doesn't affect build itself but
-  # clang-tidy will misinterpret them.
-  options = options.replace("-std=c++0x ", "")
-  options = options.replace("-std=c++11 ", "")
+    # Workaround for bazel added C++11 options, those doesn't affect build itself but
+    # clang-tidy will misinterpret them.
+    options = options.replace("-std=c++0x ", "")
+    options = options.replace("-std=c++11 ", "")
 
-  if args.vscode:
-    # Visual Studio Code doesn't seem to like "-iquote". Replace it with
-    # old-style "-I".
-    options = options.replace("-iquote ", "-I ")
+    if args.vscode:
+        # Visual Studio Code doesn't seem to like "-iquote". Replace it with
+        # old-style "-I".
+        options = options.replace("-iquote ", "-I ")
 
-  if is_header(target["file"]):
-    options += " -Wno-pragma-once-outside-header -Wno-unused-const-variable"
-    options += " -Wno-unused-function"
-    # By treating external/envoy* as C++ files we are able to use this script from subrepos that
-    # depend on Envoy targets.
-    if not target["file"].startswith("external/") or target["file"].startswith("external/envoy"):
-      # *.h file is treated as C header by default while our headers files are all C++17.
-      options = "-x c++ -std=c++17 -fexceptions " + options
+    if is_header(target["file"]):
+        options += " -Wno-pragma-once-outside-header -Wno-unused-const-variable"
+        options += " -Wno-unused-function"
+        # By treating external/envoy* as C++ files we are able to use this script from subrepos that
+        # depend on Envoy targets.
+        if not target["file"].startswith("external/") or target["file"].startswith(
+                "external/envoy"):
+            # *.h file is treated as C header by default while our headers files are all C++17.
+            options = "-x c++ -std=c++17 -fexceptions " + options
 
-  target["command"] = " ".join([cc, options])
-  return target
+    target["command"] = " ".join([cc, options])
+    return target
 
 
 def fix_compilation_database(args, db):
-  db = [modify_compile_command(target, args) for target in db if is_compile_target(target, args)]
+    db = [modify_compile_command(target, args) for target in db if is_compile_target(target, args)]
 
-  with open("compile_commands.json", "w") as db_file:
-    json.dump(db, db_file, indent=2)
+    with open("compile_commands.json", "w") as db_file:
+        json.dump(db, db_file, indent=2)
 
 
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description='Generate JSON compilation database')
-  parser.add_argument('--include_external', action='store_true')
-  parser.add_argument('--include_genfiles', action='store_true')
-  parser.add_argument('--include_headers', action='store_true')
-  parser.add_argument('--vscode', action='store_true')
-  parser.add_argument('--include_all', action='store_true')
-  parser.add_argument('bazel_targets', nargs='*', default=["//..."])  # unique
-  args = parser.parse_args()
-  fix_compilation_database(args, generate_compilation_database(args))
+    parser = argparse.ArgumentParser(description='Generate JSON compilation database')
+    parser.add_argument('--include_external', action='store_true')
+    parser.add_argument('--include_genfiles', action='store_true')
+    parser.add_argument('--include_headers', action='store_true')
+    parser.add_argument('--vscode', action='store_true')
+    parser.add_argument('--include_all', action='store_true')
+    parser.add_argument(
+        'bazel_targets',
+        nargs='*',
+        default=["//..."])  # unique
+    args = parser.parse_args()
+    fix_compilation_database(args, generate_compilation_database(args))


### PR DESCRIPTION
Keeping this file in sync with the Envoy version is part of our regular maintenance. However spotting differences has been made harder after our tools reformatted `tools/gen_compilation_database.py`.

Done here:
- copying `tools/gen_compilation_database.py` to adopt the original formatting.
- manually changing the lines that were marked unique.
- modifying our formatting tools, so that `tools/gen_compilation_database.py` gets skipped.

Signed-off-by: Jakub Sobon <mumak@google.com>