### PR TITLE
Migrate our docker workflow to AZP.

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -15,6 +15,10 @@ steps:
   displayName: "Run the CI script"
   env:
     BAZEL_REMOTE_CACHE: $(LocalBuildCache)
+    AZP_BRANCH: $(Build.SourceBranch)
+    AZP_SHA1: $(Build.SourceVersion)
+    DOCKERHUB_USERNAME: $(DockerUsername)
+    DOCKERHUB_PASSWORD: $(DockerPassword)
 
 - bash: |
     echo "disk space at end of build:"

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -6,7 +6,6 @@ trigger:
 stages:
 - stage: check
   dependsOn: []
-  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: build_and_format
@@ -27,7 +26,6 @@ stages:
 
 - stage: test
   dependsOn: ["check"]
-  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: test_and_benchmark
@@ -48,7 +46,6 @@ stages:
 
 - stage: clang_tidy
   dependsOn: ["check"]
-  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: clang_tidy
@@ -66,7 +63,6 @@ stages:
 
 - stage: test_gcc
   dependsOn: ["check"]
-  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: test_gcc
@@ -84,7 +80,6 @@ stages:
 
 - stage: sanitizers
   dependsOn: ["test"]
-  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: sanitizers
@@ -104,7 +99,6 @@ stages:
 
 - stage: coverage
   dependsOn: ["test"]
-  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: coverage

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -115,3 +115,23 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
+
+- stage: release
+  dependsOn:
+  - "clang_tidy"
+  - "test_gcc"
+  - "sanitizers"
+  - "coverage"
+  pool: "x64-large"
+  jobs:
+  - job: release
+    displayName: "do_ci.sh"
+    strategy:
+      matrix:
+        release:
+          CI_TARGET: "docker"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -122,6 +122,7 @@ stages:
   - "test_gcc"
   - "sanitizers"
   - "coverage"
+  condition: ne(variables['PostSubmit'], true)
   pool: "x64-large"
   jobs:
   - job: release
@@ -129,8 +130,14 @@ stages:
     strategy:
       matrix:
         release:
-          CI_TARGET: "docker"
+          CI_TARGET: "docker_azp"
     timeoutInMinutes: 120
+    workingDirectory: $(Build.SourcesDirectory)
+    env:
+      AZP_BRANCH: $(Build.SourceBranch)
+      AZP_SHA1: $(Build.SourceVersion)
+      DOCKERHUB_USERNAME: $(DockerUsername)
+      DOCKERHUB_PASSWORD: $(DockerPassword)
     steps:
     - template: bazel.yml
       parameters:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -128,7 +128,7 @@ stages:
   - "test_gcc"
   - "sanitizers"
   - "coverage"
-  condition: ne(variables['PostSubmit'], true)
+  condition: eq(variables['PostSubmit'], true)
   pool: "x64-large"
   jobs:
   - job: release

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -6,6 +6,7 @@ trigger:
 stages:
 - stage: check
   dependsOn: []
+  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: build_and_format
@@ -26,6 +27,7 @@ stages:
 
 - stage: test
   dependsOn: ["check"]
+  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: test_and_benchmark
@@ -46,6 +48,7 @@ stages:
 
 - stage: clang_tidy
   dependsOn: ["check"]
+  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: clang_tidy
@@ -63,6 +66,7 @@ stages:
 
 - stage: test_gcc
   dependsOn: ["check"]
+  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: test_gcc
@@ -80,6 +84,7 @@ stages:
 
 - stage: sanitizers
   dependsOn: ["test"]
+  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: sanitizers
@@ -99,6 +104,7 @@ stages:
 
 - stage: coverage
   dependsOn: ["test"]
+  condition: contains(variables['DoesNotExist'], true) # skip for debugging
   pool: "x64-large"
   jobs:
   - job: coverage

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -132,12 +132,6 @@ stages:
         release:
           CI_TARGET: "docker_azp"
     timeoutInMinutes: 120
-    workingDirectory: $(Build.SourcesDirectory)
-    env:
-      AZP_BRANCH: $(Build.SourceBranch)
-      AZP_SHA1: $(Build.SourceVersion)
-      DOCKERHUB_USERNAME: $(DockerUsername)
-      DOCKERHUB_PASSWORD: $(DockerPassword)
     steps:
     - template: bazel.yml
       parameters:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -69,6 +69,8 @@ important maintenance task. When performing the update, follow this procedure:
    to ensure we are using the same build system version.
 1. Sync (copy) [ci/run_envoy_docker.sh](ci/run_envoy_docker.sh) from
    [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/ci/run_envoy_docker.sh).
+   Be sure to retain our local modifications, all lines that are unique to
+   Nighthawk are marked with comment `# unique`.
 1. Sync (copy) [tools/gen_compilation_database.py](tools/gen_compilation_database.py) from
    [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/tools/gen_compilation_database.py) to
    update our build configurations. Be sure to retain our local modifications,

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -2,14 +2,7 @@
 
 set -eo pipefail
 set +x
-#set -u
-
-if [[ -n "$DOCKERHUB_USERNAME" ]]; then
-  echo "Username is set."
-fi
-if [[ -n "$DOCKERHUB_PASSWORD" ]]; then
-  echo "Password is set."
-fi
+set -u
 
 if [ $# -eq 0 ]; then
     set -- "help"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -187,7 +187,7 @@ function do_check_format() {
 function do_docker() {
     echo "docker..."
     cd "${SRCDIR}"
-    # Note that we implicitly test the opt build in CI here.
+    # Note that we implicly test the opt build in CI here
     do_opt_build
     ./ci/docker/docker_build.sh
     ./ci/docker/docker_push.sh
@@ -199,7 +199,7 @@ function do_docker_azp() {
     echo "docker in AZP..."
     cd "${SRCDIR}"
     # Note that we implicitly test the opt build in CI here.
-    echo "do_docker_azp: Running do_docker_azp."
+    echo "do_docker_azp: Running do_opt_build."
     do_opt_build
     echo "do_docker_azp: Running ci/docker/docker_build.sh."
     ./ci/docker/docker_build.sh

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -195,6 +195,17 @@ function do_docker() {
     ./ci/docker/benchmark_push.sh
 }
 
+function do_docker_azp() {
+    echo "docker in AZP..."
+    cd "${SRCDIR}"
+    # Note that we implicly test the opt build in CI here
+    do_opt_build
+    ./ci/docker/docker_build.sh
+    ./ci/docker/docker_azp_push.sh
+    ./ci/docker/benchmark_build.sh
+    ./ci/docker/benchmark_azp_push.sh
+}
+
 function do_fix_format() {
     echo "fix_format..."
     cd "${SRCDIR}"
@@ -299,6 +310,11 @@ case "$1" in
         do_docker
         exit 0
     ;;
+    docker_azp)
+        setup_clang_toolchain
+        do_docker_azp
+        exit 0
+    ;;
     check_format)
         setup_clang_toolchain
         do_check_format
@@ -320,7 +336,7 @@ case "$1" in
         exit 0
     ;;
     *)
-        echo "must be one of [opt_build, build,test,clang_tidy,coverage,coverage_integration,asan,tsan,benchmark_with_own_binaries,docker,check_format,fix_format,test_gcc]"
+        echo "must be one of [opt_build, build,test,clang_tidy,coverage,coverage_integration,asan,tsan,benchmark_with_own_binaries,docker,docker_azp,check_format,fix_format,test_gcc]"
         exit 1
     ;;
 esac

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -2,7 +2,14 @@
 
 set -eo pipefail
 set +x
-set -u
+#set -u
+
+if [[ -n "$DOCKERHUB_USERNAME" ]]; then
+  echo "Username is set."
+fi
+if [[ -n "$DOCKERHUB_PASSWORD" ]]; then
+  echo "Password is set."
+fi
 
 if [ $# -eq 0 ]; then
     set -- "help"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -194,7 +194,7 @@ function do_check_format() {
 function do_docker() {
     echo "docker..."
     cd "${SRCDIR}"
-    # Note that we implicly test the opt build in CI here
+    # Note that we implicitly test the opt build in CI here.
     do_opt_build
     ./ci/docker/docker_build.sh
     ./ci/docker/docker_push.sh
@@ -205,7 +205,7 @@ function do_docker() {
 function do_docker_azp() {
     echo "docker in AZP..."
     cd "${SRCDIR}"
-    # Note that we implicly test the opt build in CI here
+    # Note that we implicitly test the opt build in CI here.
     do_opt_build
     ./ci/docker/docker_build.sh
     ./ci/docker/docker_azp_push.sh

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -199,10 +199,15 @@ function do_docker_azp() {
     echo "docker in AZP..."
     cd "${SRCDIR}"
     # Note that we implicitly test the opt build in CI here.
+    echo "do_docker_azp: Running do_docker_azp."
     do_opt_build
+    echo "do_docker_azp: Running ci/docker/docker_build.sh."
     ./ci/docker/docker_build.sh
+    echo "do_docker_azp: Running ci/docker/docker_azp_push.sh."
     ./ci/docker/docker_azp_push.sh
+    echo "do_docker_azp: Running ci/docker/benchmark_build.sh."
     ./ci/docker/benchmark_build.sh
+    echo "do_docker_azp: Running ci/docker/benchmark_azp_push.sh."
     ./ci/docker/benchmark_azp_push.sh
 }
 

--- a/ci/docker/benchmark_azp_push.sh
+++ b/ci/docker/benchmark_azp_push.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/nighthawk-benchmark}"
+
+source ./ci/docker/docker_push.sh

--- a/ci/docker/benchmark_azp_push.sh
+++ b/ci/docker/benchmark_azp_push.sh
@@ -2,4 +2,4 @@
 
 DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/nighthawk-benchmark}"
 
-source ./ci/docker/docker_push.sh
+source ./ci/docker/docker_azp_push.sh

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -20,6 +20,6 @@ echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} 
 
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-echo docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
-echo docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" \
+docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
+docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" \
   "${DOCKER_IMAGE_PREFIX}-dev:${AZP_SHA1}"

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -20,6 +20,6 @@ echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX},
 
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-echo docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
-echo docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" \
+docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
+docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" \
   "${DOCKER_IMAGE_PREFIX}-dev:${AZP_SHA1}"

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -10,7 +10,7 @@ MAIN_BRANCH="refs/heads/main"
 
 DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/nighthawk}"
 
-echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} and AZP_BRANCH=${AZP_BRANCH}."
+echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX}, AZP_BRANCH=${AZP_BRANCH} and AZP_SHA1=${AZP_SHA1}."
 
 # Only push images for main builds.
 #if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]]; then

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -13,10 +13,10 @@ DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/nighthawk}"
 echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX}, AZP_BRANCH=${AZP_BRANCH} and AZP_SHA1=${AZP_SHA1}."
 
 # Only push images for main builds.
-#if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]]; then
-#  echo 'Ignoring non-main branch or tag for docker push.'
-#  exit 0
-#fi
+if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]]; then
+  echo 'Ignoring non-main branch or tag for docker push.'
+  exit 0
+fi
 
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -18,13 +18,6 @@ echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} 
 #  exit 0
 #fi
 
-if [[ -n "$DOCKERHUB_USERNAME" ]]; then
-  echo "Username is set."
-fi
-if [[ -n "$DOCKERHUB_PASSWORD" ]]; then
-  echo "Password is set."
-fi
-
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
 echo docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -1,31 +1,23 @@
 #!/bin/bash
 
-# Do not ever set -x here, it is a security hazard as it will place the credentials below in the
-# CircleCI logs.
+# Do not ever set -x here, it might leak credentials.
 set -e
 set +x
 
-if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-    echo 'Ignoring PR branch for docker push.'
-    exit 0
-fi
+# This is how AZP identifies the branch, see the Build.SourceBranch variable in:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
+MAIN_BRANCH="refs/heads/main"
 
 DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/nighthawk}"
 
-# push the nighthawk image on tags or merge to main
-if [[  "$CIRCLE_BRANCH" = 'main' ]]; then
-    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-    docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
-    docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" "${DOCKER_IMAGE_PREFIX}-dev:${CIRCLE_SHA1}"
-    docker push "${DOCKER_IMAGE_PREFIX}-dev:${CIRCLE_SHA1}"
-else
-    if [[ -n "$CIRCLE_TAG" ]]; then
-        TAG="$CIRCLE_TAG"
-        docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-        docker push "${DOCKER_IMAGE_PREFIX}:${TAG}"
-        docker tag "${DOCKER_IMAGE_PREFIX}:${TAG}" "${DOCKER_IMAGE_PREFIX}:${TAG}"
-        docker push "${DOCKER_IMAGE_PREFIX}:${TAG}"
-    else
-        echo 'Ignoring non-main branch for docker push.'
-    fi
+# Only push images for main builds.
+if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]]; then
+  echo 'Ignoring non-main branch or tag for docker push.'
+  exit 0
 fi
+
+docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+
+echo docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
+echo docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" \
+  "${DOCKER_IMAGE_PREFIX}-dev:${AZP_SHA1}"

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Do not ever set -x here, it is a security hazard as it will place the credentials below in the
+# CircleCI logs.
+set -e
+set +x
+
+if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+    echo 'Ignoring PR branch for docker push.'
+    exit 0
+fi
+
+DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/nighthawk}"
+
+# push the nighthawk image on tags or merge to main
+if [[  "$CIRCLE_BRANCH" = 'main' ]]; then
+    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+    docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
+    docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" "${DOCKER_IMAGE_PREFIX}-dev:${CIRCLE_SHA1}"
+    docker push "${DOCKER_IMAGE_PREFIX}-dev:${CIRCLE_SHA1}"
+else
+    if [[ -n "$CIRCLE_TAG" ]]; then
+        TAG="$CIRCLE_TAG"
+        docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+        docker push "${DOCKER_IMAGE_PREFIX}:${TAG}"
+        docker tag "${DOCKER_IMAGE_PREFIX}:${TAG}" "${DOCKER_IMAGE_PREFIX}:${TAG}"
+        docker push "${DOCKER_IMAGE_PREFIX}:${TAG}"
+    else
+        echo 'Ignoring non-main branch for docker push.'
+    fi
+fi

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -18,6 +18,13 @@ echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} 
 #  exit 0
 #fi
 
+if [[ -n "$DOCKERHUB_USERNAME" ]]; then
+  echo "Username is set."
+fi
+if [[ -n "$DOCKERHUB_PASSWORD" ]]; then
+  echo "Password is set."
+fi
+
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
 echo docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -10,6 +10,8 @@ MAIN_BRANCH="refs/heads/main"
 
 DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/nighthawk}"
 
+echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} and AZP_BRANCH=${AZP_BRANCH}."
+
 # Only push images for main builds.
 #if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]]; then
 #  echo 'Ignoring non-main branch or tag for docker push.'

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -11,10 +11,10 @@ MAIN_BRANCH="refs/heads/main"
 DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/nighthawk}"
 
 # Only push images for main builds.
-if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]]; then
-  echo 'Ignoring non-main branch or tag for docker push.'
-  exit 0
-fi
+#if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]]; then
+#  echo 'Ignoring non-main branch or tag for docker push.'
+#  exit 0
+#fi
 
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 

--- a/ci/docker/docker_azp_push.sh
+++ b/ci/docker/docker_azp_push.sh
@@ -20,6 +20,6 @@ echo "Running docker_azp_push.sh for DOCKER_IMAGE_PREFIX=${DOCKER_IMAGE_PREFIX} 
 
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
-docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" \
+echo docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
+echo docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" \
   "${DOCKER_IMAGE_PREFIX}-dev:${AZP_SHA1}"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -69,6 +69,7 @@ docker run --rm \
        -v "${ENVOY_DOCKER_BUILD_DIR}":"${BUILD_DIR_MOUNT_DEST}" \
        -v "${SOURCE_DIR}":"${SOURCE_DIR_MOUNT_DEST}" \
        -e AZP_BRANCH \
+       -e AZP_SHA1 `# unique` \
        -e HTTP_PROXY \
        -e HTTPS_PROXY \
        -e NO_PROXY \

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -98,7 +98,7 @@ docker run --rm \
        -e SYSTEM_STAGEDISPLAYNAME \
        -e SYSTEM_JOBDISPLAYNAME \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
-       -e DOCKERHUB_USERNAME \
-       -e DOCKERHUB_PASSWORD \
+       -e DOCKERHUB_USERNAME `# unique` \
+       -e DOCKERHUB_PASSWORD `# unique` \
        "${ENVOY_BUILD_IMAGE}" \
        "${START_COMMAND[@]}"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -98,7 +98,7 @@ docker run --rm \
        -e SYSTEM_STAGEDISPLAYNAME \
        -e SYSTEM_JOBDISPLAYNAME \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
-       -e DOCKERHUB_USERNAME \  # unique
-       -e DOCKERHUB_PASSWORD \  # unique
+       -e DOCKERHUB_USERNAME \
+       -e DOCKERHUB_PASSWORD \
        "${ENVOY_BUILD_IMAGE}" \
        "${START_COMMAND[@]}"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -98,5 +98,7 @@ docker run --rm \
        -e SYSTEM_STAGEDISPLAYNAME \
        -e SYSTEM_JOBDISPLAYNAME \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
+       -e DOCKERHUB_USERNAME \  # unique
+       -e DOCKERHUB_PASSWORD \  # unique
        "${ENVOY_BUILD_IMAGE}" \
        "${START_COMMAND[@]}"


### PR DESCRIPTION
Temporarily forking the `docker_push.sh` and `benchmark_push.sh` scripts to AZP specific versions as a simplification. The CircleCI versions will be cleared when we turn down the CircleCI pipeline. Adding new step `do_docker_azp` to `ci/do_ci.sh` to execute the forked scripts.

Modified `ci/run_envoy_docker.sh` to forward variables required by the docker scripts. Since we regularly copy this script from Envoy, the custom lines are marked as `# unique` and the maintenance steps in `MAINTAINERS.md` are updated to indicate the presence of these unique lines.

Works on #820.