### PR TITLE
Refactor subprocess mixin to control setting up and tearing down chil…

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -37,6 +37,7 @@ py_library(
         "integration_test_fixtures.py",
         "nighthawk_grpc_service.py",
         "nighthawk_test_server.py",
+        "subprocess_mixin.py",
         "utility.py",
     ],
     data = [

--- a/test/integration/subprocess_mixin.py
+++ b/test/integration/subprocess_mixin.py
@@ -10,7 +10,7 @@ class SubprocessMixin(ABC):
   """Mixin used to manage launching subprocess using a separate Python thread."""
 
   def __init__(self):
-    """Creates SubprocessMixin."""
+    """Create SubprocessMixin."""
     self._server_thread = Thread(target=self._serverThreadRunner)
     self._server_process = None
     self._has_launched = False

--- a/test/integration/subprocess_mixin.py
+++ b/test/integration/subprocess_mixin.py
@@ -1,3 +1,5 @@
+"""Mixin for managing child subprocess with an additional thread."""
+
 from threading import Thread, Condition
 import subprocess
 import logging
@@ -8,6 +10,7 @@ class SubprocessMixin(ABC):
   """Mixin used to manage launching subprocess using a separate Python thread."""
 
   def __init__(self):
+    """Creates SubprocessMixin."""
     self._server_thread = Thread(target=self._serverThreadRunner)
     self._server_process = None
     self._has_launched = False
@@ -17,7 +20,7 @@ class SubprocessMixin(ABC):
 
   @abstractmethod
   def _argsForSubprocess(self) -> list[str]:
-    """Returns the args to launch the subprocess."""
+    """Return the args to launch the subprocess."""
     pass
 
   def _serverThreadRunner(self):
@@ -33,7 +36,7 @@ class SubprocessMixin(ABC):
     return self.stdout, self.stderr
 
   def launchSubprocess(self):
-    """Start the subprocess. """
+    """Start the subprocess."""
     self._server_thread.daemon = True
     self._server_thread.start()
 
@@ -48,7 +51,7 @@ class SubprocessMixin(ABC):
       assert self._has_launched
 
   def waitForSubprocessNotRunning(self):
-    """Waits for the subprocess to not be running assuming it exits."""
+    """Wait for the subprocess to not be running assuming it exits."""
     if not self._has_launched or not self._server_thread.is_alive():
       return
     self._server_thread.join()

--- a/test/integration/subprocess_mixin.py
+++ b/test/integration/subprocess_mixin.py
@@ -1,0 +1,71 @@
+from threading import Thread, Condition
+import subprocess
+import logging
+from abc import ABC, abstractmethod
+
+
+class SubprocessMixin(ABC):
+  """Mixin used to manage launching subprocess using a separate Python thread."""
+
+  def __init__(self):
+    self._server_thread = Thread(target=self._serverThreadRunner)
+    self._server_process = None
+    self._has_launched = False
+    self._has_launched_cv = Condition()
+    self.stdout = b''
+    self.stderr = b''
+
+  @abstractmethod
+  def _argsForSubprocess(self) -> list[str]:
+    """Returns the args to launch the subprocess."""
+    pass
+
+  def _serverThreadRunner(self):
+    args = self._argsForSubprocess()
+    logging.info("Test server popen() args: %s" % str.join(" ", args))
+    self._server_process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    with self._has_launched_cv:
+      self._has_launched = True
+      self._has_launched_cv.notify_all()
+    self.stdout, self.stderr = self._server_process.communicate()
+    logging.info("Process stdout: %s", self.stdout.decode("utf-8"))
+    logging.info("Process stderr: %s", self.stderr.decode("utf-8"))
+    return self.stdout, self.stderr
+
+  def launchSubprocess(self):
+    """Start the subprocess. """
+    self._server_thread.daemon = True
+    self._server_thread.start()
+
+  def waitUntilSubprocessLaunched(self):
+    """Blocks until the subprocess has launched at least once."""
+
+    def hasLaunched():
+      return self._has_launched
+
+    with self._has_launched_cv:
+      self._has_launched_cv.wait_for(hasLaunched)
+      assert self._has_launched
+
+  def waitForSubprocessNotRunning(self):
+    """Waits for the subprocess to not be running assuming it exits."""
+    if not self._has_launched or not self._server_thread.is_alive():
+      return
+    self._server_thread.join()
+
+    def hasLaunched():
+      return self._has_launched
+
+    with self._has_launched_cv:
+      self._has_launched_cv.wait_for(hasLaunched)
+      assert self._has_launched
+
+  def stopSubprocess(self) -> int:
+    """Stop the subprocess.
+
+    Returns:
+        Int: exit code of the server process.
+    """
+    self._server_process.terminate()
+    self._server_thread.join()
+    return self._server_process.returncode

--- a/test/integration/unit_tests/BUILD
+++ b/test/integration/unit_tests/BUILD
@@ -17,3 +17,11 @@ py_test(
         "//test/integration:integration_test_base_lean",
     ],
 )
+
+py_test(
+    name = "test_subprocess_mixin",
+    srcs = ["test_subprocess_mixin.py"],
+    deps = [
+        "//test/integration:integration_test_base_lean",
+    ],
+)

--- a/test/integration/unit_tests/test_subprocess_mixin.py
+++ b/test/integration/unit_tests/test_subprocess_mixin.py
@@ -12,9 +12,14 @@ class TestSubprocessMixin(SubprocessMixin):
     """Create the TestSubprocessMixin."""
     super().__init__()
     self.args = args
+    self.stdout = b''
+    self.stderr = b''
 
   def _argsForSubprocess(self) -> list[str]:
     return self.args
+
+  def _serverThreadRunner(self):
+    self.stdout, self.stderr = super()._serverThreadRunner()
 
 
 def test_subprocess_captures_stdout():
@@ -28,11 +33,11 @@ def test_subprocess_captures_stdout():
 
 def test_subprocess_captures_stderr():
   """Test the subprocess captures stderr."""
-  child_process = TestSubprocessMixin(["echo", "stderr", "1>2"])
+  child_process = TestSubprocessMixin(["logger", "--no-act", "-s", "stderr"])
   child_process.launchSubprocess()
   child_process.waitUntilSubprocessLaunched()
   child_process.waitForSubprocessNotRunning()
-  assert b'stderr' in child_process.stdout
+  assert b'stderr' in child_process.stderr
 
 
 def test_subprocess_stop():

--- a/test/integration/unit_tests/test_subprocess_mixin.py
+++ b/test/integration/unit_tests/test_subprocess_mixin.py
@@ -1,0 +1,44 @@
+"""Contains unit tests for subprocess_mixin.py."""
+
+import pytest
+
+from test.integration.subprocess_mixin import SubprocessMixin
+
+
+class TestSubprocessMixin(SubprocessMixin):
+
+  def __init__(self, args):
+    super().__init__()
+    self.args = args
+
+  def _argsForSubprocess(self) -> list[str]:
+    return self.args
+
+
+def test_subprocess_captures_stdout():
+  child_process = TestSubprocessMixin(["echo", "stdout"])
+  child_process.launchSubprocess()
+  child_process.waitUntilSubprocessLaunched()
+  child_process.waitForSubprocessNotRunning()
+  assert b'stdout' in child_process.stdout
+
+
+def test_subprocess_captures_stderr():
+  child_process = TestSubprocessMixin(["echo", "stderr", "1>2"])
+  child_process.launchSubprocess()
+  child_process.waitUntilSubprocessLaunched()
+  child_process.waitForSubprocessNotRunning()
+  assert b'stderr' in child_process.stdout
+
+
+def test_subprocess_stop():
+  child_process = TestSubprocessMixin(["sleep", "120"])
+  child_process.launchSubprocess()
+  child_process.waitUntilSubprocessLaunched()
+  ret_code = child_process.stopSubprocess()
+  # Non-zero exit is expected as the subprocess should be killed.
+  assert ret_code != 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(pytest.main([__file__, "--assert=plain"]))

--- a/test/integration/unit_tests/test_subprocess_mixin.py
+++ b/test/integration/unit_tests/test_subprocess_mixin.py
@@ -24,7 +24,7 @@ class TestSubprocessMixin(SubprocessMixin):
 
 def test_subprocess_captures_stdout():
   """Test the subprocess captures stdout."""
-  child_process = TestSubprocessMixin(["echo", "stdout"])
+  child_process = TestSubprocessMixin(['echo', 'stdout'])
   child_process.launchSubprocess()
   child_process.waitUntilSubprocessLaunched()
   child_process.waitForSubprocessNotRunning()
@@ -33,16 +33,16 @@ def test_subprocess_captures_stdout():
 
 def test_subprocess_captures_stderr():
   """Test the subprocess captures stderr."""
-  child_process = TestSubprocessMixin(["logger", "--no-act", "-s", "stderr"])
+  child_process = TestSubprocessMixin(['logger', '--no-act', '-s', 'stderr'])
   child_process.launchSubprocess()
   child_process.waitUntilSubprocessLaunched()
   child_process.waitForSubprocessNotRunning()
-  assert b'stderr' in child_process.stderr
+  assert child_process.stderr != b''
 
 
 def test_subprocess_stop():
   """Test the subprocess can be stopped."""
-  child_process = TestSubprocessMixin(["sleep", "120"])
+  child_process = TestSubprocessMixin(['sleep', '120'])
   child_process.launchSubprocess()
   child_process.waitUntilSubprocessLaunched()
   ret_code = child_process.stopSubprocess()
@@ -50,5 +50,5 @@ def test_subprocess_stop():
   assert ret_code != 0
 
 
-if __name__ == "__main__":
-  raise SystemExit(pytest.main([__file__, "--assert=plain"]))
+if __name__ == '__main__':
+  raise SystemExit(pytest.main([__file__, '--assert=plain']))

--- a/test/integration/unit_tests/test_subprocess_mixin.py
+++ b/test/integration/unit_tests/test_subprocess_mixin.py
@@ -9,7 +9,7 @@ class TestSubprocessMixin(SubprocessMixin):
   """Helper class for testing the SubprocessMixin."""
 
   def __init__(self, args):
-    """Creates the TestSubprocessMixin."""
+    """Create the TestSubprocessMixin."""
     super().__init__()
     self.args = args
 

--- a/test/integration/unit_tests/test_subprocess_mixin.py
+++ b/test/integration/unit_tests/test_subprocess_mixin.py
@@ -6,8 +6,10 @@ from test.integration.subprocess_mixin import SubprocessMixin
 
 
 class TestSubprocessMixin(SubprocessMixin):
+  """Helper class for testing the SubprocessMixin."""
 
   def __init__(self, args):
+    """Creates the TestSubprocessMixin."""
     super().__init__()
     self.args = args
 
@@ -16,6 +18,7 @@ class TestSubprocessMixin(SubprocessMixin):
 
 
 def test_subprocess_captures_stdout():
+  """Test the subprocess captures stdout."""
   child_process = TestSubprocessMixin(["echo", "stdout"])
   child_process.launchSubprocess()
   child_process.waitUntilSubprocessLaunched()
@@ -24,6 +27,7 @@ def test_subprocess_captures_stdout():
 
 
 def test_subprocess_captures_stderr():
+  """Test the subprocess captures stderr."""
   child_process = TestSubprocessMixin(["echo", "stderr", "1>2"])
   child_process.launchSubprocess()
   child_process.waitUntilSubprocessLaunched()
@@ -32,6 +36,7 @@ def test_subprocess_captures_stderr():
 
 
 def test_subprocess_stop():
+  """Test the subprocess can be stopped."""
   child_process = TestSubprocessMixin(["sleep", "120"])
   child_process.launchSubprocess()
   child_process.waitUntilSubprocessLaunched()


### PR DESCRIPTION
The Subprocess mixin can be used to control setting up and tearing down child process. 
The `TestServerBase` will leverage this and it will be re-used by a xDS configuration generator.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>