### PR TITLE
Update test-server.yaml on README.md

### DIFF
--- a/source/server/README.md
+++ b/source/server/README.md
@@ -50,7 +50,8 @@ static_resources:
                   - name: dynamic-delay
                     typed_config:
                       "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
-                      static_delay: 0.5s
+                      experimental_response_options:
+                        static_delay: 0.5s
                   - name: test-server # before envoy.router because order matters!
                     typed_config:
                       "@type": type.googleapis.com/nighthawk.server.ResponseOptions


### PR DESCRIPTION
The current test-server.yaml returns the following error "Protobuf message (type envoy.config.bootstrap.v3.Bootstrap reason INVALID_ARGUMENT:static_delay: Cannot find field.) has unknown fields".

By adding "experimental_response_options:" this error is fixed.

This fix is already in multiple docs, but missing on this particular README.

Signed-off-by: Lucas Martinez <57833320+martinezlucas98@users.noreply.github.com>