### PR TITLE
Update Envoy to c2fccb2 (Aug 22nd 2022)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "6b83db42c418abca6d21160cf6b1c439657d6ef0"
-ENVOY_SHA = "cee390f78c56e4b94ff257c20b6c5bbf48f98bfbf278744a3420bd22b3431259"
+ENVOY_COMMIT = "c2fccb23e738b7e4bc4e8028f28f8452b5d16377"
+ENVOY_SHA = "2d7a1ebf986113428523beee743fbaee4787cbf80b11ca4e23bd4a877cb37b90"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/test/adaptive_load/BUILD
+++ b/test/adaptive_load/BUILD
@@ -36,7 +36,6 @@ envoy_cc_test(
         "//source/adaptive_load:adaptive_load_client_main",
         "//test/mocks/adaptive_load:mock_adaptive_load_controller",
         "//test/test_common:environment_lib",
-        "@com_github_grpc_grpc//:grpc++_test",
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//test/mocks/filesystem:filesystem_mocks",
         "@envoy//test/test_common:utility_lib",

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -35,8 +35,8 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/common:nighthawk_service_client_impl",
+        "//test/test_common:mock_stream",
         "//test/test_common:proto_matchers",
-        "@com_github_grpc_grpc//:grpc++_test",
     ],
 )
 

--- a/test/common/nighthawk_service_client_test.cc
+++ b/test/common/nighthawk_service_client_test.cc
@@ -6,9 +6,8 @@
 
 #include "source/common/nighthawk_service_client_impl.h"
 
+#include "test/test_common/mock_stream.h"
 #include "test/test_common/proto_matchers.h"
-
-#include "grpcpp/test/mock_stream.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -37,7 +36,7 @@ TEST(PerformNighthawkBenchmark, UsesSpecifiedCommandLineOptions) {
   EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw)
       .WillOnce([&request](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+            new MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
         // PerformNighthawkBenchmark currently expects Read to return true exactly once.
         EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(true)).WillOnce(Return(false));
         // Capture the Nighthawk request PerformNighthawkBenchmark sends on the channel.
@@ -65,7 +64,7 @@ TEST(PerformNighthawkBenchmark, ReturnsNighthawkResponseSuccessfully) {
   EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw)
       .WillOnce([&expected_response](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+            new MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
         // PerformNighthawkBenchmark currently expects Read to return true exactly once.
         // Capture the gRPC response proto as it is written to the output parameter.
         EXPECT_CALL(*mock_reader_writer, Read(_))
@@ -91,8 +90,7 @@ TEST(PerformNighthawkBenchmark, ReturnsErrorIfNighthawkServiceDoesNotSendRespons
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw).WillOnce([](grpc::ClientContext*) {
-    auto* mock_reader_writer =
-        new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+    auto* mock_reader_writer = new MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
     EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(false));
     EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(true));
@@ -113,8 +111,7 @@ TEST(PerformNighthawkBenchmark, ReturnsErrorIfNighthawkServiceWriteFails) {
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw).WillOnce([](grpc::ClientContext*) {
-    auto* mock_reader_writer =
-        new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+    auto* mock_reader_writer = new MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
     EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(false));
     return mock_reader_writer;
   });
@@ -132,8 +129,7 @@ TEST(PerformNighthawkBenchmark, ReturnsErrorIfNighthawkServiceWritesDoneFails) {
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw).WillOnce([](grpc::ClientContext*) {
-    auto* mock_reader_writer =
-        new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+    auto* mock_reader_writer = new MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
     EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(false));
     return mock_reader_writer;
@@ -152,8 +148,7 @@ TEST(PerformNighthawkBenchmark, PropagatesErrorIfNighthawkServiceGrpcStreamClose
   // Configure the mock Nighthawk Service stub to return an inner mock channel when the code under
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_service_stub, ExecutionStreamRaw).WillOnce([](grpc::ClientContext*) {
-    auto* mock_reader_writer =
-        new grpc::testing::MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
+    auto* mock_reader_writer = new MockClientReaderWriter<ExecutionRequest, ExecutionResponse>();
     // PerformNighthawkBenchmark currently expects Read to return true exactly once.
     EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(true)).WillOnce(Return(false));
     EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));

--- a/test/distributor/BUILD
+++ b/test/distributor/BUILD
@@ -14,8 +14,8 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/distributor:nighthawk_distributor_client_impl",
+        "//test/test_common:mock_stream",
         "//test/test_common:proto_matchers",
-        "@com_github_grpc_grpc//:grpc++_test",
     ],
 )
 

--- a/test/distributor/nighthawk_distributor_client_test.cc
+++ b/test/distributor/nighthawk_distributor_client_test.cc
@@ -6,9 +6,8 @@
 
 #include "source/distributor/nighthawk_distributor_client_impl.h"
 
+#include "test/test_common/mock_stream.h"
 #include "test/test_common/proto_matchers.h"
-
-#include "grpcpp/test/mock_stream.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -37,7 +36,7 @@ TEST(DistributedRequest, UsesSpecifiedCommandLineOptions) {
   EXPECT_CALL(mock_nighthawk_service_stub, DistributedRequestStreamRaw)
       .WillOnce([&request](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<DistributedRequest, DistributedResponse>();
+            new MockClientReaderWriter<DistributedRequest, DistributedResponse>();
         // DistributedRequest currently expects Read to return true exactly once.
         EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(true)).WillOnce(Return(false));
         // Capture the Nighthawk request DistributedRequest sends on the channel.
@@ -72,7 +71,7 @@ TEST(DistributedRequest, ReturnsNighthawkResponseSuccessfully) {
   EXPECT_CALL(mock_nighthawk_service_stub, DistributedRequestStreamRaw)
       .WillOnce([&expected_response](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<DistributedRequest, DistributedResponse>();
+            new MockClientReaderWriter<DistributedRequest, DistributedResponse>();
         // DistributedRequest currently expects Read to return true exactly once.
         // Capture the gRPC response proto as it is written to the output parameter.
         EXPECT_CALL(*mock_reader_writer, Read(_))
@@ -100,7 +99,7 @@ TEST(DistributedRequest, ReturnsErrorIfNighthawkServiceDoesNotSendResponse) {
   EXPECT_CALL(mock_nighthawk_service_stub, DistributedRequestStreamRaw)
       .WillOnce([](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<DistributedRequest, DistributedResponse>();
+            new MockClientReaderWriter<DistributedRequest, DistributedResponse>();
         EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(false));
         EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
         EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(true));
@@ -123,7 +122,7 @@ TEST(DistributedRequest, ReturnsErrorIfNighthawkServiceWriteFails) {
   EXPECT_CALL(mock_nighthawk_service_stub, DistributedRequestStreamRaw)
       .WillOnce([](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<DistributedRequest, DistributedResponse>();
+            new MockClientReaderWriter<DistributedRequest, DistributedResponse>();
         EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(false));
         return mock_reader_writer;
       });
@@ -143,7 +142,7 @@ TEST(DistributedRequest, ReturnsErrorIfNighthawkServiceWritesDoneFails) {
   EXPECT_CALL(mock_nighthawk_service_stub, DistributedRequestStreamRaw)
       .WillOnce([](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<DistributedRequest, DistributedResponse>();
+            new MockClientReaderWriter<DistributedRequest, DistributedResponse>();
         EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
         EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(false));
         return mock_reader_writer;
@@ -164,7 +163,7 @@ TEST(DistributedRequest, PropagatesErrorIfNighthawkServiceGrpcStreamClosesAbnorm
   EXPECT_CALL(mock_nighthawk_service_stub, DistributedRequestStreamRaw)
       .WillOnce([](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<DistributedRequest, DistributedResponse>();
+            new MockClientReaderWriter<DistributedRequest, DistributedResponse>();
         // DistributedRequest currently expects Read to return true exactly once.
         EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(true)).WillOnce(Return(false));
         EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));

--- a/test/sink/BUILD
+++ b/test/sink/BUILD
@@ -15,7 +15,6 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/sink:sink_impl_lib",
-        "@com_github_grpc_grpc//:grpc++_test",  # Avoids undefined symbol _ZN4grpc24g_core_codegen_interfaceE in coverage test build.
         "@envoy//source/common/common:random_generator_lib_with_external_headers",
     ],
 )
@@ -26,8 +25,8 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/sink:nighthawk_sink_client_impl",
+        "//test/test_common:mock_stream",
         "//test/test_common:proto_matchers",
-        "@com_github_grpc_grpc//:grpc++_test",
     ],
 )
 

--- a/test/sink/BUILD
+++ b/test/sink/BUILD
@@ -15,6 +15,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//source/sink:sink_impl_lib",
+        "//test/test_common:mock_stream",  # necessary to pass coverage tests.
         "@envoy//source/common/common:random_generator_lib_with_external_headers",
     ],
 )

--- a/test/sink/nighthawk_sink_client_test.cc
+++ b/test/sink/nighthawk_sink_client_test.cc
@@ -6,9 +6,8 @@
 
 #include "source/sink/nighthawk_sink_client_impl.h"
 
+#include "test/test_common/mock_stream.h"
 #include "test/test_common/proto_matchers.h"
-
-#include "grpcpp/test/mock_stream.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -37,7 +36,7 @@ TEST(StoreExecutionResponseStream, UsesSpecifiedExecutionResponseArguments) {
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, StoreExecutionResponseStreamRaw)
       .WillOnce([&observed_request_1](grpc::ClientContext*, nighthawk::StoreExecutionResponse*) {
-        auto* mock_writer = new grpc::testing::MockClientWriter<StoreExecutionRequest>();
+        auto* mock_writer = new MockClientWriter<StoreExecutionRequest>();
         EXPECT_CALL(*mock_writer, Write(_, _))
             .WillOnce(DoAll(SaveArg<0>(&observed_request_1), Return(true)));
         EXPECT_CALL(*mock_writer, WritesDone()).WillOnce(Return(true));
@@ -45,7 +44,7 @@ TEST(StoreExecutionResponseStream, UsesSpecifiedExecutionResponseArguments) {
         return mock_writer;
       })
       .WillOnce([&observed_request_2](grpc::ClientContext*, nighthawk::StoreExecutionResponse*) {
-        auto* mock_writer = new grpc::testing::MockClientWriter<StoreExecutionRequest>();
+        auto* mock_writer = new MockClientWriter<StoreExecutionRequest>();
         EXPECT_CALL(*mock_writer, Write(_, _))
             .WillOnce(DoAll(SaveArg<0>(&observed_request_2), Return(true)));
         EXPECT_CALL(*mock_writer, WritesDone()).WillOnce(Return(true));
@@ -80,7 +79,7 @@ TEST(StoreExecutionResponseStream, ReturnsResponseSuccessfully) {
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, StoreExecutionResponseStreamRaw)
       .WillOnce([](grpc::ClientContext*, nighthawk::StoreExecutionResponse*) {
-        auto* mock_writer = new grpc::testing::MockClientWriter<StoreExecutionRequest>();
+        auto* mock_writer = new MockClientWriter<StoreExecutionRequest>();
         EXPECT_CALL(*mock_writer, Write(_, _)).WillOnce(Return(true));
         EXPECT_CALL(*mock_writer, WritesDone()).WillOnce(Return(true));
         EXPECT_CALL(*mock_writer, Finish()).WillOnce(Return(grpc::Status::OK));
@@ -99,7 +98,7 @@ TEST(StoreExecutionResponseStream, ReturnsErrorIfNighthawkServiceWriteFails) {
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, StoreExecutionResponseStreamRaw)
       .WillOnce([](grpc::ClientContext*, nighthawk::StoreExecutionResponse*) {
-        auto* mock_writer = new grpc::testing::MockClientWriter<StoreExecutionRequest>();
+        auto* mock_writer = new MockClientWriter<StoreExecutionRequest>();
         EXPECT_CALL(*mock_writer, Write(_, _)).WillOnce(Return(false));
         return mock_writer;
       });
@@ -118,7 +117,7 @@ TEST(StoreExecutionResponseStream, ReturnsErrorIfNighthawkServiceWritesDoneFails
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, StoreExecutionResponseStreamRaw)
       .WillOnce([](grpc::ClientContext*, nighthawk::StoreExecutionResponse*) {
-        auto* mock_writer = new grpc::testing::MockClientWriter<StoreExecutionRequest>();
+        auto* mock_writer = new MockClientWriter<StoreExecutionRequest>();
         EXPECT_CALL(*mock_writer, Write(_, _)).WillOnce(Return(true));
         EXPECT_CALL(*mock_writer, WritesDone()).WillOnce(Return(false));
         return mock_writer;
@@ -138,7 +137,7 @@ TEST(StoreExecutionResponseStream, PropagatesErrorIfNighthawkServiceGrpcStreamCl
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, StoreExecutionResponseStreamRaw)
       .WillOnce([](grpc::ClientContext*, nighthawk::StoreExecutionResponse*) {
-        auto* mock_writer = new grpc::testing::MockClientWriter<StoreExecutionRequest>();
+        auto* mock_writer = new MockClientWriter<StoreExecutionRequest>();
         EXPECT_CALL(*mock_writer, Write(_, _)).WillOnce(Return(true));
         EXPECT_CALL(*mock_writer, WritesDone()).WillOnce(Return(true));
         EXPECT_CALL(*mock_writer, Finish())
@@ -163,7 +162,7 @@ TEST(SinkRequest, UsesSpecifiedCommandLineOptions) {
   EXPECT_CALL(mock_nighthawk_sink_stub, SinkRequestStreamRaw)
       .WillOnce([&request](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<SinkRequest, SinkResponse>();
+            new MockClientReaderWriter<SinkRequest, SinkResponse>();
         // SinkRequest currently expects Read to return true exactly once.
         EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(true)).WillOnce(Return(false));
         // Capture the Nighthawk request SinkRequest sends on the channel.
@@ -191,7 +190,7 @@ TEST(SinkRequest, ReturnsNighthawkResponseSuccessfully) {
   EXPECT_CALL(mock_nighthawk_sink_stub, SinkRequestStreamRaw)
       .WillOnce([&expected_response](grpc::ClientContext*) {
         auto* mock_reader_writer =
-            new grpc::testing::MockClientReaderWriter<SinkRequest, SinkResponse>();
+            new MockClientReaderWriter<SinkRequest, SinkResponse>();
         // SinkRequest currently expects Read to return true exactly once.
         // Capture the gRPC response proto as it is written to the output parameter.
         EXPECT_CALL(*mock_reader_writer, Read(_))
@@ -217,7 +216,7 @@ TEST(SinkRequest, WillFinishIfNighthawkServiceDoesNotSendResponse) {
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, SinkRequestStreamRaw).WillOnce([](grpc::ClientContext*) {
     auto* mock_reader_writer =
-        new grpc::testing::MockClientReaderWriter<SinkRequest, SinkResponse>();
+        new MockClientReaderWriter<SinkRequest, SinkResponse>();
     EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(false));
     EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(true));
@@ -237,7 +236,7 @@ TEST(SinkRequest, ReturnsErrorIfNighthawkServiceWriteFails) {
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, SinkRequestStreamRaw).WillOnce([](grpc::ClientContext*) {
     auto* mock_reader_writer =
-        new grpc::testing::MockClientReaderWriter<SinkRequest, SinkResponse>();
+        new MockClientReaderWriter<SinkRequest, SinkResponse>();
     EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(false));
     return mock_reader_writer;
   });
@@ -256,7 +255,7 @@ TEST(SinkRequest, ReturnsErrorIfNighthawkServiceWritesDoneFails) {
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, SinkRequestStreamRaw).WillOnce([](grpc::ClientContext*) {
     auto* mock_reader_writer =
-        new grpc::testing::MockClientReaderWriter<SinkRequest, SinkResponse>();
+        new MockClientReaderWriter<SinkRequest, SinkResponse>();
     EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_reader_writer, WritesDone()).WillOnce(Return(false));
     return mock_reader_writer;
@@ -276,7 +275,7 @@ TEST(SinkRequest, PropagatesErrorIfNighthawkServiceGrpcStreamClosesAbnormally) {
   // test requests a channel. Set call expectations on the inner mock channel.
   EXPECT_CALL(mock_nighthawk_sink_stub, SinkRequestStreamRaw).WillOnce([](grpc::ClientContext*) {
     auto* mock_reader_writer =
-        new grpc::testing::MockClientReaderWriter<SinkRequest, SinkResponse>();
+        new MockClientReaderWriter<SinkRequest, SinkResponse>();
     // SinkRequest currently expects Read to return true exactly once.
     EXPECT_CALL(*mock_reader_writer, Read(_)).WillOnce(Return(true)).WillOnce(Return(false));
     EXPECT_CALL(*mock_reader_writer, Write(_, _)).WillOnce(Return(true));

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -27,3 +27,13 @@ envoy_cc_test_library(
         "@envoy//test/test_common:utility_lib",
     ],
 )
+
+envoy_cc_test_library(
+    name = "mock_stream",
+    hdrs = ["mock_stream.h"],
+    repository = "@envoy",
+    deps = [
+        "@com_github_grpc_grpc//:grpc++",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)

--- a/test/test_common/mock_stream.h
+++ b/test/test_common/mock_stream.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <grpcpp/support/sync_stream.h>
+
+namespace Nighthawk {
+
+// Based off of "grpcpp/test/mock_stream.h"
+template <class W> class MockClientWriter : public grpc::ClientWriterInterface<W> {
+public:
+  MockClientWriter() = default;
+
+  /// ClientStreamingInterface
+  MOCK_METHOD0_T(Finish, grpc::Status());
+
+  /// WriterInterface
+  MOCK_METHOD2_T(Write, bool(const W&, const grpc::WriteOptions));
+
+  /// ClientWriterInterface
+  MOCK_METHOD0_T(WritesDone, bool());
+};
+
+// Based off of "grpcpp/test/mock_stream.h"
+template <class W, class R>
+class MockClientReaderWriter : public grpc::ClientReaderWriterInterface<W, R> {
+public:
+  MockClientReaderWriter() = default;
+
+  /// ClientStreamingInterface
+  MOCK_METHOD0_T(Finish, grpc::Status());
+
+  /// ReaderInterface
+  MOCK_METHOD1_T(NextMessageSize, bool(uint32_t*));
+  MOCK_METHOD1_T(Read, bool(R*));
+
+  /// WriterInterface
+  MOCK_METHOD2_T(Write, bool(const W&, const grpc::WriteOptions));
+
+  /// ClientReaderWriterInterface
+  MOCK_METHOD0_T(WaitForInitialMetadata, void());
+  MOCK_METHOD0_T(WritesDone, bool());
+};
+
+} // namespace Nighthawk


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in [bazel/repositories.bzl](https://github.com/envoyproxy/nighthawk/blob/main/bazel/repositories.bzl) to the latest Envoy's commit.
- Recreate utility mock_stream classes due to https://github.com/envoyproxy/envoy/pull/22706 and https://github.com/grpc/grpc/pull/26641#issuecomment-1074338721

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>