### PR TITLE
Create documentation for finding major dependency updates

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -73,6 +73,9 @@ important maintenance task. When performing the update, follow this procedure:
    [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/tools/gen_compilation_database.py) to
    update our build configurations. Be sure to retain our local modifications,
    all lines that are unique to Nighthawk are marked with comment `# unique`.
+1. If [requirements.txt](requirements.txt) has not been updated in the last month (based on comment at top
+   of file), check for major dependency updates. See
+   [Finding python dependencies](#finding-python-dependencies) below for instructions.
 1. Run `ci/do_ci.sh test`. Sometimes the dependency update comes with changes
    that break our build. Include any changes required to Nighthawk to fix that
    in the same PR.
@@ -86,8 +89,8 @@ important maintenance task. When performing the update, follow this procedure:
 
 ## Finding python dependencies
 
-We should check our python dependencies periodically for major version updates. Here is an easy
-way to check for major dependency updates:
+We should check our python dependencies periodically for major version updates. We attempt to
+update these dependencies monthly. Here is an easy way to check for major dependency updates:
 
 1. Create and activate a virtual env:
    ```
@@ -112,8 +115,10 @@ way to check for major dependency updates:
    dependencies you may have in addition, such as to `pip` itself. Here, we are only interested in
    cross-referencing the ones that appear with the ones in requirements.txt.
 
-   If you find any, you can either try updating the dependency in requirements.txt yourself or create
-   an issue for the change and assign it to one of the nighthawk maintainers.
+1. If you find any dependency updates, you can either try updating the dependency in requirements.txt yourself
+   or create an issue for the change and assign it to one of the nighthawk maintainers.
+
+   If there are not any dependency updates, please update the timestamp at the top of the file.
 
 1. When done, clean up the virtual env:
 
@@ -127,7 +132,9 @@ way to check for major dependency updates:
 If you encounter an error that looks like:
 
 ```
-RROR: REDACTED/nighthawk/test/integration/BUILD:32:11: no such package '@python_pip_deps//pypi__more_itertools': BUILD file not found in directory 'pypi__more_itertools' of external repository @python_pip_deps. Add a BUILD file to a directory to mark it as a package. and referenced by '//test/integration:integration_test_base_lean'
+RROR: REDACTED/nighthawk/test/integration/BUILD:32:11: no such package '@python_pip_deps//pypi__more_itertools':
+BUILD file not found in directory 'pypi__more_itertools' of external repository @python_pip_deps. Add a BUILD
+file to a directory to mark it as a package. and referenced by '//test/integration:integration_test_base_lean'
 ```
 
 Then we are missing a dependency from requirements.txt. This may happen due to changing other

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -84,6 +84,47 @@ important maintenance task. When performing the update, follow this procedure:
 1. Create a PR with a title like `Update Envoy to 9753819 (Jan 24th 2021)`,
    describe all performed changes in the PR's description.
 
+## Update python dependencies
+
+We should check our python dependencies periodically for major version updates. Here is an easy
+way to check for major dependency updates:
+
+1. Create and activate a virtual env:
+
+```
+virtualenv pip_update_env
+source pip_update_env/bin/activate
+```
+
+NOTE: if `pip_update_env/bin/activate` appears to not exist, try
+`pip_update_env/local/bin/activate` instead.
+
+2. Install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+3. Check for outdated dependencies:
+
+```
+pip list --outdated
+```
+
+This will likely show both outdated dependencies based on requirements.txt and other outdated
+dependencies you may have in addition, such as to `pip` itself. Here, we are only interested in
+cross-referencing the ones that appear with the ones in requirements.txt.
+
+If you find any, you can either try updating the dependency in requirements.txt yourself or create
+an issue for the change and assign it to one of the nighthawk maintainers.
+
+4. When done, clean up the virtual env:
+
+```
+deactivate
+rm -rf pip_update_env
+```
+
 ## Identifying an Envoy commit that introduced a breakage
 
 ### Background

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -84,46 +84,43 @@ important maintenance task. When performing the update, follow this procedure:
 1. Create a PR with a title like `Update Envoy to 9753819 (Jan 24th 2021)`,
    describe all performed changes in the PR's description.
 
-## Update python dependencies
+## Finding python dependencies
 
 We should check our python dependencies periodically for major version updates. Here is an easy
 way to check for major dependency updates:
 
 1. Create and activate a virtual env:
+   ```
+   virtualenv pip_update_env
+   source pip_update_env/bin/activate
+   ```
+   NOTE: if `pip_update_env/bin/activate` appears to not exist, try
+   `pip_update_env/local/bin/activate` instead.
 
-```
-virtualenv pip_update_env
-source pip_update_env/bin/activate
-```
+1. Install dependencies:
 
-NOTE: if `pip_update_env/bin/activate` appears to not exist, try
-`pip_update_env/local/bin/activate` instead.
+   ```
+   pip install -r requirements.txt
+   ```
 
-2. Install dependencies:
+1. Check for outdated dependencies:
 
-```
-pip install -r requirements.txt
-```
+   ```
+   pip list --outdated
+   ```
+   This will likely show both outdated dependencies based on requirements.txt and other outdated
+   dependencies you may have in addition, such as to `pip` itself. Here, we are only interested in
+   cross-referencing the ones that appear with the ones in requirements.txt.
 
-3. Check for outdated dependencies:
+   If you find any, you can either try updating the dependency in requirements.txt yourself or create
+   an issue for the change and assign it to one of the nighthawk maintainers.
 
-```
-pip list --outdated
-```
+1. When done, clean up the virtual env:
 
-This will likely show both outdated dependencies based on requirements.txt and other outdated
-dependencies you may have in addition, such as to `pip` itself. Here, we are only interested in
-cross-referencing the ones that appear with the ones in requirements.txt.
-
-If you find any, you can either try updating the dependency in requirements.txt yourself or create
-an issue for the change and assign it to one of the nighthawk maintainers.
-
-4. When done, clean up the virtual env:
-
-```
-deactivate
-rm -rf pip_update_env
-```
+   ```
+   deactivate
+   rm -rf pip_update_env
+   ```
 
 ## Identifying an Envoy commit that introduced a breakage
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -132,7 +132,7 @@ update these dependencies monthly. Here is an easy way to check for major depend
 If you encounter an error that looks like:
 
 ```
-RROR: REDACTED/nighthawk/test/integration/BUILD:32:11: no such package '@python_pip_deps//pypi__more_itertools':
+ERROR: REDACTED/nighthawk/test/integration/BUILD:32:11: no such package '@python_pip_deps//pypi__more_itertools':
 BUILD file not found in directory 'pypi__more_itertools' of external repository @python_pip_deps. Add a BUILD
 file to a directory to mark it as a package. and referenced by '//test/integration:integration_test_base_lean'
 ```

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -122,6 +122,19 @@ way to check for major dependency updates:
    rm -rf pip_update_env
    ```
 
+### Bazel Python Error
+
+If you encounter an error that looks like:
+
+```
+RROR: REDACTED/nighthawk/test/integration/BUILD:32:11: no such package '@python_pip_deps//pypi__more_itertools': BUILD file not found in directory 'pypi__more_itertools' of external repository @python_pip_deps. Add a BUILD file to a directory to mark it as a package. and referenced by '//test/integration:integration_test_base_lean'
+```
+
+Then we are missing a dependency from requirements.txt. This may happen due to changing other
+dependencies.
+
+The name of the dependency to add is everything after `pypi__`, in the above case `more_itertools`.
+
 ## Identifying an Envoy commit that introduced a breakage
 
 ### Background

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
-requests>=2.28.1, <3.0.0
+# Last updated 2022-08-02
+apipkg>=3.0.1, <4.0.0
+chardet>=5.0.0, <6.0.0
+importlib_metadata>=4.12.0, <5.0.0
+more_itertools>=8.13.0, <9.0.0
 pytest>=7.1.2, <8.0.0
 pytest-dependency>=0.5.1, <0.6.0 # versions below 1.0.0 are unstable, so we should only take in bugfixes automatically
 pytest-xdist>=2.5.0, <3.0.0
-apipkg>=3.0.1, <4.0.0
 pyyaml>=6.0.0, <7.0.0
-zipp>=3.8.1, <4.0.0
-importlib_metadata>=4.12.0, <5.0.0
-more_itertools>=8.13.0, <9.0.0
-chardet>=5.0.0, <6.0.0
+requests>=2.28.1, <3.0.0
 six>=1.16.0, <2.0.0
+zipp>=3.8.1, <4.0.0


### PR DESCRIPTION
Documentation includes:
1. Added step to check for python dependencies once a month when updating envoy.
2. Included documentation for how to find python dependency updates.
3. Included a section on identifying a class of errors as needing a new dependency, which was part of what made #819 more confusing.