### PR TITLE
Update python dependencies to their latest version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests==2.24.0
 pytest==6.0.1
 pytest-dependency==0.5.1
 pytest-xdist==1.34.0
-apipkg==1.5
-pyyaml==5.4
-zipp==3.1.0
-importlib_metadata==1.7.0
+apipkg>=3.0.1, <4.0.0
+pyyaml>=6.0.0, <7.0.0
+zipp>=3.8.1, <4.0.0
+importlib_metadata>=4.12.0, <5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
-requests==2.24.0
-pytest==6.0.1
-pytest-dependency==0.5.1
-pytest-xdist==1.34.0
+requests>=2.28.1, <3.0.0
+pytest>=7.1.2, <8.0.0
+pytest-dependency>=0.5.1, <0.6.0 # versions below 1.0.0 are unstable, so we should only take in bugfixes automatically
+pytest-xdist>=2.5.0, <3.0.0
 apipkg>=3.0.1, <4.0.0
 pyyaml>=6.0.0, <7.0.0
 zipp>=3.8.1, <4.0.0
 importlib_metadata>=4.12.0, <5.0.0
+more_itertools>=8.13.0, <9.0.0
+chardet>=5.0.0, <6.0.0
+six>=1.16.0, <2.0.0


### PR DESCRIPTION
Also, set it up so that we take in non-major version updates.

Updating pytest and request required adding in new dependencies.

This address some of the problems in https://github.com/envoyproxy/nighthawk/issues/819.

Signed-off-by: Nathan Perry <nbperry@google.com>