### PR TITLE
Fix construction order of `ServiceImpl` and `RequestSourceServiceImpl`.

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -61,6 +61,23 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
 
+- stage: test_gcc
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: test_gcc
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        test_gcc:
+          CI_TARGET: "test_gcc"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
 - stage: sanitizers
   dependsOn: ["test"]
   pool: "x64-large"
@@ -102,6 +119,7 @@ stages:
 - stage: release
   dependsOn:
   - "clang_tidy"
+  - "test_gcc"
   - "sanitizers"
   - "coverage"
   condition: eq(variables['PostSubmit'], true)

--- a/source/client/service_impl.h
+++ b/source/client/service_impl.h
@@ -55,10 +55,10 @@ private:
   void writeResponse(const nighthawk::client::ExecutionResponse& response);
   grpc::Status finishGrpcStream(const bool success, absl::string_view description = "");
 
+  Envoy::Thread::MutexBasicLockable log_lock_;
   std::unique_ptr<Envoy::Logger::Context> logging_context_;
   std::shared_ptr<Envoy::ProcessWide> process_wide_;
   Envoy::Event::RealTimeSystem time_system_; // NO_CHECK_FORMAT(real_time)
-  Envoy::Thread::MutexBasicLockable log_lock_;
   grpc::ServerReaderWriter<nighthawk::client::ExecutionResponse,
                            nighthawk::client::ExecutionRequest>* stream_;
   std::future<void> future_;

--- a/source/client/service_impl.h
+++ b/source/client/service_impl.h
@@ -95,8 +95,8 @@ public:
                                nighthawk::request_source::RequestStreamRequest>* stream) override;
 
 private:
-  std::unique_ptr<Envoy::Logger::Context> logging_context_;
   Envoy::Thread::MutexBasicLockable log_lock_;
+  std::unique_ptr<Envoy::Logger::Context> logging_context_;
   RequestSourcePtr createStaticEmptyRequestSource(const uint32_t amount);
 };
 


### PR DESCRIPTION
Also re-enable `text_gcc`.

Fixes #872.

**Details**:
- `ServiceImpl` creates `Envoy::Logger::Context` which requires `Envoy::Thread::MutexBasicLockable`.
- The `Envoy::Thread::MutexBasicLockable` was constructed after the `Envoy::Logger::Context`, so `Envoy::Logger::Context` became invalid during destruction of `ServiceImpl`.
- this PR ensures that `Envoy::Thread::MutexBasicLockable` lives longer than `Envoy::Logger::Context`.
- Fixing the same problem in the construction of `RequestSourceServiceImpl`.

**Reason for `test_gcc` failure:**
- https://github.com/envoyproxy/envoy/pull/21884 triggered this bug, because it added a logging call initiated indirectly from the destructor of `Envoy::ProcessWide`.
- This logging call happened during the destruction of `ServiceImpl` when the `Envoy::Thread::MutexBasicLockable` instance was already destroyed.
- As a result the PURE virtual methods on its parent object `Envoy::Thread::BasicLockable` were called.
- `test_gcc` reported it because it places a special function meant to detect this behavior in the `vtbl` of unimplemented pure virtual methods.

Signed-off-by: Jakub Sobon <mumak@google.com>