### PR TITLE
Don't verify the precise output of error messages from `json_util`.

### DIFF
--- a/test/server/http_filter_base_test.cc
+++ b/test/server/http_filter_base_test.cc
@@ -13,8 +13,7 @@ using ::testing::HasSubstr;
 
 enum TestRequestMethod { GET, POST };
 
-const std::string kBadConfigErrorSentinel =
-    "Unable to parse JSON as proto (INVALID_ARGUMENT:Unexpected";
+const std::string kBadConfigErrorSentinel = "Unable to parse JSON as proto";
 
 class HttpFilterBaseIntegrationTest
     : public HttpFilterIntegrationTestBase,


### PR DESCRIPTION
This change is intended to remove test assertions that verify the precise output of error messages from Protobuf's `json_util.h` library. This will unblock potential migration to another JSON parser.

Signed-off-by: Jakub Sobon <mumak@google.com>