### PR TITLE
Add new GetMetricByNameWithReportingPeriod function

### DIFF
--- a/include/nighthawk/adaptive_load/BUILD
+++ b/include/nighthawk/adaptive_load/BUILD
@@ -70,6 +70,9 @@ envoy_basic_cc_library(
 
 envoy_basic_cc_library(
     name = "metrics_plugin",
+    srcs = [
+        "metrics_plugin.cc",
+    ],
     hdrs = [
         "metrics_plugin.h",
     ],

--- a/include/nighthawk/adaptive_load/metrics_evaluator.h
+++ b/include/nighthawk/adaptive_load/metrics_evaluator.h
@@ -43,8 +43,7 @@ public:
    * MetricSpec.
    * @param threshold_spec A proto describing the threshold and scoring function. Nullptr if the
    * metric is informational only.
-   * @param start_time The start time where the metric is relevant
-   * @param duration The duration where the metric is relevant.
+   * @param measuring_period The time period where the metric is relevant
    *
    * @return StatusOr<MetricEvaluation> A proto containing the metric value (and its score if a
    * threshold was specified), or an error status if the metric could not be obtained from the
@@ -54,8 +53,7 @@ public:
   EvaluateMetric(const nighthawk::adaptive_load::MetricSpec& metric_spec,
                  MetricsPlugin& metrics_plugin,
                  const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
-                 const google::protobuf::Timestamp& start_time,
-                 const google::protobuf::Duration& duration) const PURE;
+                 const MeasuringPeriod& measuring_period) const PURE;
 
   /**
    * Extracts pointers to metric descriptors and corresponding thresholds from a top-level adaptive

--- a/include/nighthawk/adaptive_load/metrics_evaluator.h
+++ b/include/nighthawk/adaptive_load/metrics_evaluator.h
@@ -43,7 +43,8 @@ public:
    * MetricSpec.
    * @param threshold_spec A proto describing the threshold and scoring function. Nullptr if the
    * metric is informational only.
-   * @param reporting_period The time period where the metric is relevant
+   * @param reporting_period the time period the Nighthawk test iteration is sending the intended
+   * load (i.e. the time period in which the metrics are of interest).
    *
    * @return StatusOr<MetricEvaluation> A proto containing the metric value (and its score if a
    * threshold was specified), or an error status if the metric could not be obtained from the

--- a/include/nighthawk/adaptive_load/metrics_evaluator.h
+++ b/include/nighthawk/adaptive_load/metrics_evaluator.h
@@ -43,6 +43,8 @@ public:
    * MetricSpec.
    * @param threshold_spec A proto describing the threshold and scoring function. Nullptr if the
    * metric is informational only.
+   * @param start_time The start time where the metric is relevant
+   * @param duration The duration where the metric is relevant.
    *
    * @return StatusOr<MetricEvaluation> A proto containing the metric value (and its score if a
    * threshold was specified), or an error status if the metric could not be obtained from the
@@ -51,7 +53,9 @@ public:
   virtual absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>
   EvaluateMetric(const nighthawk::adaptive_load::MetricSpec& metric_spec,
                  MetricsPlugin& metrics_plugin,
-                 const nighthawk::adaptive_load::ThresholdSpec* threshold_spec) const PURE;
+                 const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
+                 const google::protobuf::Timestamp& start_time,
+                 const google::protobuf::Duration& duration) const PURE;
 
   /**
    * Extracts pointers to metric descriptors and corresponding thresholds from a top-level adaptive

--- a/include/nighthawk/adaptive_load/metrics_evaluator.h
+++ b/include/nighthawk/adaptive_load/metrics_evaluator.h
@@ -43,7 +43,7 @@ public:
    * MetricSpec.
    * @param threshold_spec A proto describing the threshold and scoring function. Nullptr if the
    * metric is informational only.
-   * @param measuring_period The time period where the metric is relevant
+   * @param reporting_period The time period where the metric is relevant
    *
    * @return StatusOr<MetricEvaluation> A proto containing the metric value (and its score if a
    * threshold was specified), or an error status if the metric could not be obtained from the
@@ -53,7 +53,7 @@ public:
   EvaluateMetric(const nighthawk::adaptive_load::MetricSpec& metric_spec,
                  MetricsPlugin& metrics_plugin,
                  const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
-                 const MeasuringPeriod& measuring_period) const PURE;
+                 const ReportingPeriod& reporting_period) const PURE;
 
   /**
    * Extracts pointers to metric descriptors and corresponding thresholds from a top-level adaptive

--- a/include/nighthawk/adaptive_load/metrics_plugin.cc
+++ b/include/nighthawk/adaptive_load/metrics_plugin.cc
@@ -1,0 +1,15 @@
+#include "nighthawk/adaptive_load/metrics_plugin.h"
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+namespace Nighthawk {
+
+absl::StatusOr<double>
+MetricsPlugin::GetMetricByNameWithTime(absl::string_view metric_name,
+                                       const google::protobuf::Timestamp& start_time,
+                                       const google::protobuf::Duration& duration) {
+  return absl::Status{absl::StatusCode::kUnimplemented, "GetMetricByNameWithTime not implemented."};
+}
+
+} // namespace Nighthawk

--- a/include/nighthawk/adaptive_load/metrics_plugin.cc
+++ b/include/nighthawk/adaptive_load/metrics_plugin.cc
@@ -5,10 +5,10 @@
 
 namespace Nighthawk {
 
-absl::StatusOr<double>
-MetricsPlugin::GetMetricByNameWithTime(absl::string_view metric_name,
-                                       const google::protobuf::Timestamp& start_time,
-                                       const google::protobuf::Duration& duration) {
+absl::StatusOr<double> MetricsPlugin::GetMetricByNameWithTime(
+    [[maybe_unused]] absl::string_view metric_name,
+    [[maybe_unused]] const google::protobuf::Timestamp& start_time,
+    [[maybe_unused]] const google::protobuf::Duration& duration) {
   return absl::Status{absl::StatusCode::kUnimplemented, "GetMetricByNameWithTime not implemented."};
 }
 

--- a/include/nighthawk/adaptive_load/metrics_plugin.cc
+++ b/include/nighthawk/adaptive_load/metrics_plugin.cc
@@ -5,10 +5,9 @@
 
 namespace Nighthawk {
 
-absl::StatusOr<double> MetricsPlugin::GetMetricByNameWithTime(
+absl::StatusOr<double> MetricsPlugin::GetMetricByNameWithMeasuringPeriod(
     [[maybe_unused]] absl::string_view metric_name,
-    [[maybe_unused]] const google::protobuf::Timestamp& start_time,
-    [[maybe_unused]] const google::protobuf::Duration& duration) {
+    [[maybe_unused]] const MeasuringPeriod& measuring_period) {
   return absl::Status{absl::StatusCode::kUnimplemented, "GetMetricByNameWithTime not implemented."};
 }
 

--- a/include/nighthawk/adaptive_load/metrics_plugin.cc
+++ b/include/nighthawk/adaptive_load/metrics_plugin.cc
@@ -5,10 +5,11 @@
 
 namespace Nighthawk {
 
-absl::StatusOr<double> MetricsPlugin::GetMetricByNameWithMeasuringPeriod(
+absl::StatusOr<double> MetricsPlugin::GetMetricByNameWithReportingPeriod(
     [[maybe_unused]] absl::string_view metric_name,
-    [[maybe_unused]] const MeasuringPeriod& measuring_period) {
-  return absl::Status{absl::StatusCode::kUnimplemented, "GetMetricByNameWithTime not implemented."};
+    [[maybe_unused]] const ReportingPeriod& reporting_period) {
+  return absl::Status{absl::StatusCode::kUnimplemented,
+                      "GetMetricByNameWithReportingPeriod not implemented."};
 }
 
 } // namespace Nighthawk

--- a/include/nighthawk/adaptive_load/metrics_plugin.h
+++ b/include/nighthawk/adaptive_load/metrics_plugin.h
@@ -53,7 +53,7 @@ public:
    *
    * @param metric_name The name of the metric to retrieve. Must be supported by the plugin.
    * @param reporting_period the time period the Nighthawk test iteration is sending the intended
-   * load (i.e. the time period in which the metrics are of interest.)
+   * load (i.e. the time period in which the metrics are of interest).
    *
    * @return StatusOr<double> The metric value, or an error status if the metric was unsupported or
    * unavailable.

--- a/include/nighthawk/adaptive_load/metrics_plugin.h
+++ b/include/nighthawk/adaptive_load/metrics_plugin.h
@@ -27,6 +27,23 @@ public:
    * unavailable.
    */
   virtual absl::StatusOr<double> GetMetricByName(absl::string_view metric_name) PURE;
+
+  /**
+   * Obtains the numeric metric with the given name, usually by querying an outside system. Provides
+   * start_time and duration of measurement period for the plugin to utilitize.
+   *
+   * @param metric_name The name of the metric to retrieve. Must be supported by the plugin.
+   * @param start_time start_time with duration indicates when the metric is relevant.
+   * @param duration start_time with duration indicates when the metric is relevant.
+   *
+   * @return StatusOr<double> The metric value, or an error status if the metric was unsupported or
+   * unavailable.
+   */
+  virtual absl::StatusOr<double>
+  GetMetricByNameWithTime(absl::string_view metric_name,
+                          const google::protobuf::Timestamp& start_time,
+                          const google::protobuf::Duration& duration);
+
   /**
    * All metric names implemented by this plugin, for use in input validation.
    *

--- a/include/nighthawk/adaptive_load/metrics_plugin.h
+++ b/include/nighthawk/adaptive_load/metrics_plugin.h
@@ -11,11 +11,18 @@
 
 namespace Nighthawk {
 
-// Describes the period in which a Metrics plugin should measure.
-struct MeasuringPeriod {
-  // The beginning of the time period where nighthawk is measuring.
+// Describes the period of time where the Nighthawk test iteration is sending the intended load.
+// Metric Plugins should report metrics relevant to this time period.
+// For example, if a plugin is tracking the peak memory usage of a system under test. When given
+// this data, it should filter the memory usage samples to only include data points in this time
+// period and then calculate the peak usage out of those data points.
+struct ReportingPeriod {
+  // start time of the latest (current) iteration of Nighthawk test in the adaptive stage. See
+  // https://github.com/envoyproxy/nighthawk/blob/main/docs/root/adaptive_load_controller.md#the-adaptive-load-controller
+  // for more information on adaptive load testing.
   google::protobuf::Timestamp start_time;
-  // The duration of the time period nighthawk is measuring.
+
+  // The duration of the time where nighthawk is sending the intended load in the adaptive stage.
   google::protobuf::Duration duration;
 };
 
@@ -34,21 +41,26 @@ public:
    * @return StatusOr<double> The metric value, or an error status if the metric was unsupported or
    * unavailable.
    */
+  ABSL_DEPRECATED("Use GetMetricByNameWithReportingPeriod instead.")
   virtual absl::StatusOr<double> GetMetricByName(absl::string_view metric_name) PURE;
 
   /**
    * Obtains the numeric metric with the given name, usually by querying an outside system. Provides
-   * measuring_period to allow plugins to determine what time period is relevant.
+   * reporting_period to allow plugins to determine what metrics to consider report.
+   * For example, if a plugin is tracking the peak memory usage of a system under test. When given
+   * this data, it should filter the memory usage samples to only include data points in this time
+   * period and then calculate the peak usage out of those data points.
    *
    * @param metric_name The name of the metric to retrieve. Must be supported by the plugin.
-   * @param measuring_period the time period when the metric is relevant.
+   * @param reporting_period the time period the Nighthawk test iteration is sending the intended
+   * load (i.e. the time period in which the metrics are of interest.)
    *
    * @return StatusOr<double> The metric value, or an error status if the metric was unsupported or
    * unavailable.
    */
   virtual absl::StatusOr<double>
-  GetMetricByNameWithMeasuringPeriod(absl::string_view metric_name,
-                                     const MeasuringPeriod& measuring_period);
+  GetMetricByNameWithReportingPeriod(absl::string_view metric_name,
+                                     const ReportingPeriod& reporting_period);
 
   /**
    * All metric names implemented by this plugin, for use in input validation.

--- a/include/nighthawk/adaptive_load/metrics_plugin.h
+++ b/include/nighthawk/adaptive_load/metrics_plugin.h
@@ -38,7 +38,7 @@ public:
 
   /**
    * Obtains the numeric metric with the given name, usually by querying an outside system. Provides
-   * start_time and duration of measurement period for the plugin to utilitize.
+   * measuring_period to allow plugins to determine what time period is relevant.
    *
    * @param metric_name The name of the metric to retrieve. Must be supported by the plugin.
    * @param measuring_period the time period when the metric is relevant.

--- a/include/nighthawk/adaptive_load/metrics_plugin.h
+++ b/include/nighthawk/adaptive_load/metrics_plugin.h
@@ -11,6 +11,14 @@
 
 namespace Nighthawk {
 
+// Describes the period in which a Metrics plugin should measure.
+struct MeasuringPeriod {
+  // The beginning of the time period where nighthawk is measuring.
+  google::protobuf::Timestamp start_time;
+  // The duration of the time period nighthawk is measuring.
+  google::protobuf::Duration duration;
+};
+
 /**
  * An interface for plugins that retrieve platform-specific metrics from outside data sources.
  * Connection info is passed via a plugin-specific config proto.
@@ -33,16 +41,14 @@ public:
    * start_time and duration of measurement period for the plugin to utilitize.
    *
    * @param metric_name The name of the metric to retrieve. Must be supported by the plugin.
-   * @param start_time start_time with duration indicates when the metric is relevant.
-   * @param duration start_time with duration indicates when the metric is relevant.
+   * @param measuring_period the time period when the metric is relevant.
    *
    * @return StatusOr<double> The metric value, or an error status if the metric was unsupported or
    * unavailable.
    */
   virtual absl::StatusOr<double>
-  GetMetricByNameWithTime(absl::string_view metric_name,
-                          const google::protobuf::Timestamp& start_time,
-                          const google::protobuf::Duration& duration);
+  GetMetricByNameWithMeasuringPeriod(absl::string_view metric_name,
+                                     const MeasuringPeriod& measuring_period);
 
   /**
    * All metric names implemented by this plugin, for use in input validation.

--- a/source/adaptive_load/metrics_evaluator_impl.cc
+++ b/source/adaptive_load/metrics_evaluator_impl.cc
@@ -91,8 +91,6 @@ MetricsEvaluatorImpl::AnalyzeNighthawkBenchmark(
                         nighthawk_response.error_detail().message());
   }
 
-  // nighthawk_response.output.timestamp
-  // nighthawk_response.output.options.duration
   nighthawk::adaptive_load::BenchmarkResult benchmark_result;
   *benchmark_result.mutable_nighthawk_service_output() = nighthawk_response.output();
 

--- a/source/adaptive_load/metrics_evaluator_impl.cc
+++ b/source/adaptive_load/metrics_evaluator_impl.cc
@@ -15,7 +15,8 @@ using ::nighthawk::adaptive_load::MetricSpec;
 using ::nighthawk::adaptive_load::MetricSpecWithThreshold;
 using ::nighthawk::adaptive_load::ThresholdSpec;
 
-// Extract estimated measuring period from Nighthawk output proto.
+// Extract estimated reporting period from Nighthawk output proto. Reporting period is the time when
+// in when all workers are active and thus sending the intended amount of traffic.
 absl::StatusOr<ReportingPeriod> GetReportingPeriod(const nighthawk::client::Output& output) {
   if (output.results().empty()) {
     return absl::Status{absl::StatusCode::kInvalidArgument, "output.results cannot be empty."};

--- a/source/adaptive_load/metrics_evaluator_impl.cc
+++ b/source/adaptive_load/metrics_evaluator_impl.cc
@@ -16,24 +16,43 @@ using ::nighthawk::adaptive_load::MetricSpecWithThreshold;
 using ::nighthawk::adaptive_load::ThresholdSpec;
 
 // Extract estimated measuring period from Nighthawk output proto.
-absl::StatusOr<MeasuringPeriod> GetMeasuringPeriod(const nighthawk::client::Output& output) {
+absl::StatusOr<ReportingPeriod> GetReportingPeriod(const nighthawk::client::Output& output) {
   if (output.results().empty()) {
     return absl::Status{absl::StatusCode::kInvalidArgument, "output.results cannot be empty."};
   }
-  // Assume the first result is a good representation for the entire run.
-  MeasuringPeriod time_interval;
-  time_interval.start_time = output.results(0).execution_start();
-  time_interval.duration = output.results(0).execution_duration();
-  return time_interval;
+  // Find the reporting_period in which all workers are active and thus sending the intended amount
+  // of traffic.
+  ReportingPeriod reporting_period;
+  google::protobuf::Timestamp max_start_time = output.results(0).execution_start();
+  google::protobuf::Timestamp min_end_time =
+      output.results(0).execution_start() + output.results(0).execution_duration();
+  for (const auto& result : output.results()) {
+    if (result.execution_start() > max_start_time) {
+      max_start_time = result.execution_start();
+    }
+    if (result.execution_start() + result.execution_duration() < min_end_time) {
+      min_end_time = result.execution_start() + result.execution_duration();
+    }
+  }
+  // we've calculated a negative duration. This indicates that nighthawk never actually reached the
+  // intended load among all workers.
+  if (min_end_time <= max_start_time) {
+    return absl::Status{absl::StatusCode::kInvalidArgument,
+                        "Reported execution times in output.results indicate that there is no time "
+                        "where all workers were active."};
+  }
+  reporting_period.start_time = max_start_time;
+  reporting_period.duration = min_end_time - max_start_time;
+  return reporting_period;
 }
 
 // Utility function for GetMetric functionality with fallback logic.
 absl::StatusOr<double> GetMetric(MetricsPlugin& metrics_plugin, absl::string_view metric_name,
-                                 const MeasuringPeriod& measuring_period) {
+                                 const ReportingPeriod& reporting_period) {
   absl::StatusOr<double> metric_value_or =
-      metrics_plugin.GetMetricByNameWithMeasuringPeriod(metric_name, measuring_period);
-  // If the metric plugin does not support WithTime implementation (i.e. is using the default
-  // implementation), default to GetMetricByName
+      metrics_plugin.GetMetricByNameWithReportingPeriod(metric_name, reporting_period);
+  // If the metric plugin does not support WithReportingPeriod implementation (i.e. is using the
+  // default implementation), default to GetMetricByName
   if (metric_value_or.status().code() == absl::StatusCode::kUnimplemented) {
     return metrics_plugin.GetMetricByName(metric_name);
   }
@@ -45,12 +64,12 @@ absl::StatusOr<double> GetMetric(MetricsPlugin& metrics_plugin, absl::string_vie
 absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>
 MetricsEvaluatorImpl::EvaluateMetric(const MetricSpec& metric_spec, MetricsPlugin& metrics_plugin,
                                      const ThresholdSpec* threshold_spec,
-                                     const MeasuringPeriod& measuring_period) const {
+                                     const ReportingPeriod& reporting_period) const {
   nighthawk::adaptive_load::MetricEvaluation evaluation;
   evaluation.set_metric_id(
       absl::StrCat(metric_spec.metrics_plugin_name(), "/", metric_spec.metric_name()));
   const absl::StatusOr<double> metric_value_or =
-      GetMetric(metrics_plugin, metric_spec.metric_name(), measuring_period);
+      GetMetric(metrics_plugin, metric_spec.metric_name(), reporting_period);
   if (!metric_value_or.ok()) {
     return absl::Status(static_cast<absl::StatusCode>(metric_value_or.status().code()),
                         absl::StrCat("Error calling MetricsPlugin '",
@@ -117,10 +136,10 @@ MetricsEvaluatorImpl::AnalyzeNighthawkBenchmark(
   const std::vector<std::pair<const MetricSpec*, const ThresholdSpec*>> spec_threshold_pairs =
       ExtractMetricSpecs(spec);
 
-  absl::StatusOr<MeasuringPeriod> measuring_period_or =
-      GetMeasuringPeriod(nighthawk_response.output());
-  if (!measuring_period_or.ok()) {
-    return measuring_period_or.status();
+  absl::StatusOr<ReportingPeriod> reporting_period_or =
+      GetReportingPeriod(nighthawk_response.output());
+  if (!reporting_period_or.ok()) {
+    return reporting_period_or.status();
   }
   std::vector<std::string> errors;
   for (const std::pair<const MetricSpec*, const ThresholdSpec*>& spec_threshold_pair :
@@ -128,7 +147,7 @@ MetricsEvaluatorImpl::AnalyzeNighthawkBenchmark(
     absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation> evaluation_or =
         EvaluateMetric(*spec_threshold_pair.first,
                        *name_to_plugin_map[spec_threshold_pair.first->metrics_plugin_name()],
-                       spec_threshold_pair.second, *measuring_period_or);
+                       spec_threshold_pair.second, *reporting_period_or);
     if (!evaluation_or.ok()) {
       errors.emplace_back(absl::StrCat("Error evaluating metric: ", evaluation_or.status().code(),
                                        ": ", evaluation_or.status().message()));

--- a/source/adaptive_load/metrics_evaluator_impl.cc
+++ b/source/adaptive_load/metrics_evaluator_impl.cc
@@ -4,6 +4,7 @@
 
 #include "api/adaptive_load/metric_spec.pb.h"
 
+#include "nighthawk/adaptive_load/metrics_evaluator.h"
 #include "source/adaptive_load/metrics_plugin_impl.h"
 #include "source/adaptive_load/plugin_loader.h"
 
@@ -15,12 +16,23 @@ using ::nighthawk::adaptive_load::MetricSpec;
 using ::nighthawk::adaptive_load::MetricSpecWithThreshold;
 using ::nighthawk::adaptive_load::ThresholdSpec;
 
+// Extract estimated measuring period from Nighthawk output proto.
+absl::StatusOr<MeasuringPeriod> GetMeasuringPeriod(const nighthawk::client::Output& output) {
+  if (output.results().empty()) {
+    return absl::Status{absl::StatusCode::kInvalidArgument, "output.results cannot be empty."};
+  }
+  // Assume the first result is a good representation for the entire run.
+  MeasuringPeriod time_interval;
+  time_interval.start_time = output.results(0).execution_start();
+  time_interval.duration = output.results(0).execution_duration();
+  return time_interval;
+}
+
 // Utility function for GetMetric functionality with fallback logic.
 absl::StatusOr<double> GetMetric(MetricsPlugin& metrics_plugin, absl::string_view metric_name,
-                                 const google::protobuf::Timestamp& start_time,
-                                 const google::protobuf::Duration& duration) {
+                                 const MeasuringPeriod& measuring_period) {
   absl::StatusOr<double> metric_value_or =
-      metrics_plugin.GetMetricByNameWithTime(metric_name, start_time, duration);
+      metrics_plugin.GetMetricByNameWithMeasuringPeriod(metric_name, measuring_period);
   // If the metric plugin does not support WithTime implementation (i.e. is using the default
   // implementation), default to GetMetricByName
   if (metric_value_or.status().code() == absl::StatusCode::kUnimplemented) {
@@ -34,13 +46,12 @@ absl::StatusOr<double> GetMetric(MetricsPlugin& metrics_plugin, absl::string_vie
 absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>
 MetricsEvaluatorImpl::EvaluateMetric(const MetricSpec& metric_spec, MetricsPlugin& metrics_plugin,
                                      const ThresholdSpec* threshold_spec,
-                                     const google::protobuf::Timestamp& start_time,
-                                     const google::protobuf::Duration& duration) const {
+                                     const MeasuringPeriod& measuring_period) const {
   nighthawk::adaptive_load::MetricEvaluation evaluation;
   evaluation.set_metric_id(
       absl::StrCat(metric_spec.metrics_plugin_name(), "/", metric_spec.metric_name()));
   const absl::StatusOr<double> metric_value_or =
-      GetMetric(metrics_plugin, metric_spec.metric_name(), start_time, duration);
+      GetMetric(metrics_plugin, metric_spec.metric_name(), measuring_period);
   if (!metric_value_or.ok()) {
     return absl::Status(static_cast<absl::StatusCode>(metric_value_or.status().code()),
                         absl::StrCat("Error calling MetricsPlugin '",
@@ -107,14 +118,18 @@ MetricsEvaluatorImpl::AnalyzeNighthawkBenchmark(
   const std::vector<std::pair<const MetricSpec*, const ThresholdSpec*>> spec_threshold_pairs =
       ExtractMetricSpecs(spec);
 
+  absl::StatusOr<MeasuringPeriod> measuring_period_or =
+      GetMeasuringPeriod(nighthawk_response.output());
+  if (!measuring_period_or.ok()) {
+    return measuring_period_or.status();
+  }
   std::vector<std::string> errors;
   for (const std::pair<const MetricSpec*, const ThresholdSpec*>& spec_threshold_pair :
        spec_threshold_pairs) {
     absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation> evaluation_or =
         EvaluateMetric(*spec_threshold_pair.first,
                        *name_to_plugin_map[spec_threshold_pair.first->metrics_plugin_name()],
-                       spec_threshold_pair.second, nighthawk_response.output().timestamp(),
-                       nighthawk_response.output().options().duration());
+                       spec_threshold_pair.second, *measuring_period_or);
     if (!evaluation_or.ok()) {
       errors.emplace_back(absl::StrCat("Error evaluating metric: ", evaluation_or.status().code(),
                                        ": ", evaluation_or.status().message()));

--- a/source/adaptive_load/metrics_evaluator_impl.cc
+++ b/source/adaptive_load/metrics_evaluator_impl.cc
@@ -4,7 +4,6 @@
 
 #include "api/adaptive_load/metric_spec.pb.h"
 
-#include "nighthawk/adaptive_load/metrics_evaluator.h"
 #include "source/adaptive_load/metrics_plugin_impl.h"
 #include "source/adaptive_load/plugin_loader.h"
 

--- a/source/adaptive_load/metrics_evaluator_impl.h
+++ b/source/adaptive_load/metrics_evaluator_impl.h
@@ -8,8 +8,7 @@ public:
   EvaluateMetric(const nighthawk::adaptive_load::MetricSpec& metric_spec,
                  MetricsPlugin& metrics_plugin,
                  const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
-                 const google::protobuf::Timestamp& start_time,
-                 const google::protobuf::Duration& duration) const override;
+                 const MeasuringPeriod& measuring_period) const override;
 
   const std::vector<std::pair<const nighthawk::adaptive_load::MetricSpec*,
                               const nighthawk::adaptive_load::ThresholdSpec*>>

--- a/source/adaptive_load/metrics_evaluator_impl.h
+++ b/source/adaptive_load/metrics_evaluator_impl.h
@@ -8,7 +8,7 @@ public:
   EvaluateMetric(const nighthawk::adaptive_load::MetricSpec& metric_spec,
                  MetricsPlugin& metrics_plugin,
                  const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
-                 const MeasuringPeriod& measuring_period) const override;
+                 const ReportingPeriod& reporting_period) const override;
 
   const std::vector<std::pair<const nighthawk::adaptive_load::MetricSpec*,
                               const nighthawk::adaptive_load::ThresholdSpec*>>

--- a/source/adaptive_load/metrics_evaluator_impl.h
+++ b/source/adaptive_load/metrics_evaluator_impl.h
@@ -7,7 +7,9 @@ public:
   absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>
   EvaluateMetric(const nighthawk::adaptive_load::MetricSpec& metric_spec,
                  MetricsPlugin& metrics_plugin,
-                 const nighthawk::adaptive_load::ThresholdSpec* threshold_spec) const override;
+                 const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
+                 const google::protobuf::Timestamp& start_time,
+                 const google::protobuf::Duration& duration) const override;
 
   const std::vector<std::pair<const nighthawk::adaptive_load::MetricSpec*,
                               const nighthawk::adaptive_load::ThresholdSpec*>>

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
@@ -41,17 +41,6 @@ absl::StatusOr<double> FakeMetricsPlugin::GetMetricByName(absl::string_view metr
   return value_or_error_from_name_[metric_name];
 }
 
-FakeMetricsPluginWithMeasuringPeriod::FakeMetricsPluginWithMeasuringPeriod(
-    const nighthawk::adaptive_load::FakeMetricsPluginConfig& config)
-    : FakeMetricsPlugin(config) {}
-
-absl::StatusOr<double> FakeMetricsPluginWithMeasuringPeriod::GetMetricByNameWithMeasuringPeriod(
-    absl::string_view metric_name, const MeasuringPeriod& measuring_period) {
-  return absl::InternalError(
-      absl::StrCat("Call for '", metric_name, "' with measuring period starting at ",
-                   Envoy::Protobuf::util::TimeUtil::ToString(measuring_period.start_time), " for ",
-                   Envoy::Protobuf::util::TimeUtil::ToString(measuring_period.duration)));
-}
 
 const std::vector<std::string> FakeMetricsPlugin::GetAllSupportedMetricNames() const {
   std::vector<std::string> metric_names;

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
@@ -41,6 +41,18 @@ absl::StatusOr<double> FakeMetricsPlugin::GetMetricByName(absl::string_view metr
   return value_or_error_from_name_[metric_name];
 }
 
+FakeMetricsPluginWithMeasuringPeriod::FakeMetricsPluginWithMeasuringPeriod(
+    const nighthawk::adaptive_load::FakeMetricsPluginConfig& config)
+    : FakeMetricsPlugin(config) {}
+
+absl::StatusOr<double> FakeMetricsPluginWithMeasuringPeriod::GetMetricByNameWithMeasuringPeriod(
+    absl::string_view metric_name, const MeasuringPeriod& measuring_period) {
+  return absl::InternalError(
+      absl::StrCat("Call for '", metric_name, "' with measuring period starting at ",
+                   Envoy::Protobuf::util::TimeUtil::ToString(measuring_period.start_time), " for ",
+                   Envoy::Protobuf::util::TimeUtil::ToString(measuring_period.duration)));
+}
+
 const std::vector<std::string> FakeMetricsPlugin::GetAllSupportedMetricNames() const {
   std::vector<std::string> metric_names;
   for (const auto& key_value : value_or_error_from_name_) {

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.h
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.h
@@ -11,7 +11,9 @@
 namespace Nighthawk {
 
 /**
- * MetricsPlugin for testing, supporting fixed values and artificial errors.
+ * MetricsPlugin for testing, supporting fixed values and artificial errors. Note that this class
+ * intentionally does not override GetMetricByNameWithReportingPeriod to properly test fallback
+ * behavior.
  */
 class FakeMetricsPlugin : public MetricsPlugin {
 public:
@@ -33,22 +35,6 @@ public:
 
 private:
   absl::flat_hash_map<std::string, absl::StatusOr<double>> value_or_error_from_name_;
-};
-
-// MetricsPlugin for testing to test GetMetricByNameWithMeasuringPeriod override behavior.
-class FakeMetricsPluginWithMeasuringPeriod : public FakeMetricsPlugin {
-public:
-  /**
-   * Initializes the fake plugin with a FakeMetricsPluginConfig proto.
-   *
-   * @param config FakeMetricsPluginConfig proto for setting the fixed metric value.
-   */
-  explicit FakeMetricsPluginWithMeasuringPeriod(
-      const nighthawk::adaptive_load::FakeMetricsPluginConfig& config);
-
-  absl::StatusOr<double>
-  GetMetricByNameWithMeasuringPeriod(absl::string_view metric_name,
-                                     const MeasuringPeriod& measuring_period) override;
 };
 
 /**

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.h
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.h
@@ -35,7 +35,21 @@ private:
   absl::flat_hash_map<std::string, absl::StatusOr<double>> value_or_error_from_name_;
 };
 
-// TODO(zhangtom): Create a child class of above that overrides WithMeasuringPeriod.
+// MetricsPlugin for testing to test GetMetricByNameWithMeasuringPeriod override behavior.
+class FakeMetricsPluginWithMeasuringPeriod : public FakeMetricsPlugin {
+public:
+  /**
+   * Initializes the fake plugin with a FakeMetricsPluginConfig proto.
+   *
+   * @param config FakeMetricsPluginConfig proto for setting the fixed metric value.
+   */
+  explicit FakeMetricsPluginWithMeasuringPeriod(
+      const nighthawk::adaptive_load::FakeMetricsPluginConfig& config);
+
+  absl::StatusOr<double>
+  GetMetricByNameWithMeasuringPeriod(absl::string_view metric_name,
+                                     const MeasuringPeriod& measuring_period) override;
+};
 
 /**
  * Factory that creates a FakeMetricsPlugin plugin from a FakeMetricsPluginConfig proto.

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.h
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.h
@@ -35,6 +35,8 @@ private:
   absl::flat_hash_map<std::string, absl::StatusOr<double>> value_or_error_from_name_;
 };
 
+// TODO(zhangtom): Create a child class of above that overrides WithMeasuringPeriod.
+
 /**
  * Factory that creates a FakeMetricsPlugin plugin from a FakeMetricsPluginConfig proto.
  * Registered as an Envoy plugin.

--- a/test/adaptive_load/metrics_evaluator_test.cc
+++ b/test/adaptive_load/metrics_evaluator_test.cc
@@ -79,12 +79,11 @@ TEST(EvaluateMetric, SetsMetricIdForValidMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
-  google::protobuf::Timestamp start_time;
-  google::protobuf::Duration duration;
+  MeasuringPeriod measuring_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
-      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, start_time, duration);
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, measuring_period);
   ASSERT_TRUE(evaluation_or.ok());
   nighthawk::adaptive_load::MetricEvaluation evaluation = evaluation_or.value();
   EXPECT_EQ(evaluation.metric_id(), "nighthawk.fake_metrics_plugin/good-metric");
@@ -105,12 +104,11 @@ TEST(EvaluateMetric, PropagatesMetricsPluginError) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
-  google::protobuf::Timestamp start_time;
-  google::protobuf::Duration duration;
+  MeasuringPeriod measuring_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
-      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, start_time, duration);
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, measuring_period);
   ASSERT_FALSE(evaluation_or.ok());
   EXPECT_EQ(static_cast<int>(evaluation_or.status().code()), kExpectedStatusCode);
   EXPECT_THAT(evaluation_or.status().message(), HasSubstr(kExpectedStatusMessage));
@@ -129,12 +127,11 @@ TEST(EvaluateMetric, StoresMetricValueForValidMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
-  google::protobuf::Timestamp start_time;
-  google::protobuf::Duration duration;
+  MeasuringPeriod measuring_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
-      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, start_time, duration);
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, measuring_period);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().metric_value(), kExpectedValue);
 }
@@ -153,12 +150,11 @@ TEST(EvaluateMetric, SetsWeightToZeroForValidInformationalMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
-  google::protobuf::Timestamp start_time;
-  google::protobuf::Duration duration;
+  MeasuringPeriod measuring_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
-      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, start_time, duration);
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, measuring_period);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().weight(), 0.0);
 }
@@ -184,12 +180,11 @@ TEST(EvaluateMetric, SetsWeightForValidScoredMetric) {
   *threshold_spec.mutable_scoring_function() =
       MakeLowerThresholdBinaryScoringFunctionConfig(kLowerThreshold);
 
-  google::protobuf::Timestamp start_time;
-  google::protobuf::Duration duration;
+  MeasuringPeriod measuring_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, start_time, duration);
+      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, measuring_period);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().weight(), kExpectedWeight);
 }
@@ -213,12 +208,11 @@ TEST(EvaluateMetric, SetsScoreForValidMetric) {
   *threshold_spec.mutable_scoring_function() =
       MakeLowerThresholdBinaryScoringFunctionConfig(kLowerThreshold);
 
-  google::protobuf::Timestamp start_time;
-  google::protobuf::Duration duration;
+  MeasuringPeriod measuring_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, start_time, duration);
+      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, measuring_period);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().threshold_score(), -1.0);
 }
@@ -382,6 +376,10 @@ TEST(AnalyzeNighthawkBenchmark, UsesBuiltinMetricsPluginForUnspecifiedPluginName
   ASSERT_GT(result_or.value().metric_evaluations().size(), 0);
   EXPECT_EQ(result_or.value().metric_evaluations()[0].metric_value(), kExpectedSendRate);
 }
+
+// TODO(zhangtom): Unit test that implements fallback logic.
+
+// TODO(zhangtom): Unit test that errors out with no results proto.
 
 } // namespace
 } // namespace Nighthawk

--- a/test/adaptive_load/metrics_evaluator_test.cc
+++ b/test/adaptive_load/metrics_evaluator_test.cc
@@ -1,4 +1,5 @@
 #include "external/envoy/source/common/protobuf/protobuf.h"
+#include "external/envoy/test/mocks/common.h"
 
 #include "api/adaptive_load/benchmark_result.pb.h"
 #include "api/adaptive_load/metric_spec.pb.h"
@@ -22,7 +23,24 @@ using ::nighthawk::adaptive_load::FakeMetricsPluginConfig;
 using ::nighthawk::adaptive_load::MetricEvaluation;
 using ::nighthawk::adaptive_load::MetricSpec;
 using ::nighthawk::adaptive_load::ThresholdSpec;
+
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::Eq;
+using ::testing::Field;
 using ::testing::HasSubstr;
+using ::testing::Return;
+
+// For testing MetricPlugin with GetMetricByNameWithReportingPeriod defined.
+class MockMetricsPluginWithReportingPeriod : public FakeMetricsPlugin {
+public:
+  explicit MockMetricsPluginWithReportingPeriod(
+      const nighthawk::adaptive_load::FakeMetricsPluginConfig& config)
+      : FakeMetricsPlugin(config) {}
+
+  MOCK_METHOD(absl::StatusOr<double>, GetMetricByNameWithReportingPeriod,
+              (absl::string_view metric_name, const ReportingPeriod& reporting_period), (override));
+};
 
 /**
  * Creates a valid TypedExtensionConfig proto selecting the real BinaryScoringFunction plugin
@@ -79,11 +97,11 @@ TEST(EvaluateMetric, SetsMetricIdForValidMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
-  MeasuringPeriod measuring_period;
+  ReportingPeriod reporting_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
-      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, measuring_period);
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, reporting_period);
   ASSERT_TRUE(evaluation_or.ok());
   nighthawk::adaptive_load::MetricEvaluation evaluation = evaluation_or.value();
   EXPECT_EQ(evaluation.metric_id(), "nighthawk.fake_metrics_plugin/good-metric");
@@ -104,11 +122,11 @@ TEST(EvaluateMetric, PropagatesMetricsPluginError) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
-  MeasuringPeriod measuring_period;
+  ReportingPeriod reporting_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
-      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, measuring_period);
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, reporting_period);
   ASSERT_FALSE(evaluation_or.ok());
   EXPECT_EQ(static_cast<int>(evaluation_or.status().code()), kExpectedStatusCode);
   EXPECT_THAT(evaluation_or.status().message(), HasSubstr(kExpectedStatusMessage));
@@ -127,11 +145,11 @@ TEST(EvaluateMetric, StoresMetricValueForValidMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
-  MeasuringPeriod measuring_period;
+  ReportingPeriod reporting_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
-      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, measuring_period);
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, reporting_period);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().metric_value(), kExpectedValue);
 }
@@ -150,11 +168,11 @@ TEST(EvaluateMetric, SetsWeightToZeroForValidInformationalMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
-  MeasuringPeriod measuring_period;
+  ReportingPeriod reporting_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
-      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, measuring_period);
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, reporting_period);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().weight(), 0.0);
 }
@@ -180,11 +198,11 @@ TEST(EvaluateMetric, SetsWeightForValidScoredMetric) {
   *threshold_spec.mutable_scoring_function() =
       MakeLowerThresholdBinaryScoringFunctionConfig(kLowerThreshold);
 
-  MeasuringPeriod measuring_period;
+  ReportingPeriod reporting_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, measuring_period);
+      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, reporting_period);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().weight(), kExpectedWeight);
 }
@@ -208,11 +226,11 @@ TEST(EvaluateMetric, SetsScoreForValidMetric) {
   *threshold_spec.mutable_scoring_function() =
       MakeLowerThresholdBinaryScoringFunctionConfig(kLowerThreshold);
 
-  MeasuringPeriod measuring_period;
+  ReportingPeriod reporting_period;
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, measuring_period);
+      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, reporting_period);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().threshold_score(), -1.0);
 }
@@ -377,12 +395,11 @@ TEST(AnalyzeNighthawkBenchmark, UsesBuiltinMetricsPluginForUnspecifiedPluginName
   EXPECT_EQ(result_or.value().metric_evaluations()[0].metric_value(), kExpectedSendRate);
 }
 
-TEST(AnalyzeNighthawkBenchmark, CorrectlyPrioritizesWithMeasuringPeriodImplementation) {
+TEST(AnalyzeNighthawkBenchmark, ReturnsErrorWithReportingPeriodImplementation) {
   nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec;
 
   const std::string kMetricName = "metric";
-  const std::string kWithMeasuringPeriodStatusMessage =
-      "Call for 'metric' with measuring period starting at 1970-01-01T00:01:00Z for 10s";
+  const std::string kWithReportingPeriodStatusMessage = "GetMetricByNameWithReportingPeriod Error";
 
   FakeMetricsPluginConfig metrics_plugin_config;
 
@@ -392,12 +409,12 @@ TEST(AnalyzeNighthawkBenchmark, CorrectlyPrioritizesWithMeasuringPeriodImplement
   *spec.mutable_informational_metric_specs()->Add() = metric_spec;
 
   nighthawk::client::ExecutionResponse nighthawk_response = MakeNighthawkResponseWithSendRate(1.0);
-  // Make the first result is unique to verify it is being used.
-  nighthawk_response.mutable_output()->mutable_results(0)->mutable_execution_start()->set_seconds(
-      60);
   absl::flat_hash_map<std::string, MetricsPluginPtr> name_to_custom_metrics_plugin_map;
-  name_to_custom_metrics_plugin_map["nighthawk.fake_metrics_plugin"] =
-      std::make_unique<FakeMetricsPluginWithMeasuringPeriod>(metrics_plugin_config);
+  std::unique_ptr<MockMetricsPluginWithReportingPeriod> plugin =
+      std::make_unique<MockMetricsPluginWithReportingPeriod>(metrics_plugin_config);
+  EXPECT_CALL(*plugin, GetMetricByNameWithReportingPeriod(_, _))
+      .WillRepeatedly(Return(absl::InternalError(kWithReportingPeriodStatusMessage)));
+  name_to_custom_metrics_plugin_map["nighthawk.fake_metrics_plugin"] = std::move(plugin);
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<BenchmarkResult> result_or = evaluator.AnalyzeNighthawkBenchmark(
@@ -405,23 +422,49 @@ TEST(AnalyzeNighthawkBenchmark, CorrectlyPrioritizesWithMeasuringPeriodImplement
   ASSERT_FALSE(result_or.ok());
   // All errors during evaluation are rolled up into a single InternalError.
   EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInternal);
-  EXPECT_THAT(result_or.status().message(), HasSubstr(kWithMeasuringPeriodStatusMessage));
+  EXPECT_THAT(result_or.status().message(), HasSubstr(kWithReportingPeriodStatusMessage));
+}
+
+TEST(AnalyzeNighthawkBenchmark, ReturnsSuccessWithReportingPeriodImplementation) {
+  nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec;
+
+  const std::string kMetricName = "good-metric";
+  const double kDeprecatedMetricValue = 123.0;
+
+  FakeMetricsPluginConfig metrics_plugin_config;
+  FakeMetricsPluginConfig::FakeMetric* fake_metric =
+      metrics_plugin_config.mutable_fake_metrics()->Add();
+  fake_metric->set_name(kMetricName);
+  fake_metric->set_value(kDeprecatedMetricValue);
+
+  MetricSpec metric_spec;
+  metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
+  metric_spec.set_metric_name(kMetricName);
+
+  *spec.mutable_informational_metric_specs()->Add() = metric_spec;
+
+  const double kOverrideMetricValue = 1337;
+  nighthawk::client::ExecutionResponse nighthawk_response = MakeNighthawkResponseWithSendRate(1.0);
+  absl::flat_hash_map<std::string, MetricsPluginPtr> name_to_custom_metrics_plugin_map;
+  std::unique_ptr<MockMetricsPluginWithReportingPeriod> plugin =
+      std::make_unique<MockMetricsPluginWithReportingPeriod>(metrics_plugin_config);
+  EXPECT_CALL(*plugin, GetMetricByNameWithReportingPeriod(_, _))
+      .WillRepeatedly(Return(kOverrideMetricValue));
+  name_to_custom_metrics_plugin_map["nighthawk.fake_metrics_plugin"] = std::move(plugin);
+
+  MetricsEvaluatorImpl evaluator;
+  absl::StatusOr<BenchmarkResult> result_or = evaluator.AnalyzeNighthawkBenchmark(
+      nighthawk_response, spec, name_to_custom_metrics_plugin_map);
+  ASSERT_TRUE(result_or.ok());
+  ASSERT_GT(result_or.value().metric_evaluations().size(), 0);
+  EXPECT_EQ(result_or.value().metric_evaluations()[0].metric_value(), kOverrideMetricValue);
 }
 
 TEST(AnalyzeNighthawkBenchmark, FailsWithNoResults) {
   nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec;
-
-  const std::string kMetricName = "bad-metric";
-
-  FakeMetricsPluginConfig metrics_plugin_config;
-  MetricSpec metric_spec;
-
   nighthawk::client::ExecutionResponse nighthawk_response = MakeNighthawkResponseWithSendRate(1.0);
   nighthawk_response.mutable_output()->clear_results();
-
   absl::flat_hash_map<std::string, MetricsPluginPtr> name_to_custom_metrics_plugin_map;
-  name_to_custom_metrics_plugin_map["nighthawk.fake_metrics_plugin"] =
-      std::make_unique<FakeMetricsPlugin>(metrics_plugin_config);
 
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<BenchmarkResult> result_or = evaluator.AnalyzeNighthawkBenchmark(
@@ -429,6 +472,67 @@ TEST(AnalyzeNighthawkBenchmark, FailsWithNoResults) {
   ASSERT_FALSE(result_or.ok());
   EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(result_or.status().message(), HasSubstr("output.results cannot be empty."));
+}
+
+// Utility to set the execution time and execution duration of a results object.
+void SetTimeAndDurationOnResult(nighthawk::client::Result* result, int64_t time_seconds,
+                                int64_t duration_seconds) {
+  result->mutable_execution_start()->set_seconds(time_seconds);
+  result->mutable_execution_start()->set_nanos(0);
+  result->mutable_execution_duration()->set_seconds(duration_seconds);
+  result->mutable_execution_duration()->set_nanos(0);
+}
+
+TEST(AnalyzeNighthawkBenchmark, FailsWithDurationWhereAllWorkersAreActive) {
+  nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec;
+  nighthawk::client::ExecutionResponse nighthawk_response = MakeNighthawkResponseWithSendRate(1.0);
+  SetTimeAndDurationOnResult(nighthawk_response.mutable_output()->mutable_results(0), 0, 100);
+  SetTimeAndDurationOnResult(nighthawk_response.mutable_output()->add_results(), 100, 100);
+  absl::flat_hash_map<std::string, MetricsPluginPtr> name_to_custom_metrics_plugin_map;
+
+  MetricsEvaluatorImpl evaluator;
+  absl::StatusOr<BenchmarkResult> result_or = evaluator.AnalyzeNighthawkBenchmark(
+      nighthawk_response, spec, name_to_custom_metrics_plugin_map);
+  ASSERT_FALSE(result_or.ok());
+  EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(result_or.status().message(),
+              HasSubstr("Reported execution times in output.results indicate that there is no time "
+                        "where all workers were active."));
+}
+
+TEST(AnalyzeNighthawkBenchmark, SelectsOverlappingReportingWithAllWorkers) {
+  nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec;
+  const std::string kMetricName = "good-metric";
+  FakeMetricsPluginConfig metrics_plugin_config;
+  MetricSpec metric_spec;
+  metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
+  metric_spec.set_metric_name(kMetricName);
+  *spec.mutable_informational_metric_specs()->Add() = metric_spec;
+
+  nighthawk::client::ExecutionResponse nighthawk_response = MakeNighthawkResponseWithSendRate(1.0);
+  SetTimeAndDurationOnResult(nighthawk_response.mutable_output()->mutable_results(0), 0, 100);
+  SetTimeAndDurationOnResult(nighthawk_response.mutable_output()->add_results(), 50, 100);
+  SetTimeAndDurationOnResult(nighthawk_response.mutable_output()->add_results(), 25, 50);
+
+  // Overlapping time for all is 50 -> 75.
+  ReportingPeriod kExpectedReportingPeriod;
+  kExpectedReportingPeriod.start_time.set_seconds(50);
+  kExpectedReportingPeriod.duration.set_seconds(25);
+  absl::flat_hash_map<std::string, MetricsPluginPtr> name_to_custom_metrics_plugin_map;
+  std::unique_ptr<MockMetricsPluginWithReportingPeriod> plugin =
+      std::make_unique<MockMetricsPluginWithReportingPeriod>(metrics_plugin_config);
+  EXPECT_CALL(
+      *plugin,
+      GetMetricByNameWithReportingPeriod(
+          _, AllOf(Field(&ReportingPeriod::start_time, Eq(kExpectedReportingPeriod.start_time)),
+                   Field(&ReportingPeriod::duration, Eq(kExpectedReportingPeriod.duration)))))
+      .WillOnce(Return(10));
+  name_to_custom_metrics_plugin_map["nighthawk.fake_metrics_plugin"] = std::move(plugin);
+
+  MetricsEvaluatorImpl evaluator;
+  absl::StatusOr<BenchmarkResult> result_or = evaluator.AnalyzeNighthawkBenchmark(
+      nighthawk_response, spec, name_to_custom_metrics_plugin_map);
+  ASSERT_TRUE(result_or.ok());
 }
 
 } // namespace

--- a/test/adaptive_load/metrics_evaluator_test.cc
+++ b/test/adaptive_load/metrics_evaluator_test.cc
@@ -420,7 +420,6 @@ TEST(AnalyzeNighthawkBenchmark, ReturnsErrorWithReportingPeriodImplementation) {
   absl::StatusOr<BenchmarkResult> result_or = evaluator.AnalyzeNighthawkBenchmark(
       nighthawk_response, spec, name_to_custom_metrics_plugin_map);
   ASSERT_FALSE(result_or.ok());
-  // All errors during evaluation are rolled up into a single InternalError.
   EXPECT_EQ(result_or.status().code(), absl::StatusCode::kInternal);
   EXPECT_THAT(result_or.status().message(), HasSubstr(kWithReportingPeriodStatusMessage));
 }
@@ -483,7 +482,7 @@ void SetTimeAndDurationOnResult(nighthawk::client::Result* result, int64_t time_
   result->mutable_execution_duration()->set_nanos(0);
 }
 
-TEST(AnalyzeNighthawkBenchmark, FailsWithDurationWhereAllWorkersAreActive) {
+TEST(AnalyzeNighthawkBenchmark, FailsWithDurationWhereAllWorkersAreNeverActive) {
   nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec;
   nighthawk::client::ExecutionResponse nighthawk_response = MakeNighthawkResponseWithSendRate(1.0);
   SetTimeAndDurationOnResult(nighthawk_response.mutable_output()->mutable_results(0), 0, 100);
@@ -500,7 +499,7 @@ TEST(AnalyzeNighthawkBenchmark, FailsWithDurationWhereAllWorkersAreActive) {
                         "where all workers were active."));
 }
 
-TEST(AnalyzeNighthawkBenchmark, SelectsOverlappingReportingWithAllWorkers) {
+TEST(AnalyzeNighthawkBenchmark, SelectsOverlappingReportingPeriodWithAllWorkers) {
   nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec;
   const std::string kMetricName = "good-metric";
   FakeMetricsPluginConfig metrics_plugin_config;

--- a/test/adaptive_load/metrics_evaluator_test.cc
+++ b/test/adaptive_load/metrics_evaluator_test.cc
@@ -79,9 +79,12 @@ TEST(EvaluateMetric, SetsMetricIdForValidMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
+  google::protobuf::Timestamp start_time;
+  google::protobuf::Duration duration;
+
   MetricsEvaluatorImpl evaluator;
-  absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, /*threshold_spec=*/nullptr);
+  absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, start_time, duration);
   ASSERT_TRUE(evaluation_or.ok());
   nighthawk::adaptive_load::MetricEvaluation evaluation = evaluation_or.value();
   EXPECT_EQ(evaluation.metric_id(), "nighthawk.fake_metrics_plugin/good-metric");
@@ -102,9 +105,12 @@ TEST(EvaluateMetric, PropagatesMetricsPluginError) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
+  google::protobuf::Timestamp start_time;
+  google::protobuf::Duration duration;
+
   MetricsEvaluatorImpl evaluator;
-  absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, /*threshold_spec=*/nullptr);
+  absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, start_time, duration);
   ASSERT_FALSE(evaluation_or.ok());
   EXPECT_EQ(static_cast<int>(evaluation_or.status().code()), kExpectedStatusCode);
   EXPECT_THAT(evaluation_or.status().message(), HasSubstr(kExpectedStatusMessage));
@@ -123,9 +129,12 @@ TEST(EvaluateMetric, StoresMetricValueForValidMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
+  google::protobuf::Timestamp start_time;
+  google::protobuf::Duration duration;
+
   MetricsEvaluatorImpl evaluator;
-  absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, /*threshold_spec=*/nullptr);
+  absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, start_time, duration);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().metric_value(), kExpectedValue);
 }
@@ -144,9 +153,12 @@ TEST(EvaluateMetric, SetsWeightToZeroForValidInformationalMetric) {
   metric_spec.set_metrics_plugin_name("nighthawk.fake_metrics_plugin");
   metric_spec.set_metric_name(kMetricName);
 
+  google::protobuf::Timestamp start_time;
+  google::protobuf::Duration duration;
+
   MetricsEvaluatorImpl evaluator;
-  absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, /*threshold_spec=*/nullptr);
+  absl::StatusOr<MetricEvaluation> evaluation_or = evaluator.EvaluateMetric(
+      metric_spec, fake_plugin, /*threshold_spec=*/nullptr, start_time, duration);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().weight(), 0.0);
 }
@@ -172,9 +184,12 @@ TEST(EvaluateMetric, SetsWeightForValidScoredMetric) {
   *threshold_spec.mutable_scoring_function() =
       MakeLowerThresholdBinaryScoringFunctionConfig(kLowerThreshold);
 
+  google::protobuf::Timestamp start_time;
+  google::protobuf::Duration duration;
+
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec);
+      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, start_time, duration);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().weight(), kExpectedWeight);
 }
@@ -198,9 +213,12 @@ TEST(EvaluateMetric, SetsScoreForValidMetric) {
   *threshold_spec.mutable_scoring_function() =
       MakeLowerThresholdBinaryScoringFunctionConfig(kLowerThreshold);
 
+  google::protobuf::Timestamp start_time;
+  google::protobuf::Duration duration;
+
   MetricsEvaluatorImpl evaluator;
   absl::StatusOr<MetricEvaluation> evaluation_or =
-      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec);
+      evaluator.EvaluateMetric(metric_spec, fake_plugin, &threshold_spec, start_time, duration);
   ASSERT_TRUE(evaluation_or.ok());
   EXPECT_EQ(evaluation_or.value().threshold_score(), -1.0);
 }

--- a/test/adaptive_load/metrics_plugin_test.cc
+++ b/test/adaptive_load/metrics_plugin_test.cc
@@ -243,9 +243,8 @@ TEST(NighthawkStatsEmulatedMetricsPlugin, GetMetricByNameWithTimeReturnsUnImplem
           /*pstdev_ns=*/11,
       }));
 
-  google::protobuf::Timestamp start_time;
-  google::protobuf::Duration duration;
-  EXPECT_THAT(plugin.GetMetricByNameWithTime("x", start_time, duration).status().code(),
+  MeasuringPeriod measuring_period;
+  EXPECT_THAT(plugin.GetMetricByNameWithMeasuringPeriod("x", measuring_period).status().code(),
               absl::StatusCode::kUnimplemented);
 }
 

--- a/test/adaptive_load/metrics_plugin_test.cc
+++ b/test/adaptive_load/metrics_plugin_test.cc
@@ -243,8 +243,8 @@ TEST(NighthawkStatsEmulatedMetricsPlugin, GetMetricByNameWithTimeReturnsUnImplem
           /*pstdev_ns=*/11,
       }));
 
-  MeasuringPeriod measuring_period;
-  EXPECT_THAT(plugin.GetMetricByNameWithMeasuringPeriod("x", measuring_period).status().code(),
+  ReportingPeriod reporting_period;
+  EXPECT_THAT(plugin.GetMetricByNameWithReportingPeriod("x", reporting_period).status().code(),
               absl::StatusCode::kUnimplemented);
 }
 

--- a/test/adaptive_load/metrics_plugin_test.cc
+++ b/test/adaptive_load/metrics_plugin_test.cc
@@ -229,6 +229,26 @@ TEST(NighthawkStatsEmulatedMetricsPlugin, ReturnsCorrectSupportedMetricNames) {
                                    "success-rate"));
 }
 
+TEST(NighthawkStatsEmulatedMetricsPlugin, GetMetricByNameWithTimeReturnsUnImplementedError) {
+  NighthawkStatsEmulatedMetricsPlugin plugin =
+      NighthawkStatsEmulatedMetricsPlugin(MakeSimpleNighthawkOutput({
+          /*concurrency=*/"auto",
+          /*requests_per_second=*/1024,
+          /*actual_duration_seconds=*/0,
+          /*upstream_rq_total=*/2560,
+          /*response_count_2xx=*/320,
+          /*min_ns=*/400,
+          /*mean_ns=*/500,
+          /*max_ns=*/600,
+          /*pstdev_ns=*/11,
+      }));
+
+  google::protobuf::Timestamp start_time;
+  google::protobuf::Duration duration;
+  EXPECT_THAT(plugin.GetMetricByNameWithTime("x", start_time, duration).status().code(),
+              absl::StatusCode::kUnimplemented);
+}
+
 } // namespace
 
 } // namespace Nighthawk

--- a/test/mocks/adaptive_load/mock_metrics_evaluator.h
+++ b/test/mocks/adaptive_load/mock_metrics_evaluator.h
@@ -27,7 +27,9 @@ public:
   MOCK_METHOD(absl::StatusOr<nighthawk::adaptive_load::MetricEvaluation>, EvaluateMetric,
               (const nighthawk::adaptive_load::MetricSpec& metric_spec,
                MetricsPlugin& metrics_plugin,
-               const nighthawk::adaptive_load::ThresholdSpec* threshold_spec),
+               const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
+               const google::protobuf::Timestamp& timestamp,
+               const google::protobuf::Duration& duration),
               (const, override));
 
   MOCK_METHOD((const std::vector<std::pair<const nighthawk::adaptive_load::MetricSpec*,

--- a/test/mocks/adaptive_load/mock_metrics_evaluator.h
+++ b/test/mocks/adaptive_load/mock_metrics_evaluator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nighthawk/adaptive_load/metrics_evaluator.h"
+#include "nighthawk/adaptive_load/metrics_plugin.h"
 
 #include "gmock/gmock.h"
 
@@ -28,8 +29,7 @@ public:
               (const nighthawk::adaptive_load::MetricSpec& metric_spec,
                MetricsPlugin& metrics_plugin,
                const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
-               const google::protobuf::Timestamp& timestamp,
-               const google::protobuf::Duration& duration),
+               const MeasuringPeriod& measuring_period),
               (const, override));
 
   MOCK_METHOD((const std::vector<std::pair<const nighthawk::adaptive_load::MetricSpec*,

--- a/test/mocks/adaptive_load/mock_metrics_evaluator.h
+++ b/test/mocks/adaptive_load/mock_metrics_evaluator.h
@@ -29,7 +29,7 @@ public:
               (const nighthawk::adaptive_load::MetricSpec& metric_spec,
                MetricsPlugin& metrics_plugin,
                const nighthawk::adaptive_load::ThresholdSpec* threshold_spec,
-               const MeasuringPeriod& measuring_period),
+               const ReportingPeriod& reporting_period),
               (const, override));
 
   MOCK_METHOD((const std::vector<std::pair<const nighthawk::adaptive_load::MetricSpec*,


### PR DESCRIPTION
Create new interface function to provide plugins with appropriate measuring period.

Provide default implementation to avoid breaking any existing clients. 

Try providing measuring period first, if it is unimplemented, fallback to old implementation. This way, external plugins can easily migrate to the new interface.

Fixes #798

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>