### PR TITLE
Update Envoy to f307e71 (Sep 13th 2022).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -194,7 +194,7 @@ build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --experimental_use_llvm_covmap
 build:coverage --collect_code_coverage
 build:coverage --test_tag_filters=-nocoverage
-build:coverage --instrumentation_filter="//source(?!/common/quic/platform)[/:],//include[/:],//contrib(?!/.*/test)[/:]"
+build:coverage --instrumentation_filter="//source(?!/common/quic/platform)[/:],//envoy[/:],//contrib(?!/.*/test)[/:]"
 build:test-coverage --test_arg="-l trace"
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "c1744d490c8b03034cde2452adc56d77a8300f59"
-ENVOY_SHA = "57e5f447e7cebdf15a4cbb80b8ee15a1bee181fe5b42bac58eebe49126c0584d"
+ENVOY_COMMIT = "f307e710fd9f28a48cd9059ec124313277142c52"
+ENVOY_SHA = "8a27bea4450005c7c7ac9973a8455323b0051838f0f8428c1d067dad54ad76bf"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/adaptive_load/adaptive_load_controller_impl.cc
+++ b/source/adaptive_load/adaptive_load_controller_impl.cc
@@ -128,7 +128,7 @@ absl::StatusOr<BenchmarkResult> AdaptiveLoadControllerImpl::PerformAndAnalyzeNig
       step_controller.GetCurrentCommandLineOptions();
   if (!command_line_options_or.ok()) {
     ENVOY_LOG_MISC(error, "Error constructing Nighthawk input: {}: {}",
-                   command_line_options_or.status().code(),
+                   command_line_options_or.status().raw_code(),
                    command_line_options_or.status().message());
     return command_line_options_or.status();
   }
@@ -144,7 +144,7 @@ absl::StatusOr<BenchmarkResult> AdaptiveLoadControllerImpl::PerformAndAnalyzeNig
                                                           command_line_options);
   Envoy::SystemTime end_time = time_source_.systemTime();
   if (!nighthawk_response_or.ok()) {
-    ENVOY_LOG_MISC(error, "Nighthawk Service error: {}: {}", nighthawk_response_or.status().code(),
+    ENVOY_LOG_MISC(error, "Nighthawk Service error: {}: {}", nighthawk_response_or.status().raw_code(),
                    nighthawk_response_or.status().message());
     return nighthawk_response_or.status();
   }
@@ -155,7 +155,7 @@ absl::StatusOr<BenchmarkResult> AdaptiveLoadControllerImpl::PerformAndAnalyzeNig
       metrics_evaluator_.AnalyzeNighthawkBenchmark(nighthawk_response, spec,
                                                    name_to_custom_plugin_map);
   if (!benchmark_result_or.ok()) {
-    ENVOY_LOG_MISC(error, "Benchmark scoring error: {}: {}", benchmark_result_or.status().code(),
+    ENVOY_LOG_MISC(error, "Benchmark scoring error: {}: {}", benchmark_result_or.status().raw_code(),
                    benchmark_result_or.status().message());
     return benchmark_result_or.status();
   }
@@ -205,7 +205,7 @@ absl::StatusOr<AdaptiveLoadSessionOutput> AdaptiveLoadControllerImpl::PerformAda
 
     if (spec.has_benchmark_cooldown_duration()) {
       ENVOY_LOG_MISC(info, "Cooling down before the next benchmark for duration: {}",
-                     spec.benchmark_cooldown_duration());
+                     spec.benchmark_cooldown_duration().ShortDebugString());
       uint64_t sleep_time_ms = Envoy::Protobuf::util::TimeUtil::DurationToMilliseconds(
           spec.benchmark_cooldown_duration());
       absl::SleepFor(absl::Milliseconds(sleep_time_ms));

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -100,122 +100,153 @@ public:
   }
 };
 
-// Implementation of Envoy::Server::Instance used as a placeholder. None of its methods
-// should be called because Nighthawk is not a real Envoy that performs xDS config validation.
-class NullServerInstance : public Envoy::Server::Instance {
-  Envoy::Server::Admin& admin() override { PANIC("not implemented"); }
-  Envoy::Api::Api& api() override { PANIC("not implemented"); }
-  Envoy::Upstream::ClusterManager& clusterManager() override { PANIC("not implemented"); }
+// Implementation of Envoy::Server::Instance. Only methods used by Envoy's code
+// when Nighthawk is running are implemented.
+class NighthawkServerInstance : public Envoy::Server::Instance {
+ public:
+  NighthawkServerInstance(Envoy::Server::Admin& admin, Envoy::Api::Api& api, Envoy::Event::Dispatcher& dispatcher,
+                          Envoy::AccessLog::AccessLogManager& log_manager,
+                          Envoy::Server::Options& options,
+                          Envoy::Runtime::Loader& runtime, Envoy::Singleton::Manager& singleton_manager, Envoy::ThreadLocal::Instance& tls,
+                          Envoy::LocalInfo::LocalInfo& local_info) :
+                            admin_(admin), api_(api), dispatcher_(dispatcher), log_manager_(log_manager),
+                            options_(options),
+                            runtime_(runtime), singleton_manager_(singleton_manager), tls_(tls), local_info_(local_info) {}
+
+  Envoy::Server::Admin& admin() override { return admin_; }
+  Envoy::Api::Api& api() override { return api_; }
+  Envoy::Upstream::ClusterManager& clusterManager() override { PANIC("NighthawkServerInstance::clusterManager not implemented"); }
   const Envoy::Upstream::ClusterManager& clusterManager() const override {
-    PANIC("not implemented");
+    PANIC("NighthawkServerInstance::clusterManager not implemented");
   }
-  Envoy::Ssl::ContextManager& sslContextManager() override { PANIC("not implemented"); }
-  Envoy::Event::Dispatcher& dispatcher() override { PANIC("not implemented"); }
-  Envoy::Network::DnsResolverSharedPtr dnsResolver() override { PANIC("not implemented"); }
-  void drainListeners() override { PANIC("not implemented"); }
-  Envoy::Server::DrainManager& drainManager() override { PANIC("not implemented"); }
-  Envoy::AccessLog::AccessLogManager& accessLogManager() override { PANIC("not implemented"); }
-  void failHealthcheck(bool) override { PANIC("not implemented"); }
-  bool healthCheckFailed() override { PANIC("not implemented"); }
-  Envoy::Server::HotRestart& hotRestart() override { PANIC("not implemented"); }
-  Envoy::Init::Manager& initManager() override { PANIC("not implemented"); }
-  Envoy::Server::ListenerManager& listenerManager() override { PANIC("not implemented"); }
-  Envoy::MutexTracer* mutexTracer() override { PANIC("not implemented"); }
-  Envoy::Server::OverloadManager& overloadManager() override { PANIC("not implemented"); }
-  Envoy::Secret::SecretManager& secretManager() override { PANIC("not implemented"); }
-  const Envoy::Server::Options& options() override { PANIC("not implemented"); }
-  Envoy::Runtime::Loader& runtime() override { PANIC("not implemented"); }
-  Envoy::Server::ServerLifecycleNotifier& lifecycleNotifier() override { PANIC("not implemented"); }
-  void shutdown() override { PANIC("not implemented"); }
-  bool isShutdown() override { PANIC("not implemented"); }
-  void shutdownAdmin() override { PANIC("not implemented"); }
-  Envoy::Singleton::Manager& singletonManager() override { PANIC("not implemented"); }
-  time_t startTimeCurrentEpoch() override { PANIC("not implemented"); }
-  time_t startTimeFirstEpoch() override { PANIC("not implemented"); }
-  Envoy::Stats::Store& stats() override { PANIC("not implemented"); }
-  Envoy::Grpc::Context& grpcContext() override { PANIC("not implemented"); }
-  Envoy::Http::Context& httpContext() override { PANIC("not implemented"); }
-  Envoy::Router::Context& routerContext() override { PANIC("not implemented"); }
-  Envoy::ProcessContextOptRef processContext() override { PANIC("not implemented"); }
-  Envoy::ThreadLocal::Instance& threadLocal() override { PANIC("not implemented"); }
-  Envoy::LocalInfo::LocalInfo& localInfo() const override { PANIC("not implemented"); }
-  Envoy::TimeSource& timeSource() override { PANIC("not implemented"); }
-  void flushStats() override { PANIC("not implemented"); }
+  Envoy::Ssl::ContextManager& sslContextManager() override { PANIC("NighthawkServerInstance::sslContextManager not implemented"); }
+  Envoy::Event::Dispatcher& dispatcher() override { return dispatcher_; }
+  Envoy::Network::DnsResolverSharedPtr dnsResolver() override { PANIC("NighthawkServerInstance::dnsResolver not implemented"); }
+  void drainListeners() override { PANIC("NighthawkServerInstance::drainListeners not implemented"); }
+  Envoy::Server::DrainManager& drainManager() override { PANIC("NighthawkServerInstance::drainManager not implemented"); }
+  Envoy::AccessLog::AccessLogManager& accessLogManager() override { return log_manager_; }
+  void failHealthcheck(bool) override { PANIC("NighthawkServerInstance::failHealthcheck not implemented"); }
+  bool healthCheckFailed() override { PANIC("NighthawkServerInstance::healthCheckFailed not implemented"); }
+  Envoy::Server::HotRestart& hotRestart() override { PANIC("NighthawkServerInstance::hotRestart not implemented"); }
+  Envoy::Init::Manager& initManager() override { PANIC("NighthawkServerInstance::initManager not implemented"); }
+  Envoy::Server::ListenerManager& listenerManager() override { PANIC("NighthawkServerInstance::listenerManager not implemented"); }
+  Envoy::MutexTracer* mutexTracer() override { PANIC("NighthawkServerInstance::mutexTracer not implemented"); }
+  Envoy::Server::OverloadManager& overloadManager() override { PANIC("NighthawkServerInstance::overloadManager not implemented"); }
+  Envoy::Secret::SecretManager& secretManager() override { PANIC("NighthawkServerInstance::secretManager not implemented"); }
+  const Envoy::Server::Options& options() override { return options_; }
+  Envoy::Runtime::Loader& runtime() override { return runtime_; }
+  Envoy::Server::ServerLifecycleNotifier& lifecycleNotifier() override { PANIC("NighthawkServerInstance::lifecycleNotifier not implemented"); }
+  void shutdown() override { PANIC("NighthawkServerInstance::shutdown not implemented"); }
+  bool isShutdown() override { PANIC("NighthawkServerInstance::isShutdown not implemented"); }
+  void shutdownAdmin() override { PANIC("NighthawkServerInstance::shutdownAdmin not implemented"); }
+  Envoy::Singleton::Manager& singletonManager() override { return singleton_manager_; }
+  time_t startTimeCurrentEpoch() override { PANIC("NighthawkServerInstance::startTimeCurrentEpoch not implemented"); }
+  time_t startTimeFirstEpoch() override { PANIC("NighthawkServerInstance::startTimeFirstEpoch not implemented"); }
+  Envoy::Stats::Store& stats() override { PANIC("NighthawkServerInstance::stats not implemented"); }
+  Envoy::Grpc::Context& grpcContext() override { PANIC("NighthawkServerInstance::grpcContext not implemented"); }
+  Envoy::Http::Context& httpContext() override { PANIC("NighthawkServerInstance::httpContext not implemented"); }
+  Envoy::Router::Context& routerContext() override { PANIC("NighthawkServerInstance::routerContext not implemented"); }
+  Envoy::ProcessContextOptRef processContext() override { PANIC("NighthawkServerInstance::processContext not implemented"); }
+  Envoy::ThreadLocal::Instance& threadLocal() override { return tls_; }
+  Envoy::LocalInfo::LocalInfo& localInfo() const override { return local_info_; }
+  Envoy::TimeSource& timeSource() override { PANIC("NighthawkServerInstance::timeSource not implemented"); }
+  void flushStats() override { PANIC("NighthawkServerInstance::flushStats not implemented"); }
   Envoy::ProtobufMessage::ValidationContext& messageValidationContext() override {
-    PANIC("not implemented");
+    PANIC("NighthawkServerInstance::messageValidationContext not implemented");
   }
-  Envoy::Server::Configuration::StatsConfig& statsConfig() override { PANIC("not implemented"); }
-  envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { PANIC("not implemented"); }
+  Envoy::Server::Configuration::StatsConfig& statsConfig() override { PANIC("NighthawkServerInstance::statsConfig not implemented"); }
+  envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { PANIC("NighthawkServerInstance::bootstrap not implemented"); }
   Envoy::Server::Configuration::ServerFactoryContext& serverFactoryContext() override {
-    PANIC("not implemented");
+    PANIC("NighthawkServerInstance::serverFactoryContext not implemented");
   }
   Envoy::Server::Configuration::TransportSocketFactoryContext&
   transportSocketFactoryContext() override {
-    PANIC("not implemented");
+    PANIC("NighthawkServerInstance::transportSocketFactoryContext not implemented");
   }
   void setDefaultTracingConfig(const envoy::config::trace::v3::Tracing&) override {
-    PANIC("not implemented");
+    PANIC("NighthawkServerInstance::setDefaultTracingConfig not implemented");
   }
-  bool enableReusePortDefault() override { PANIC("not implemented"); }
+  bool enableReusePortDefault() override { PANIC("NighthawkServerInstance::enableReusePortDefault not implemented"); }
   void setSinkPredicates(std::unique_ptr<Envoy::Stats::SinkPredicates>&&) override {
-    PANIC("not implemented");
+    PANIC("NighthawkServerInstance::setSinkPredicates not implemented");
   }
+
+ private:
+  Envoy::Server::Admin& admin_;
+  Envoy::Api::Api& api_;
+  Envoy::Event::Dispatcher& dispatcher_;
+  Envoy::AccessLog::AccessLogManager& log_manager_;
+  Envoy::Server::Options& options_;
+  Envoy::Runtime::Loader& runtime_;
+  Envoy::Singleton::Manager& singleton_manager_;
+  Envoy::ThreadLocal::Instance& tls_;
+  Envoy::LocalInfo::LocalInfo& local_info_;
+
 };
 
-// Implementation of Envoy::Server::Configuration::ServerFactoryContext used as a placeholder. None
-// of its methods should be called because Nighthawk is not a real Envoy that performs xDS config
-// validation.
-class NullServerFactoryContext : public Envoy::Server::Configuration::ServerFactoryContext {
-  const Envoy::Server::Options& options() override { PANIC("not implemented"); };
+// Implementation of Envoy::Server::Configuration::ServerFactoryContext.
+class NighthawkServerFactoryContext : public Envoy::Server::Configuration::ServerFactoryContext {
+ public:
+  NighthawkServerFactoryContext(Envoy::Server::Instance& server) : server_(server) {}
 
-  Envoy::Event::Dispatcher& mainThreadDispatcher() override { PANIC("not implemented"); };
+  const Envoy::Server::Options& options() override { return server_.options(); };
 
-  Envoy::Api::Api& api() override { PANIC("not implemented"); };
+  Envoy::Event::Dispatcher& mainThreadDispatcher() override { return server_.dispatcher(); }
 
-  Envoy::LocalInfo::LocalInfo& localInfo() const override { PANIC("not implemented"); };
+  Envoy::Api::Api& api() override { return server_.api(); }
 
-  Envoy::Server::Admin& admin() override { PANIC("not implemented"); };
+  Envoy::LocalInfo::LocalInfo& localInfo() const override { return server_.localInfo(); }
 
-  Envoy::Runtime::Loader& runtime() override { PANIC("not implemented"); };
+  Envoy::Server::Admin& admin() override { return server_.admin(); }
 
-  Envoy::Singleton::Manager& singletonManager() override { PANIC("not implemented"); };
+  Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
+
+  Envoy::Singleton::Manager& singletonManager() override { return server_.singletonManager(); }
 
   Envoy::ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
-    PANIC("not implemented");
+    return Envoy::ProtobufMessage::getStrictValidationVisitor();
   };
 
-  Envoy::Stats::Scope& scope() override { PANIC("not implemented"); };
+  Envoy::Stats::Scope& scope() override { PANIC("NighthawkServerFactoryContext::scope not implemented"); };
 
-  Envoy::Stats::Scope& serverScope() override { PANIC("not implemented"); };
+  Envoy::Stats::Scope& serverScope() override { PANIC("NighthawkServerFactoryContext::serverScope not implemented"); };
 
-  Envoy::ThreadLocal::SlotAllocator& threadLocal() override { PANIC("not implemented"); };
+  Envoy::ThreadLocal::SlotAllocator& threadLocal() override { return server_.threadLocal(); }
 
-  Envoy::Upstream::ClusterManager& clusterManager() override { PANIC("not implemented"); };
+  Envoy::Upstream::ClusterManager& clusterManager() override { PANIC("NighthawkServerFactoryContext::clusterManager not implemented"); };
 
   Envoy::ProtobufMessage::ValidationContext& messageValidationContext() override {
-    PANIC("not implemented");
+    PANIC("NighthawkServerFactoryContext::messageValidationContext not implemented");
   };
 
-  Envoy::TimeSource& timeSource() override { PANIC("not implemented"); };
+  Envoy::TimeSource& timeSource() override { PANIC("NighthawkServerFactoryContext::timeSource not implemented"); };
 
-  Envoy::AccessLog::AccessLogManager& accessLogManager() override { PANIC("not implemented"); };
+  Envoy::AccessLog::AccessLogManager& accessLogManager() override { return server_.accessLogManager(); }
 
   Envoy::Server::ServerLifecycleNotifier& lifecycleNotifier() override {
-    PANIC("not implemented");
+    PANIC("NighthawkServerFactoryContext::lifecycleNotifier not implemented");
   };
 
-  Envoy::Init::Manager& initManager() override { PANIC("not implemented"); };
+  Envoy::Init::Manager& initManager() override { PANIC("NighthawkServerFactoryContext::initManager not implemented"); };
 
-  Envoy::Grpc::Context& grpcContext() override { PANIC("not implemented"); };
+  Envoy::Grpc::Context& grpcContext() override { PANIC("NighthawkServerFactoryContext::grpcContext not implemented"); };
 
-  Envoy::Router::Context& routerContext() override { PANIC("not implemented"); };
+  Envoy::Router::Context& routerContext() override { PANIC("NighthawkServerFactoryContext::routerContext not implemented"); };
 
-  Envoy::Server::DrainManager& drainManager() override { PANIC("not implemented"); };
+  Envoy::Server::DrainManager& drainManager() override { PANIC("NighthawkServerFactoryContext::drainManager not implemented"); };
 
-  Envoy::Server::Configuration::StatsConfig& statsConfig() override { PANIC("not implemented"); }
+  Envoy::Server::Configuration::StatsConfig& statsConfig() override { PANIC("NighthawkServerFactoryContext::statsConfig not implemented"); }
 
-  envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { PANIC("not implemented"); }
+  envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { PANIC("NighthawkServerFactoryContext::bootstrap not implemented"); }
+
+ private:
+  Envoy::Server::Instance& server_;
 };
+
+// Disables the hot restart Envoy functionality.
+std::string HotRestartDisabled(bool) {
+  return "hot restart is disabled";
+}
 
 } // namespace
 
@@ -308,8 +339,7 @@ ProcessImpl::ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_
       init_watcher_("Nighthawk", []() {}),
       admin_(Envoy::Network::Address::InstanceConstSharedPtr()),
       validation_context_(false, false, false), router_context_(store_root_.symbolTable()),
-      server_(std::make_unique<NullServerInstance>()),
-      server_factory_context_(std::make_unique<NullServerFactoryContext>()) {
+      envoy_options_(/* args = */ {"process_impl"}, HotRestartDisabled, spdlog::level::info) {
   // Any dispatchers created after the following call will use hr timers.
   setupForHRTimers();
   std::string lower = absl::AsciiStrToLower(
@@ -574,16 +604,11 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const UriPtr& tracing_
     }
     shutdown_ = false;
 
-    const Envoy::OptionsImpl::HotRestartVersionCb hot_restart_version_cb = [](bool) {
-      return "hot restart is disabled";
-    };
-    const Envoy::OptionsImpl envoy_options(
-        /* args = */ {"process_impl"}, hot_restart_version_cb, spdlog::level::info);
     // Needs to happen as early as possible (before createWorkers()) in the instantiation to preempt
     // the objects that require stats.
     if (!options_.statsSinks().empty()) {
       store_root_.setTagProducer(
-          Envoy::Config::Utility::createTagProducer(bootstrap_, envoy_options.statsTags()));
+          Envoy::Config::Utility::createTagProducer(bootstrap_, envoy_options_.statsTags()));
     }
 
     createWorkers(number_of_workers_, scheduled_start);
@@ -597,11 +622,13 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const UriPtr& tracing_
         std::make_unique<Envoy::Extensions::TransportSockets::Tls::ContextManagerImpl>(
             time_system_);
 
+    server_ = std::make_unique<NighthawkServerInstance>(admin_, *api_, *dispatcher_, access_log_manager_, envoy_options_, runtime_singleton_->instance(), *singleton_manager_, tls_, *local_info_);
+    server_factory_context_ = std::make_unique<NighthawkServerFactoryContext>(*server_);
     cluster_manager_factory_ = std::make_unique<ClusterManagerFactory>(
         *server_factory_context_, admin_, Envoy::Runtime::LoaderSingleton::get(), store_root_, tls_,
         dns_resolver, *ssl_context_manager_, *dispatcher_, *local_info_, secret_manager_,
         validation_context_, *api_, http_context_, grpc_context_, router_context_,
-        access_log_manager_, *singleton_manager_, envoy_options, quic_stat_names_, *server_);
+        access_log_manager_, *singleton_manager_, envoy_options_, quic_stat_names_, *server_);
     cluster_manager_factory_->setConnectionReuseStrategy(
         options_.h1ConnectionReuseStrategy() == nighthawk::client::H1ConnectionReuseStrategy::LRU
             ? Http1PoolImpl::ConnectionReuseStrategy::LRU

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -35,6 +35,7 @@
 #include "external/envoy/source/exe/process_wide.h"
 #include "external/envoy/source/extensions/transport_sockets/tls/context_manager_impl.h"
 #include "external/envoy/source/server/config_validation/admin.h"
+#include "external/envoy/source/server/options_impl.h"
 #include "external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h"
 
 #include "source/client/benchmark_client_impl.h"
@@ -211,6 +212,7 @@ private:
   bool cancelled_{false};
   std::unique_ptr<FlushWorkerImpl> flush_worker_;
   Envoy::Router::ContextImpl router_context_;
+  Envoy::OptionsImpl envoy_options_;
   // Null server implementation used as a placeholder. Its methods should never get called
   // because Nighthawk is not a full Envoy server that performs xDS config validation.
   std::unique_ptr<Envoy::Server::Instance> server_;

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -2,6 +2,8 @@
 
 #include <memory>
 
+#include "fmt/ostream.h"
+
 #include "external/envoy/source/common/http/http1/codec_impl.h"
 #include "external/envoy/source/common/http/utility.h"
 #include "external/envoy/source/common/network/address_impl.h"
@@ -194,3 +196,9 @@ void StreamDecoder::setupForTracing() {
 
 } // namespace Client
 } // namespace Nighthawk
+
+// NOLINT(namespace-nighthawk)
+namespace fmt {
+// Allow fmtlib to use operator << defined in HeaderMapPtr.
+template <> struct formatter<::Nighthawk::HeaderMapPtr> : ostream_formatter {};
+} // namespace fmt

--- a/source/sink/sink_impl.cc
+++ b/source/sink/sink_impl.cc
@@ -137,3 +137,10 @@ InMemorySinkImpl::LoadExecutionResult(absl::string_view execution_id) const {
 }
 
 } // namespace Nighthawk
+
+
+// NOLINT(namespace-nighthawk)
+namespace fmt {
+// Allow fmtlib to use operator << defined in std::filesystem::path.
+template <> struct formatter<::std::filesystem::path> : ostream_formatter {};
+}  // namespace fmt


### PR DESCRIPTION
- Envoy started calling some methods on `::Envoy::Server::Configuration::ServerFactoryContext` since https://github.com/envoyproxy/envoy/pull/23019. Done the following changes:
  1. Renamed `NullServerInstance` to `NighthawkServerInstance` and `NullServerFactoryContext` to `NighthawkServerFactoryContext` since some of the methods now need to be implemented.
  2. Improved PANIC messages in unimplemented methods on these objects, so that they mention the specific method that was called. This improved debugging of this kind of problems.
  3. Implemented methods, which are now called by Envoy. The methods just forward pre-existing object instances.
- making sure we only format types that are 'formattable' in log messages as required by the new fmtlib imported in https://github.com/envoyproxy/envoy/pull/22981. Done by either switching to such types, or allowing fmt to use the `<<` operator on the formatted type.
- synced `.bazelrc` from Envoy.
- no changes to `.bazelversion`, `ci/run_envoy_docker.sh`, `tools/gen_compilation_database.py` and `tools/code_format/config.yaml`.

Signed-off-by: Jakub Sobon <mumak@google.com>