### PR TITLE
Support specifying custom HTTP3 protocol options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,11 +373,11 @@ load multiplier combined with the configured --rps and --connections
 values. Default: 1.
 
 --http3-protocol-options <string>
-HTTP3 protocol options in json. If specified, Nighthawk uses these
-HTTP3 protocol options when sending requests. Only valid with
---protocol http3. Exclusive with any other command line option that
-would modify the http3 protocol options, e.g.
---max-concurrent-streams. Example (json):
+HTTP3 protocol options (envoy::config::core::v3::Http3ProtocolOptions)
+in json. If specified, Nighthawk uses these HTTP3 protocol options
+when sending requests. Only valid with --protocol http3. Mutually
+exclusive with any other command line option that would modify the
+http3 protocol options, e.g. --max-concurrent-streams. Example (json):
 {quic_protocol_options:{max_concurrent_streams:1}}
 
 -p <http1|http2|http3>,  --protocol <http1|http2|http3>

--- a/README.md
+++ b/README.md
@@ -181,11 +181,13 @@ format>] [--sequencer-idle-strategy <spin
 <json|human|yaml|dotted|fortio
 |experimental_fortio_pedantic>] [-v <trace
 |debug|info|warn|error|critical>]
-[--concurrency <string>] [-p <http1|http2
-|http3>] [--h2] [--timeout <uint32_t>]
-[--duration <uint32_t>] [--connections
-<uint32_t>] [--rps <uint32_t>] [--]
-[--version] [-h] <uri format>
+[--concurrency <string>]
+[--http3-protocol-options <string>] [-p
+<http1|http2|http3>] [--h2] [--timeout
+<uint32_t>] [--duration <uint32_t>]
+[--connections <uint32_t>] [--rps
+<uint32_t>] [--] [--version] [-h] <uri
+format>
 
 
 Where:
@@ -369,6 +371,14 @@ The number of concurrent event loops that should be used. Specify
 Nighthawk process. Note that increasing this results in an effective
 load multiplier combined with the configured --rps and --connections
 values. Default: 1.
+
+--http3-protocol-options <string>
+HTTP3 protocol options in json. If specified, Nighthawk uses these
+HTTP3 protocol options when sending requests. Only valid with
+--protocol http3. Exclusive with any other command line option that
+would modify the http3 protocol options, e.g.
+--max-concurrent-streams. Example (json):
+{quic_protocol_options:{max_concurrent_streams:1}}
 
 -p <http1|http2|http3>,  --protocol <http1|http2|http3>
 The protocol to encapsulate requests in. Possible values: [http1,

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -7,6 +7,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
+import "envoy/config/core/v3/protocol.proto";
 import "envoy/config/metrics/v3/stats.proto";
 import "envoy/extensions/transport_sockets/tls/v3/cert.proto";
 import "envoy/config/core/v3/extension.proto";
@@ -127,7 +128,7 @@ message Protocol {
 
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
-// Highest unused number is 111.
+// Highest unused number is 112.
 message CommandLineOptions {
   // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
@@ -153,6 +154,12 @@ message CommandLineOptions {
     // The protocol to use when encapsulating requests.
     Protocol protocol = 107;
   }
+
+  // Allows user to set specific HTTP3 protocol options.
+  // Only valid when protocol is set to HTTP3.
+  // Is exclusive with any other command line option that would modify the
+  // http3 protocol options, e.g. max_concurrent_streams.
+  envoy.config.core.v3.Http3ProtocolOptions http3_protocol_options = 111;
 
   // The number of concurrent event loops that should be used. Specify 'auto' to let
   // Nighthawk leverage all vCPUs that have affinity to the Nighthawk process. Note that

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -10,6 +10,7 @@
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/address.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/core/v3/protocol.pb.h"
 #include "envoy/config/metrics/v3/stats.pb.h"
 #include "envoy/http/protocol.h"
 
@@ -43,6 +44,10 @@ public:
   // The protocol to encapsulate requests in.
   // Defaults to HTTP/1.1 if the user doesn't make an explicit selection.
   virtual Envoy::Http::Protocol protocol() const PURE;
+
+  // The following sets specific protocol options.
+  virtual const absl::optional<envoy::config::core::v3::Http3ProtocolOptions>&
+  http3ProtocolOptions() const PURE;
 
   virtual std::string concurrency() const PURE;
   virtual nighthawk::client::Verbosity::VerbosityOptions verbosity() const PURE;

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -45,7 +45,7 @@ public:
   // Defaults to HTTP/1.1 if the user doesn't make an explicit selection.
   virtual Envoy::Http::Protocol protocol() const PURE;
 
-  // The following sets specific protocol options.
+  // The following sets specific protocol options for http3.
   virtual const absl::optional<envoy::config::core::v3::Http3ProtocolOptions>&
   http3ProtocolOptions() const PURE;
 

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -79,9 +79,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::ValueArg<std::string> http3_protocol_options(
       "", "http3-protocol-options",
       "HTTP3 protocol options in json. If specified, Nighthawk uses these HTTP3 protocol options "
-      "when sending requests. Only valid with --protocol http3. Exclusive with any other command "
-      "line option that would modify the http3 protocol options, e.g. --max-concurrent-streams. "
-      "Example (json): "
+      "when sending requests. Only valid with --protocol http3. Mutually exclusive with any other "
+      "command line option that would modify the http3 protocol options, e.g. "
+      "--max-concurrent-streams. Example (json): "
       "{quic_protocol_options:{max_concurrent_streams:1}}",
       false, "", "string", cmd);
 

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -78,10 +78,10 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       false, "", &protocols_allowed, cmd);
   TCLAP::ValueArg<std::string> http3_protocol_options(
       "", "http3-protocol-options",
-      "HTTP3 protocol options in json. If specified, Nighthawk uses these HTTP3 protocol options "
-      "when sending requests. Only valid with --protocol http3. Mutually exclusive with any other "
-      "command line option that would modify the http3 protocol options, e.g. "
-      "--max-concurrent-streams. Example (json): "
+      "HTTP3 protocol options (envoy::config::core::v3::Http3ProtocolOptions) in json. If "
+      "specified, Nighthawk uses these HTTP3 protocol options when sending requests. Only valid "
+      "with --protocol http3. Mutually exclusive with any other command line option that would "
+      "modify the http3 protocol options, e.g. --max-concurrent-streams. Example (json): "
       "{quic_protocol_options:{max_concurrent_streams:1}}",
       false, "", "string", cmd);
 

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -37,7 +37,13 @@ public:
   std::chrono::seconds duration() const override { return std::chrono::seconds(duration_); }
   std::chrono::seconds timeout() const override { return std::chrono::seconds(timeout_); }
   absl::optional<std::string> uri() const override { return uri_; }
+
   Envoy::Http::Protocol protocol() const override;
+  const absl::optional<envoy::config::core::v3::Http3ProtocolOptions>&
+  http3ProtocolOptions() const override {
+    return http3_protocol_options_;
+  }
+
   std::string concurrency() const override { return concurrency_; }
   nighthawk::client::Verbosity::VerbosityOptions verbosity() const override { return verbosity_; };
   nighthawk::client::OutputFormat::OutputFormatOptions outputFormat() const override {
@@ -120,8 +126,11 @@ private:
   uint32_t duration_{5};
   uint32_t timeout_{30};
   absl::optional<std::string> uri_;
+
   bool h2_{false}; // Deprecated.
   nighthawk::client::Protocol::ProtocolOptions protocol_{nighthawk::client::Protocol::HTTP1};
+  absl::optional<envoy::config::core::v3::Http3ProtocolOptions> http3_protocol_options_;
+
   std::string concurrency_;
   nighthawk::client::Verbosity::VerbosityOptions verbosity_{nighthawk::client::Verbosity::WARN};
   nighthawk::client::OutputFormat::OutputFormatOptions output_format_{

--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -151,11 +151,15 @@ Cluster createNighthawkClusterForWorker(const Client::Options& options,
     http2_options->mutable_max_concurrent_streams()->set_value(options.maxConcurrentStreams());
 
   } else if (options.protocol() == Envoy::Http::Protocol::Http3) {
-    Http3ProtocolOptions* http3_options =
-        http_options.mutable_explicit_http_config()->mutable_http3_protocol_options();
-    http3_options->mutable_quic_protocol_options()->mutable_max_concurrent_streams()->set_value(
-        options.maxConcurrentStreams());
-
+    if (options.http3ProtocolOptions().has_value()) {
+      *http_options.mutable_explicit_http_config()->mutable_http3_protocol_options() =
+          options.http3ProtocolOptions().value();
+    } else {
+      Http3ProtocolOptions* http3_options =
+          http_options.mutable_explicit_http_config()->mutable_http3_protocol_options();
+      http3_options->mutable_quic_protocol_options()->mutable_max_concurrent_streams()->set_value(
+          options.maxConcurrentStreams());
+    }
   } else {
     http_options.mutable_explicit_http_config()->mutable_http_protocol_options();
   }

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -340,8 +340,7 @@ def test_h3_quic_with_custom_http3_protocol_options(quic_test_server_fixture):
   Sets the maximum number of concurrent streams to one and verifies that
   Nighthawk uses multiple connections.
   """
-  address = quic_test_server_fixture.server_ip
-  http3_protocol_options = f"{{quic_protocol_options:{{max_concurrent_streams:1}}}}"
+  http3_protocol_options = "{quic_protocol_options:{max_concurrent_streams:1}}"
 
   parsed_json, _ = quic_test_server_fixture.runNighthawkClient([
       "--protocol http3",
@@ -354,8 +353,10 @@ def test_h3_quic_with_custom_http3_protocol_options(quic_test_server_fixture):
       "benchmark.http_2xx:99",
       "--max-active-requests",
       "10",
-      "--max-pending-requests", "10",
-      "--burst-size", "10",
+      "--max-pending-requests",
+      "10",
+      "--burst-size",
+      "10",
       # Envoy doesn't support disabling certificate verification on Quic
       # connections, so the host in our requests has to match the hostname in
       # the leaf certificate.

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -334,6 +334,40 @@ def test_h3_quic(quic_test_server_fixture):
   asserts.assertCounterEqual(counters, "default.total_match_count", 1)
 
 
+def test_h3_quic_with_custom_http3_protocol_options(quic_test_server_fixture):
+  """Test http3 quic with custom http3 protocol options.
+
+  Sets the maximum number of concurrent streams to one and verifies that
+  Nighthawk uses multiple connections.
+  """
+  address = quic_test_server_fixture.server_ip
+  http3_protocol_options = f"{{quic_protocol_options:{{max_concurrent_streams:1}}}}"
+
+  parsed_json, _ = quic_test_server_fixture.runNighthawkClient([
+      "--protocol http3",
+      quic_test_server_fixture.getTestServerRootUri(),
+      "--rps",
+      "100",
+      "--duration",
+      "100",
+      "--termination-predicate",
+      "benchmark.http_2xx:99",
+      "--max-active-requests",
+      "10",
+      "--max-pending-requests", "10",
+      "--burst-size", "10",
+      # Envoy doesn't support disabling certificate verification on Quic
+      # connections, so the host in our requests has to match the hostname in
+      # the leaf certificate.
+      "--request-header",
+      "Host:www.lyft.com",
+      "--http3-protocol-options %s" % http3_protocol_options
+  ])
+  counters = quic_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
+  asserts.assertCounterEqual(counters, "benchmark.http_2xx", 100)
+  asserts.assertCounterGreaterEqual(counters, "upstream_cx_http3_total", 10)
+
+
 def test_h3_quic_with_custom_upstream_bind_configuration(quic_test_server_fixture):
   """Test http3 quic with a custom upstream bind configuration.
 

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -18,6 +18,8 @@ public:
   MOCK_METHOD(absl::optional<std::string>, uri, (), (const, override));
   MOCK_METHOD(bool, h2, (), (const));
   MOCK_METHOD(Envoy::Http::Protocol, protocol, (), (const, override));
+  MOCK_METHOD(absl::optional<envoy::config::core::v3::Http3ProtocolOptions>&, http3ProtocolOptions,
+              (), (const, override));
   MOCK_METHOD(std::string, concurrency, (), (const, override));
   MOCK_METHOD(nighthawk::client::Verbosity::VerbosityOptions, verbosity, (), (const, override));
   MOCK_METHOD(nighthawk::client::OutputFormat::OutputFormatOptions, outputFormat, (),


### PR DESCRIPTION
Allows Nighthawk users to specify custom HTTP3 protocol options. Only valid when running with `--protocol http3`.

Signed-off-by: Jakub Sobon [mumak@google.com](mailto:mumak@google.com)