### PR TITLE
Remove all instances of using DebugString in tests to compare protos

### DIFF
--- a/test/adaptive_load/BUILD
+++ b/test/adaptive_load/BUILD
@@ -60,6 +60,7 @@ envoy_cc_test(
         "//test/mocks/adaptive_load:mock_metrics_evaluator",
         "//test/mocks/adaptive_load:mock_session_spec_proto_helper",
         "//test/mocks/common:mock_nighthawk_service_client",
+        "//test/test_common:proto_matchers",
         "@envoy//source/common/common:assert_lib_with_external_headers",
         "@envoy//source/common/common:statusor_lib_with_external_headers",
         "@envoy//source/common/config:utility_lib_with_external_headers",
@@ -73,6 +74,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/adaptive_load:input_variable_setter_impl",
+        "//test/test_common:proto_matchers",
     ],
 )
 
@@ -85,6 +87,7 @@ envoy_cc_test(
         "//source/adaptive_load:metrics_evaluator_impl",
         "//source/adaptive_load:scoring_function_impl",
         "//test/adaptive_load/fake_plugins/fake_metrics_plugin",
+        "//test/test_common:proto_matchers",
     ],
 )
 
@@ -126,6 +129,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/adaptive_load:scoring_function_impl",
+        "//test/test_common:proto_matchers",
     ],
 )
 
@@ -137,5 +141,6 @@ envoy_cc_test(
         "//source/adaptive_load:step_controller_impl",
         "//test/adaptive_load/fake_plugins/fake_input_variable_setter",
         "//test/adaptive_load/fake_plugins/fake_metrics_plugin",
+        "//test/test_common:proto_matchers",
     ],
 )

--- a/test/adaptive_load/adaptive_load_controller_test.cc
+++ b/test/adaptive_load/adaptive_load_controller_test.cc
@@ -38,6 +38,7 @@
 #include "test/mocks/adaptive_load/mock_metrics_evaluator.h"
 #include "test/mocks/adaptive_load/mock_session_spec_proto_helper.h"
 #include "test/mocks/common/mock_nighthawk_service_client.h"
+#include "test/test_common/proto_matchers.h"
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
@@ -286,8 +287,7 @@ TEST_F(AdaptiveLoadControllerImplFixture, StoresAdjustingStageResult) {
   ASSERT_TRUE(output_or.ok());
   ASSERT_EQ(output_or.value().adjusting_stage_results_size(), 1);
   const BenchmarkResult& actual_benchmark_result = output_or.value().adjusting_stage_results(0);
-  EXPECT_TRUE(MessageDifferencer::Equivalent(actual_benchmark_result, expected_benchmark_result));
-  EXPECT_EQ(actual_benchmark_result.DebugString(), expected_benchmark_result.DebugString());
+  EXPECT_THAT(actual_benchmark_result, EqualsProto(expected_benchmark_result));
 }
 
 TEST_F(AdaptiveLoadControllerImplFixture, StoresTestingStageResult) {
@@ -308,8 +308,7 @@ TEST_F(AdaptiveLoadControllerImplFixture, StoresTestingStageResult) {
       controller.PerformAdaptiveLoadSession(&mock_nighthawk_service_stub_, spec);
   ASSERT_TRUE(output_or.ok());
   const BenchmarkResult& actual_benchmark_result = output_or.value().testing_stage_result();
-  EXPECT_TRUE(MessageDifferencer::Equivalent(actual_benchmark_result, expected_benchmark_result));
-  EXPECT_EQ(actual_benchmark_result.DebugString(), expected_benchmark_result.DebugString());
+  EXPECT_THAT(actual_benchmark_result, EqualsProto(expected_benchmark_result));
 }
 
 TEST_F(AdaptiveLoadControllerImplFixture, SucceedsWhenBenchmarkCooldownRequested) {

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/BUILD
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/BUILD
@@ -49,6 +49,7 @@ envoy_cc_test(
     deps = [
         ":fake_input_variable_setter",
         "//source/adaptive_load:plugin_loader",
+        "//test/test_common:proto_matchers",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//test/test_common:utility_lib",
     ],

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter_test.cc
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter_test.cc
@@ -8,6 +8,7 @@
 #include "source/adaptive_load/plugin_loader.h"
 
 #include "test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.h"
+#include "test/test_common/proto_matchers.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -26,7 +27,7 @@ TEST(FakeInputVariableSetterConfigFactory, CreateEmptyConfigProtoCreatesCorrectT
           "nighthawk.fake_input_variable_setter");
   Envoy::ProtobufTypes::MessagePtr message = config_factory.createEmptyConfigProto();
   FakeInputVariableSetterConfig expected_config;
-  EXPECT_EQ(message->DebugString(), expected_config.DebugString());
+  EXPECT_THAT(*message, EqualsProto(expected_config));
 }
 
 TEST(FakeInputVariableSetterConfigFactory, FactoryRegistersUnderCorrectName) {

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/BUILD
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/BUILD
@@ -48,6 +48,7 @@ envoy_cc_test(
     deps = [
         ":fake_metrics_plugin",
         "//source/adaptive_load:plugin_loader",
+        "//test/test_common:proto_matchers",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//test/test_common:utility_lib",
     ],

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin_test.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin_test.cc
@@ -9,6 +9,7 @@
 
 #include "test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.h"
 #include "test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.pb.h"
+#include "test/test_common/proto_matchers.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -29,8 +30,7 @@ TEST(FakeMetricsPluginConfigFactory, CreateEmptyConfigProtoCreatesCorrectType) {
           "nighthawk.fake_metrics_plugin");
   Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
   FakeMetricsPluginConfig expected_config;
-  EXPECT_EQ(empty_config->DebugString(), expected_config.DebugString());
-  EXPECT_TRUE(MessageDifferencer::Equivalent(*empty_config, expected_config));
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
 }
 
 TEST(FakeMetricsPluginConfigFactory, FactoryRegistersUnderCorrectName) {
@@ -130,8 +130,7 @@ TEST(MakeFakeMetricsPluginTypedExtensionConfig, PacksGivenConfigProto) {
       MakeFakeMetricsPluginTypedExtensionConfig(expected_config);
   nighthawk::adaptive_load::FakeMetricsPluginConfig actual_config;
   Envoy::MessageUtil::unpackTo(activator.typed_config(), actual_config);
-  EXPECT_EQ(expected_config.DebugString(), actual_config.DebugString());
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_config, actual_config));
+  EXPECT_THAT(expected_config, EqualsProto(actual_config));
 }
 
 } // namespace

--- a/test/adaptive_load/fake_plugins/fake_step_controller/BUILD
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/BUILD
@@ -50,6 +50,7 @@ envoy_cc_test(
     deps = [
         ":fake_step_controller",
         "//source/adaptive_load:plugin_loader",
+        "//test/test_common:proto_matchers",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//test/test_common:utility_lib",
     ],

--- a/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller_test.cc
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller_test.cc
@@ -8,6 +8,7 @@
 #include "source/adaptive_load/plugin_loader.h"
 
 #include "test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.h"
+#include "test/test_common/proto_matchers.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -28,8 +29,7 @@ TEST(FakeStepControllerConfigFactory, CreateEmptyConfigProtoCreatesCorrectType) 
           "nighthawk.fake_step_controller");
   Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
   FakeStepControllerConfig expected_config;
-  EXPECT_EQ(empty_config->DebugString(), expected_config.DebugString());
-  EXPECT_TRUE(MessageDifferencer::Equivalent(*empty_config, expected_config));
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
 }
 
 TEST(FakeStepControllerConfigFactory, FactoryRegistersUnderCorrectName) {

--- a/test/adaptive_load/input_variable_setter_test.cc
+++ b/test/adaptive_load/input_variable_setter_test.cc
@@ -2,6 +2,8 @@
 
 #include "source/adaptive_load/input_variable_setter_impl.h"
 
+#include "test/test_common/proto_matchers.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -15,8 +17,7 @@ TEST(RequestsPerSecondInputVariableSetterConfigFactory, CreateEmptyConfigProtoCr
           "nighthawk.rps");
   const Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
   const nighthawk::adaptive_load::RequestsPerSecondInputVariableSetterConfig expected_config;
-  EXPECT_EQ(empty_config->DebugString(), expected_config.DebugString());
-  EXPECT_TRUE(Envoy::MessageUtil()(*empty_config, expected_config));
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
 }
 
 TEST(RequestsPerSecondInputVariableSetterConfigFactory, FactoryRegistrationUsesCorrectPluginName) {

--- a/test/adaptive_load/metrics_evaluator_test.cc
+++ b/test/adaptive_load/metrics_evaluator_test.cc
@@ -9,6 +9,7 @@
 
 #include "test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.h"
 #include "test/adaptive_load/minimal_output.h"
+#include "test/test_common/proto_matchers.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -223,8 +224,7 @@ TEST(ExtractMetricSpecs, ExtractsScoredMetricAndThresholdForValidMetric) {
   ASSERT_GT(spec_threshold_pairs.size(), 0);
   EXPECT_EQ(spec_threshold_pairs[0].first->metric_name(), kExpectedMetricName);
   ASSERT_NE(spec_threshold_pairs[0].second, nullptr);
-  EXPECT_TRUE(MessageDifferencer::Equivalent(*spec_threshold_pairs[0].second, threshold_spec));
-  EXPECT_EQ(spec_threshold_pairs[0].second->DebugString(), threshold_spec.DebugString());
+  EXPECT_THAT(*spec_threshold_pairs[0].second, EqualsProto(threshold_spec));
 }
 
 TEST(ExtractMetricSpecs, ExtractsValueForValidInformationalMetric) {
@@ -273,8 +273,8 @@ TEST(AnalyzeNighthawkBenchmark, StoresNighthawkResultForSuccessfulMetricEvaluati
 
   EXPECT_TRUE(MessageDifferencer::Equivalent(result_or.value().nighthawk_service_output(),
                                              nighthawk_response.output()));
-  EXPECT_EQ(result_or.value().nighthawk_service_output().DebugString(),
-            nighthawk_response.output().DebugString());
+  EXPECT_THAT(result_or.value().nighthawk_service_output(),
+            EqualsProto(nighthawk_response.output()));
 }
 
 TEST(AnalyzeNighthawkBenchmark, StoresScoreForSuccessfulMetricEvaluation) {

--- a/test/adaptive_load/scoring_function_test.cc
+++ b/test/adaptive_load/scoring_function_test.cc
@@ -6,6 +6,8 @@
 
 #include "source/adaptive_load/scoring_function_impl.h"
 
+#include "test/test_common/proto_matchers.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -19,8 +21,7 @@ TEST(BinaryScoringFunctionConfigFactory, CreateEmptyConfigProtoCreatesCorrectTyp
           "nighthawk.binary_scoring");
   const Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
   const nighthawk::adaptive_load::BinaryScoringFunctionConfig expected_config;
-  EXPECT_EQ(empty_config->DebugString(), expected_config.DebugString());
-  EXPECT_TRUE(Envoy::MessageUtil()(*empty_config, expected_config));
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
 }
 
 TEST(LinearScoringFunctionConfigFactory, CreateEmptyConfigProtoCreatesCorrectType) {
@@ -29,8 +30,7 @@ TEST(LinearScoringFunctionConfigFactory, CreateEmptyConfigProtoCreatesCorrectTyp
           "nighthawk.linear_scoring");
   const Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
   const nighthawk::adaptive_load::LinearScoringFunctionConfig expected_config;
-  EXPECT_EQ(empty_config->DebugString(), expected_config.DebugString());
-  EXPECT_TRUE(Envoy::MessageUtil()(*empty_config, expected_config));
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
 }
 
 TEST(BinaryScoringFunctionConfigFactory, FactoryRegistrationUsesCorrectPluginName) {

--- a/test/adaptive_load/step_controller_test.cc
+++ b/test/adaptive_load/step_controller_test.cc
@@ -12,6 +12,8 @@
 #include "source/adaptive_load/plugin_loader.h"
 #include "source/adaptive_load/step_controller_impl.h"
 
+#include "test/test_common/proto_matchers.h"
+
 #include "fake_plugins/fake_input_variable_setter/fake_input_variable_setter.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -36,7 +38,7 @@ TEST(ExponentialSearchStepControllerConfigFactory, GeneratesEmptyConfigProto) {
           "nighthawk.exponential_search");
   Envoy::ProtobufTypes::MessagePtr message = config_factory.createEmptyConfigProto();
   nighthawk::adaptive_load::ExponentialSearchStepControllerConfig expected_config;
-  EXPECT_EQ(message->DebugString(), expected_config.DebugString());
+  EXPECT_THAT(*message, EqualsProto(expected_config));
 }
 
 TEST(ExponentialSearchStepControllerConfigFactory, CreatesCorrectFactoryName) {

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -35,6 +35,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/common:nighthawk_service_client_impl",
+        "//test/test_common:proto_matchers",
         "@com_github_grpc_grpc//:grpc++_test",
     ],
 )

--- a/test/common/nighthawk_service_client_test.cc
+++ b/test/common/nighthawk_service_client_test.cc
@@ -6,6 +6,8 @@
 
 #include "source/common/nighthawk_service_client_impl.h"
 
+#include "test/test_common/proto_matchers.h"
+
 #include "grpcpp/test/mock_stream.h"
 
 #include "gmock/gmock.h"
@@ -81,7 +83,7 @@ TEST(PerformNighthawkBenchmark, ReturnsNighthawkResponseSuccessfully) {
   EXPECT_TRUE(response_or.ok());
   ExecutionResponse actual_response = response_or.value();
   EXPECT_TRUE(MessageDifferencer::Equivalent(actual_response, expected_response));
-  EXPECT_EQ(actual_response.DebugString(), expected_response.DebugString());
+  EXPECT_THAT(actual_response, EqualsProto(expected_response));
 }
 
 TEST(PerformNighthawkBenchmark, ReturnsErrorIfNighthawkServiceDoesNotSendResponse) {

--- a/test/distributor/BUILD
+++ b/test/distributor/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/distributor:nighthawk_distributor_client_impl",
+        "//test/test_common:proto_matchers",
         "@com_github_grpc_grpc//:grpc++_test",
     ],
 )

--- a/test/distributor/nighthawk_distributor_client_test.cc
+++ b/test/distributor/nighthawk_distributor_client_test.cc
@@ -6,6 +6,8 @@
 
 #include "source/distributor/nighthawk_distributor_client_impl.h"
 
+#include "test/test_common/proto_matchers.h"
+
 #include "grpcpp/test/mock_stream.h"
 
 #include "gmock/gmock.h"
@@ -88,7 +90,7 @@ TEST(DistributedRequest, ReturnsNighthawkResponseSuccessfully) {
   EXPECT_TRUE(response_or.ok());
   DistributedResponse actual_response = response_or.value();
   EXPECT_TRUE(MessageDifferencer::Equivalent(actual_response, expected_response));
-  EXPECT_EQ(actual_response.DebugString(), expected_response.DebugString());
+  EXPECT_THAT(actual_response, EqualsProto(expected_response));
 }
 
 TEST(DistributedRequest, ReturnsErrorIfNighthawkServiceDoesNotSendResponse) {

--- a/test/request_source/BUILD
+++ b/test/request_source/BUILD
@@ -51,6 +51,7 @@ envoy_cc_test(
         "//source/request_source:request_options_list_plugin_impl",
         "//test/request_source:stub_plugin_impl",
         "//test/test_common:environment_lib",
+        "//test/test_common:proto_matchers",
         "@envoy//source/common/config:utility_lib_with_external_headers",
         "@envoy//test/mocks/api:api_mocks",
     ],

--- a/test/request_source/request_source_plugin_test.cc
+++ b/test/request_source/request_source_plugin_test.cc
@@ -10,6 +10,7 @@
 
 #include "test/request_source/stub_plugin_impl.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/proto_matchers.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -63,8 +64,7 @@ TEST_F(StubRequestSourcePluginTest, CreateEmptyConfigProtoCreatesCorrectType) {
           "nighthawk.stub-request-source-plugin");
   const Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
   const nighthawk::request_source::StubPluginConfig expected_config;
-  EXPECT_EQ(empty_config->DebugString(), expected_config.DebugString());
-  EXPECT_TRUE(Envoy::MessageUtil()(*empty_config, expected_config));
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
 }
 
 TEST_F(StubRequestSourcePluginTest, FactoryRegistrationUsesCorrectPluginName) {
@@ -116,8 +116,7 @@ TEST_F(FileBasedRequestSourcePluginTest, CreateEmptyConfigProtoCreatesCorrectTyp
           "nighthawk.file-based-request-source-plugin");
   const Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
   const nighthawk::request_source::FileBasedOptionsListRequestSourceConfig expected_config;
-  EXPECT_EQ(empty_config->DebugString(), expected_config.DebugString());
-  EXPECT_TRUE(Envoy::MessageUtil()(*empty_config, expected_config));
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
 }
 
 TEST_F(FileBasedRequestSourcePluginTest, FactoryRegistrationUsesCorrectPluginName) {
@@ -286,8 +285,7 @@ TEST_F(InLineRequestSourcePluginTest, CreateEmptyConfigProtoCreatesCorrectType) 
           "nighthawk.in-line-options-list-request-source-plugin");
   const Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
   const nighthawk::request_source::InLineOptionsListRequestSourceConfig expected_config;
-  EXPECT_EQ(empty_config->DebugString(), expected_config.DebugString());
-  EXPECT_TRUE(Envoy::MessageUtil()(*empty_config, expected_config));
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
 }
 
 TEST_F(InLineRequestSourcePluginTest, FactoryRegistrationUsesCorrectPluginName) {

--- a/test/sink/BUILD
+++ b/test/sink/BUILD
@@ -26,6 +26,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/sink:nighthawk_sink_client_impl",
+        "//test/test_common:proto_matchers",
         "@com_github_grpc_grpc//:grpc++_test",
     ],
 )
@@ -38,6 +39,7 @@ envoy_cc_test(
         "//source/sink:grpc_service_lib",
         "//test/mocks/sink:mock_sink",
         "//test/test_common:environment_lib",
+        "//test/test_common:proto_matchers",
         "@envoy//test/test_common:network_utility_lib",
     ],
 )

--- a/test/sink/nighthawk_sink_client_test.cc
+++ b/test/sink/nighthawk_sink_client_test.cc
@@ -6,6 +6,8 @@
 
 #include "source/sink/nighthawk_sink_client_impl.h"
 
+#include "test/test_common/proto_matchers.h"
+
 #include "grpcpp/test/mock_stream.h"
 
 #include "gmock/gmock.h"
@@ -68,10 +70,8 @@ TEST(StoreExecutionResponseStream, UsesSpecifiedExecutionResponseArguments) {
       client.StoreExecutionResponseStream(mock_nighthawk_sink_stub, request_1);
   absl::StatusOr<nighthawk::StoreExecutionResponse> response_2 =
       client.StoreExecutionResponseStream(mock_nighthawk_sink_stub, request_2);
-  EXPECT_EQ(observed_request_1.DebugString(), request_1.DebugString());
-  EXPECT_EQ(observed_request_2.DebugString(), request_2.DebugString());
-  EXPECT_TRUE(MessageDifferencer::Equivalent(observed_request_1, request_1));
-  EXPECT_TRUE(MessageDifferencer::Equivalent(observed_request_2, request_2));
+  EXPECT_THAT(observed_request_1, EqualsProto(request_1));
+  EXPECT_THAT(observed_request_2, EqualsProto(request_2));
 }
 
 TEST(StoreExecutionResponseStream, ReturnsResponseSuccessfully) {
@@ -208,8 +208,7 @@ TEST(SinkRequest, ReturnsNighthawkResponseSuccessfully) {
       client.SinkRequestStream(mock_nighthawk_sink_stub, nighthawk::SinkRequest());
   EXPECT_TRUE(response_or.ok());
   SinkResponse actual_response = response_or.value();
-  EXPECT_TRUE(MessageDifferencer::Equivalent(actual_response, expected_response));
-  EXPECT_EQ(actual_response.DebugString(), expected_response.DebugString());
+  EXPECT_THAT(actual_response, EqualsProto(expected_response));
 }
 
 TEST(SinkRequest, WillFinishIfNighthawkServiceDoesNotSendResponse) {

--- a/test/sink/sink_service_test.cc
+++ b/test/sink/sink_service_test.cc
@@ -11,6 +11,7 @@
 #include "source/sink/service_impl.h"
 
 #include "test/mocks/sink/mock_sink.h"
+#include "test/test_common/proto_matchers.h"
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
@@ -161,7 +162,7 @@ TEST_P(SinkServiceTest, LoadTwoResultsWithExecutionResponseWhereOneHasErrorDetai
   ::google::rpc::Status status;
   Envoy::MessageUtil::unpackTo(response_.execution_response().error_detail().details(0), status);
   // TODO(XXX): proper equivalence test.
-  EXPECT_EQ(status.DebugString(), error_detail->DebugString());
+  EXPECT_THAT(status, EqualsProto(*error_detail));
   EXPECT_TRUE(reader_writer->Finish().ok());
 }
 


### PR DESCRIPTION
Fixes #433 

Signed-off-by: Nathan Perry <nbperry@google.com>