### PR TITLE
Update Envoy to 84b6682 (May 23, 2022)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -106,8 +106,8 @@ build:clang-asan --linkopt --unwindlib=libgcc
 
 # macOS
 build:macos --cxxopt=-std=c++17
-build:macos --action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
-build:macos --host_action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
+build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
+build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --define tcmalloc=disabled
 build:macos --define wasm=disabled
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "f1a3fd1c549e86a02aa222784bcef9bf63dca19d"
-ENVOY_SHA = "092e7243de4cd49e1ac9de611996a9dcc9fa2f398ef5e3f92fc90269abfcbfab"
+ENVOY_COMMIT = "84b66829bdda86c719047ccc3c0a4fc2f2e2c328"  # May 23, 2022
+ENVOY_SHA = "37061191b50281149a58a7234b2640e98651038d4cad9a81b94a4c98864207ba"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "84b66829bdda86c719047ccc3c0a4fc2f2e2c328"  # May 23, 2022
+ENVOY_COMMIT = "84b66829bdda86c719047ccc3c0a4fc2f2e2c328"
 ENVOY_SHA = "37061191b50281149a58a7234b2640e98651038d4cad9a81b94a4c98864207ba"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -191,7 +191,7 @@ public:
           host, priority, dispatcher, options, transport_socket_options,
           context_.api().randomGenerator(), state,
           [](Envoy::Http::HttpConnPoolImplBase* pool) {
-            return std::make_unique<Envoy::Http::Http1::ActiveClient>(*pool);
+            return std::make_unique<Envoy::Http::Http1::ActiveClient>(*pool, absl::nullopt);
           },
           [](Envoy::Upstream::Host::CreateConnectionData& data,
              Envoy::Http::HttpConnPoolImplBase* pool) {


### PR DESCRIPTION
- Envoy's `.bazelrc` reordered the tools paths on macOS
- `Envoy::Http::Http1::ActiveClient` 1-arg constructor was removed; migrated to the 2-arg constructor with the second arg `absl::nullopt` 

Signed-off-by: eric846 <56563761+eric846@users.noreply.github.com>