### PR TITLE
CDS churn with multiple clusters with traffic

### DIFF
--- a/benchmarks/BUILD
+++ b/benchmarks/BUILD
@@ -54,10 +54,12 @@ py_library(
     data = [
         "configurations/dynamic_resources.yaml",
         "configurations/lds.yaml",
+        "configurations/request_source_five_clusters.json",
     ],
     srcs_version = "PY2AND3",
     deps = [
         "//api/configuration:cluster_config_manager_py_proto",
+        "@rules_python//python/runfiles",
     ],
 )
 

--- a/benchmarks/configurations/lds.yaml
+++ b/benchmarks/configurations/lds.yaml
@@ -20,7 +20,47 @@ resources:
         route_config:
           name: local_route
           virtual_hosts:
-          - name: local_service
+          - name: cluster_one_service
+            domains:
+            - "cluster_one.com"
+            routes:
+            - match:
+                prefix: "/"
+              route:
+                cluster: cluster_one
+          - name: cluster_two_service
+            domains:
+            - "cluster_two.com"
+            routes:
+            - match:
+                prefix: "/"
+              route:
+                cluster: cluster_two
+          - name: cluster_three_service
+            domains:
+            - "cluster_three.com"
+            routes:
+            - match:
+                prefix: "/"
+              route:
+                cluster: cluster_three
+          - name: cluster_four_service
+            domains:
+            - "cluster_four.com"
+            routes:
+            - match:
+                prefix: "/"
+              route:
+                cluster: cluster_four
+          - name: cluster_five_service
+            domains:
+            - "cluster_five.com"
+            routes:
+            - match:
+                prefix: "/"
+              route:
+                cluster: cluster_five
+          - name: fallback_service
             domains:
             - "*"
             routes:

--- a/benchmarks/configurations/request_source_five_clusters.json
+++ b/benchmarks/configurations/request_source_five_clusters.json
@@ -1,0 +1,65 @@
+{
+  "name": "nighthawk.in-line-options-list-request-source-plugin",
+  "typedConfig": {
+    "@type": "type.googleapis.com/nighthawk.request_source.InLineOptionsListRequestSourceConfig",
+    "optionsList": {
+      "options": [
+        {
+          "requestHeaders": [
+            {
+              "header": {
+                "key": "HOST",
+                "value": "cluster_one.com"
+              }
+            }
+          ],
+          "requestMethod": "GET"
+        },
+        {
+          "requestHeaders": [
+            {
+              "header": {
+                "key": "HOST",
+                "value": "cluster_two.com"
+              }
+            }
+          ],
+          "requestMethod": "GET"
+        },
+        {
+          "requestHeaders": [
+            {
+              "header": {
+                "key": "HOST",
+                "value": "cluster_three.com"
+              }
+            }
+          ],
+          "requestMethod": "GET"
+        },
+        {
+          "requestHeaders": [
+            {
+              "header": {
+                "key": "HOST",
+                "value": "cluster_four.com"
+              }
+            }
+          ],
+          "requestMethod": "GET"
+        },
+        {
+          "requestHeaders": [
+            {
+              "header": {
+                "key": "HOST",
+                "value": "cluster_five.com"
+              }
+            }
+          ],
+          "requestMethod": "GET"
+        }
+      ]
+    }
+  }
+}

--- a/benchmarks/dynamic_config_envoy_proxy.py
+++ b/benchmarks/dynamic_config_envoy_proxy.py
@@ -17,8 +17,6 @@ def proxy_config() -> Generator[str, None, None]:
   yield "nighthawk/benchmarks/configurations/envoy_proxy.yaml"
 
 
-# TODO(kbaichoo): Stubbed implementation. Will be enhanced to
-# leverage backend addresses.
 @pytest.fixture()
 def dynamic_config_settings(
 ) -> Generator[cluster_config_manager_pb2.DynamicClusterConfigManagerSettings, None, None]:

--- a/benchmarks/dynamic_config_envoy_proxy.py
+++ b/benchmarks/dynamic_config_envoy_proxy.py
@@ -5,7 +5,7 @@ import logging
 import os
 from typing import Generator
 
-from test.integration import integration_test_fixtures
+from test.integration import integration_test_fixtures, common
 import envoy_proxy
 from dynamic_config import dynamic_config_server
 from nighthawk.api.configuration import cluster_config_manager_pb2
@@ -26,8 +26,6 @@ def dynamic_config_settings(
   settings = cluster_config_manager_pb2.DynamicClusterConfigManagerSettings()
   settings.refresh_interval.seconds = 5
   settings.output_file = 'new_cds.pb'
-  cluster = settings.clusters.add()
-  cluster.name = 'service_envoyproxy_io'
   yield settings
 
 
@@ -68,16 +66,44 @@ class InjectDynamicHttpProxyIntegrationTestBase(envoy_proxy.InjectHttpProxyInteg
     self._dynamic_config_settings.output_file = output_file
     logging.info(f"Injecting dynamic configuration. Output file: {output_file}")
 
-    # TODO(kbaichoo): we only hardcode a single endpoint, but will expand on this.
-    endpoints = self._dynamic_config_settings.clusters[0].endpoints.add()
-    endpoints.ip = self.test_server.server_ip
-    endpoints.port = self.test_server.server_port
+    # TODO(kbaichoo): Don't hardcode the clusters based on path configuration.
+    if '15_listeners' in self._nighthawk_test_config_path:
+      clusters = [
+          'cluster_one',
+          'cluster_two',
+          'cluster_three',
+          'cluster_four',
+          'cluster_five',
+      ]
+    else:
+      clusters = ['service_envoyproxy_io']
+
+    self._assignEndpointsToClusters(clusters)
 
     self._dynamic_config_controller = dynamic_config_server.DynamicConfigController(
         self._dynamic_config_settings)
 
     assert (self._dynamic_config_controller.start())
     logging.info("dynamic configuration running")
+
+  def _assignEndpointsToClusters(self, clusters):
+    """Process all backend endpoints, round robin assigning to the given clusters."""
+    available_endpoints = []
+
+    for endpoint in self.getAllTestServerRootUris():
+      ip_and_port = endpoint.split('/')[2]
+      available_endpoints.append(ip_and_port)
+
+    for cluster in clusters:
+      new_cluster = self._dynamic_config_settings.clusters.add()
+      new_cluster.name = cluster
+    cluster_idx = 0
+    for endpoint in available_endpoints:
+      new_endpoint = self._dynamic_config_settings.clusters[cluster_idx].endpoints.add()
+      ip, port = endpoint.rsplit(':', maxsplit=1)
+      new_endpoint.ip = ip
+      new_endpoint.port = int(port)
+      cluster_idx = (cluster_idx + 1) % len(clusters)
 
   def tearDown(self, caplog):
     """Tear down the proxy and test server. Assert that both exit succesfully."""

--- a/benchmarks/dynamic_test/test_cds_churn_with_traffic.py
+++ b/benchmarks/dynamic_test/test_cds_churn_with_traffic.py
@@ -9,6 +9,8 @@ import pytest
 from dynamic_config_envoy_proxy import (dynamic_config_settings,
                                         inject_dynamic_envoy_http_proxy_fixture, proxy_config)
 from benchmarks import utilities
+from typing import Generator
+from rules_python.python.runfiles import runfiles
 
 
 def _run_benchmark(fixture,
@@ -18,7 +20,8 @@ def _run_benchmark(fixture,
                    max_active_requests=100,
                    request_body_size=0,
                    response_size=1024,
-                   concurrency=1):
+                   concurrency=1,
+                   request_source_config=None):
   args = [
       fixture.getTestServerRootUri(), "--rps",
       str(rps), "--duration",
@@ -29,9 +32,14 @@ def _run_benchmark(fixture,
       "x-nighthawk-test-server-config:{response_body_size:%s}" % response_size,
       "--experimental-h1-connection-reuse-strategy", "lru", "--prefetch-connections"
   ]
+
   if request_body_size > 0:
     args.append("--request-body-size")
     args.append(str(request_body_size))
+
+  if request_source_config:
+    args.append("--request-source-plugin-config")
+    args.append(_readRunfile(request_source_config))
 
   parsed_json, _ = fixture.runNighthawkClient(args, expect_failure=True)
 
@@ -39,10 +47,35 @@ def _run_benchmark(fixture,
   utilities.output_benchmark_results(parsed_json, fixture)
 
 
+def _readRunfile(path: str) -> str:
+  runfiles_instance = runfiles.Create()
+  with open(runfiles_instance.Rlocation(path)) as f:
+    return f.read()
+
+
 # Test via injected Envoy
 @pytest.mark.parametrize('proxy_config',
                          ["nighthawk/benchmarks/configurations/dynamic_resources.yaml"])
 @pytest.mark.parametrize('server_config',
                          ["nighthawk/test/integration/configurations/nighthawk_http_origin.yaml"])
-def test_dynamic_http(inject_dynamic_envoy_http_proxy_fixture, proxy_config):  # noqa
+def test_dynamic_http_single_cluster_traffic(inject_dynamic_envoy_http_proxy_fixture,
+                                             proxy_config):  # noqa
   _run_benchmark(inject_dynamic_envoy_http_proxy_fixture)
+
+
+@pytest.fixture()
+def request_source_config() -> Generator[str, None, None]:
+  """Yield path to request_source_config for the nighthawk client to send different requests."""
+  yield "nighthawk/benchmarks/configurations/request_source_five_clusters.json"
+
+
+@pytest.mark.parametrize('proxy_config',
+                         ["nighthawk/benchmarks/configurations/dynamic_resources.yaml"])
+@pytest.mark.parametrize(
+    'server_config',
+    ["nighthawk/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml"])
+def test_dynamic_http_multiple_cluster_traffic(inject_dynamic_envoy_http_proxy_fixture,
+                                               request_source_config, proxy_config):
+  """Test that the nighthawkClient can run with request-source-plugin option."""
+  _run_benchmark(inject_dynamic_envoy_http_proxy_fixture,
+                 request_source_config=request_source_config)

--- a/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
@@ -1,0 +1,538 @@
+admin:
+  access_log:
+    - name: envoy.access_loggers.file
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: $tmpdir/nighthawk-test-server-admin-access.log
+  profile_path: $tmpdir/nighthawk-test-server.prof
+  address:
+    socket_address: { address: $server_ip, port_value: 0 }
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  listeners:
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  listeners:
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false

--- a/test/integration/unit_tests/test_utility.py
+++ b/test/integration/unit_tests/test_utility.py
@@ -71,5 +71,13 @@ def test_count_log_lines_with_substring_returns_zero_with_empty_logs():
   assert count == 0
 
 
+def test_parse_uris_to_socket_address():
+  """Test parse uri for both ipv4 and ipv6."""
+  addresses = ["http://1.2.3.45:2022", "http://2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF:9001"]
+  v4_address, v6_address = utility.parseUrisToSocketAddress(addresses)
+  assert v4_address.ip == "1.2.3.45" and v4_address.port == 2022
+  assert v6_address.ip == "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF" and v6_address.port == 9001
+
+
 if __name__ == "__main__":
   raise SystemExit(pytest.main([__file__]))

--- a/test/integration/utility.py
+++ b/test/integration/utility.py
@@ -2,10 +2,32 @@
 
 import os
 import subprocess
+from collections import namedtuple
 
 
 class Error(Exception):
   """Raised on errors in this module."""
+
+
+# Helper class to parse ip, port.
+SocketAddress = namedtuple('SocketAddress', ['ip', 'port'])
+
+
+def parseUrisToSocketAddress(uris: list[str]) -> list[SocketAddress]:
+  """Parse a list of uris returning the corresponding list of SocketAddresses.
+
+  Args:
+    uris: List of uri strings of the format http://<ip>:<port>, the ip address can be IPv4 or IPv6.
+
+  Returns:
+    The corresponding list of SocketAddress for each URI.
+  """
+  addresses = []
+  for uri in uris:
+    ip_and_port = uri.split('/')[2]
+    ip, port = ip_and_port.rsplit(':', maxsplit=1)
+    addresses.append(SocketAddress(ip, int(port)))
+  return addresses
 
 
 def isSanitizerRun():


### PR DESCRIPTION
Add a test that has 5 clusters, 3 endpoints each. Use `request-source-plugin-config` to configure client to target different backends.