### PR TITLE
Use proto matcher instead of debug_string matching for protos.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -109,6 +109,7 @@ envoy_cc_test(
         "//source/client:nighthawk_client_lib",
         "//test/client:utility_lib",
         "//test/test_common:environment_lib",
+        "//test/test_common:proto_matchers",
     ],
 )
 


### PR DESCRIPTION
In some environments, whitespace differences cause these tests to fail.
String matching is less stable than the proto matchers that we now have.

Works on #433 

Signed-off-by: Nathan Perry <nbperry@google.com>