### PR TITLE
Disable integration tests that cannot execute locally.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -64,11 +64,11 @@ function do_opt_build () {
 }
 
 function do_test() {
-    # The environment variable CI is used to determine if some expensive tests
-    # that cannot run locally should be executed.
+    # The environment variable AZP_BRANCH is used to determine if some expensive
+    # tests that cannot run locally should be executed.
     # E.g. test_http_h1_mini_stress_test_open_loop.
-    run_on_build_parts "bazel build -c dbg $BAZEL_BUILD_OPTIONS --action_env=CI"
-    bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all --action_env=CI //test/...
+    run_on_build_parts "bazel build -c dbg $BAZEL_BUILD_OPTIONS --action_env=AZP_BRANCH"
+    bazel test -c dbg $BAZEL_TEST_OPTIONS --test_output=all --action_env=AZP_BRANCH //test/...
 }
 
 function do_clang_tidy() {

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -143,6 +143,8 @@ def test_http_h2_mini_stress_test_without_client_side_queueing(http_test_server_
   asserts.assertNotIn("upstream_rq_pending_overflow", counters)
 
 
+@pytest.mark.skipif(not utility.isRunningInAzpCi(),
+                    reason="Has very high failure rate in local executions.")
 @pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable and very slow in sanitizer runs")
 def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   """Run an H1 open loop stress test. We expect higher pending and overflow counts."""
@@ -155,6 +157,8 @@ def test_http_h1_mini_stress_test_open_loop(http_test_server_fixture):
   asserts.assertCounterGreater(counters, "benchmark.pool_overflow", 10)
 
 
+@pytest.mark.skipif(not utility.isRunningInAzpCi(),
+                    reason="Has very high failure rate in local executions.")
 @pytest.mark.skipif(utility.isSanitizerRun(), reason="Unstable and very slow in sanitizer runs")
 def test_http_h2_mini_stress_test_open_loop(http_test_server_fixture):
   """Run an H2 open loop stress test. We expect higher overflow counts."""

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -74,3 +74,15 @@ def count_log_lines_with_substring(logs, substring):
     An integer, the number of log entries that contain the substring.
   """
   return len([line for line in logs.split(os.linesep) if substring in line])
+
+
+def isRunningInAzpCi():
+  """Determine if the current execution is running in the AZP CI.
+
+  Depends on the environment variable AZP_BRANCH which is set in
+  .azure-pipelines/bazel.yml.
+
+  Returns:
+      bool: True iff the current execution is running in the AZP CI.
+  """
+  return True if os.environ.get("AZP_BRANCH", "") else False


### PR DESCRIPTION
These were disabled previously and were incorrectly enabled in #837.
They will execute in AZP CI.

Fixes #842.

Verified that they are skipped locally:

```
[gw1] [ 25%] SKIPPED test/integration/test_integration_basics.py::test_http_h2_mini_stress_test_open_loop[IpVersion.IPV4]
[gw0] [ 31%] SKIPPED test/integration/test_integration_basics.py::test_http_h1_mini_stress_test_open_loop[IpVersion.IPV4]
```

And are [executed in AZP](https://dev.azure.com/cncf/envoy/_build/results?buildId=106921&view=logs&s=859b8d9a-8fd6-5a5c-6f5e-f84f1990894e&j=a10fa2d5-ad16-525d-3f64-d3c7d0f53774):
```
[gw1] [ 66%] PASSED ../../../../../../../../../../../../../../../source/test/integration/test_integration_basics.py::test_http_h2_mini_stress_test_open_loop[IpVersion.IPV4] 
[gw0] [ 77%] PASSED ../../../../../../../../../../../../../../../source/test/integration/test_integration_basics.py::test_http_h1_mini_stress_test_open_loop[IpVersion.IPV4] 
```

Signed-off-by: Jakub Sobon <mumak@google.com>