### PR TITLE
Clean up all remaining instances of no_extension_lookup_by_name

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -151,6 +151,7 @@ envoy_cc_test(
     deps = [
         "//source/client:nighthawk_client_lib",
         "//test/client:utility_lib",
+        "//test/sink:test_stats_sink_config_proto_cc_proto",
         "//test/test_common:environment_lib",
         "@envoy//test/test_common:network_utility_lib",
         "@envoy//test/test_common:registry_lib",

--- a/test/integration/configurations/nighthawk_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_http_origin.yaml
@@ -44,8 +44,3 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
-layered_runtime:
-  layers:
-  - name: static_layer
-    static_layer:
-      envoy.reloadable_features.no_extension_lookup_by_name: false

--- a/test/integration/configurations/nighthawk_https_origin.yaml
+++ b/test/integration/configurations/nighthawk_https_origin.yaml
@@ -53,8 +53,3 @@ static_resources:
                     private_key:
                       inline_string: |
                         @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem
-layered_runtime:
-  layers:
-  - name: static_layer
-    static_layer:
-      envoy.reloadable_features.no_extension_lookup_by_name: false

--- a/test/integration/configurations/nighthawk_https_origin_dsa.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_dsa.yaml
@@ -53,8 +53,3 @@ static_resources:
                     private_key:
                       inline_string: |
                         @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/server_ecdsakey.pem
-layered_runtime:
-  layers:
-  - name: static_layer
-    static_layer:
-      envoy.reloadable_features.no_extension_lookup_by_name: false

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -58,9 +58,3 @@ static_resources:
                       private_key:
                           inline_string: |
                             @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem
-layered_runtime:
-  layers:
-  - name: static_layer
-    static_layer:
-      envoy.reloadable_features.no_extension_lookup_by_name: false
-      

--- a/test/integration/configurations/nighthawk_track_timings.yaml
+++ b/test/integration/configurations/nighthawk_track_timings.yaml
@@ -44,8 +44,3 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
-layered_runtime:
-  layers:
-  - name: static_layer
-    static_layer:
-      envoy.reloadable_features.no_extension_lookup_by_name: false

--- a/test/integration/configurations/sni_origin.yaml
+++ b/test/integration/configurations/sni_origin.yaml
@@ -33,7 +33,9 @@ static_resources:
                     @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem
     listener_filters:
     - name: "envoy.filters.listener.tls_inspector"
-      typed_config: {}
+      typed_config: {
+          "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      }
     filter_chains:
     - filter_chain_match:
         server_names: ["sni.com"]
@@ -97,8 +99,3 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
-layered_runtime:
-  layers:
-  - name: static_layer
-    static_layer:
-      envoy.reloadable_features.no_extension_lookup_by_name: false

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -18,6 +18,7 @@
 #include "source/common/uri_impl.h"
 
 #include "test/client/utility.h"
+#include "test/sink/test_stats_sink_config.pb.h"
 
 #include "gtest/gtest.h"
 
@@ -28,7 +29,10 @@ namespace {
 using ::testing::TestWithParam;
 using ::testing::ValuesIn;
 
-constexpr absl::string_view kSinkName = "{name:\"nighthawk.fake_stats_sink\"}";
+constexpr absl::string_view kSinkConfig =
+    "{name:\"nighthawk.fake_stats_sink\",typed_config:{\"@type\":\"type."
+    "googleapis.com/"
+    "nighthawk.TestStatsSinkConfig\"}}";
 // Global variable keeps count of number of flushes in FakeStatsSink. It is reset
 // to 0 when a new FakeStatsSink is created.
 int numFlushes = 0;
@@ -55,7 +59,7 @@ public:
   Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     // Using Struct instead of a custom per-filter empty config proto
     // This is only allowed in tests.
-    return Envoy::ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Struct()};
+    return Envoy::ProtobufTypes::MessagePtr{new nighthawk::TestStatsSinkConfig()};
   }
 
   std::string name() const override { return "nighthawk.fake_stats_sink"; }
@@ -183,7 +187,7 @@ TEST_P(ProcessTest, RunProcessWithStatsSinkConfigured) {
   options_ = TestUtility::createOptionsImpl(
       fmt::format("foo --h2 --duration 1 --rps 10 --stats-flush-interval 1 "
                   "--stats-sinks {} https://{}/",
-                  kSinkName, loopback_address_));
+                  kSinkConfig, loopback_address_));
   numFlushes = 0;
   ASSERT_TRUE(runProcess(RunExpectation::EXPECT_FAILURE).ok());
   EXPECT_GT(numFlushes, 0);
@@ -195,7 +199,7 @@ TEST_P(ProcessTest, NoFlushWhenCancelExecutionBeforeLoadTestBegin) {
   options_ = TestUtility::createOptionsImpl(
       fmt::format("foo --duration 300 --failure-predicate foo:0 --concurrency "
                   "2 --stats-flush-interval 1 --stats-sinks {} https://{}/",
-                  kSinkName, loopback_address_));
+                  kSinkConfig, loopback_address_));
   numFlushes = 0;
   ASSERT_TRUE(runProcess(RunExpectation::EXPECT_SUCCESS, true, true).ok());
   EXPECT_EQ(numFlushes, 0);

--- a/test/sink/BUILD
+++ b/test/sink/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_test",
     "envoy_package",
 )
+load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
 
@@ -39,4 +40,12 @@ envoy_cc_test(
         "//test/test_common:environment_lib",
         "@envoy//test/test_common:network_utility_lib",
     ],
+)
+
+api_cc_py_proto_library(
+    name = "test_stats_sink_config_proto",
+    srcs = [
+        "test_stats_sink_config.proto",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/test/sink/test_stats_sink_config.proto
+++ b/test/sink/test_stats_sink_config.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package nighthawk;
+
+// Empty config currently required for us to support envoy plugin lookup, which
+// is by unique proto.
+message TestStatsSinkConfig {
+}


### PR DESCRIPTION
Required changes:
- Removed all runtime overrides.
- Added type declaration for `envoy.filters.listener.tls_inspector`.
- Added empty config proto for fake stats sink and used it in relevant places.

Signed-off-by: Nathan Perry <nbperry@google.com>