### PR TITLE
Pass user defined output plugin through to options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ For using the Nighthawk test server, see [here](source/server/README.md).
 
 USAGE:
 
-bazel-bin/nighthawk_client  [--latency-response-header-name <string>]
+bazel-bin/nighthawk_client  [--user-defined-plugin-config <string>] ...
+[--latency-response-header-name <string>]
 [--stats-flush-interval-duration <duration>]
 [--stats-flush-interval <uint32_t>]
 [--stats-sinks <string>] ... [--no-duration]
@@ -197,6 +198,14 @@ format>
 
 
 Where:
+
+--user-defined-plugin-config <string>  (accepted multiple times)
+WIP - will throw unimplemented error. Optional configurations for
+plugins that collect data about responses received by NH and attach a
+corresponding UserDefinedOutput to the Result. Example (json):
+{name:"nighthawk.fake_user_defined_output"
+,typed_config:{"@type":"type.googleapis.com/nighthawk.FakeUserDefinedO
+utputConfig",fail_data:"false"}}
 
 --latency-response-header-name <string>
 Set an optional header name that will be returned in responses, whose

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -89,7 +89,8 @@ function do_unit_test_coverage() {
 function do_integration_test_coverage() {
     export TEST_TARGETS="//test:python_test"
     # TODO(#830): Raise the integration test coverage.
-    export COVERAGE_THRESHOLD=73.0
+    # TODO(nbperry): Raise back to 73 when User Defined Output plugin completed
+    export COVERAGE_THRESHOLD=72.7
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
     exit 0

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -98,6 +98,8 @@ public:
 
   virtual absl::optional<Envoy::SystemTime> scheduled_start() const PURE;
   virtual absl::optional<std::string> executionId() const PURE;
+  virtual const std::vector<envoy::config::core::v3::TypedExtensionConfig>&
+  userDefinedOutputPluginConfigs() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -655,7 +655,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
     }
   }
   if (!user_defined_output_plugin_configs.getValue().empty()) {
-    for (std::string plugin_config_string : user_defined_output_plugin_configs.getValue()) {
+    for (const std::string& plugin_config_string : user_defined_output_plugin_configs.getValue()) {
       try {
         envoy::config::core::v3::TypedExtensionConfig typed_config;
         Envoy::MessageUtil::loadFromJson(plugin_config_string, typed_config,

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -183,7 +183,7 @@ private:
   std::string latency_response_header_name_;
   absl::optional<Envoy::SystemTime> scheduled_start_;
   absl::optional<std::string> execution_id_;
-  std::vector<envoy::config::core::v3::TypedExtensionConfig> user_defined_output_plugin_configs_{};
+  std::vector<envoy::config::core::v3::TypedExtensionConfig> user_defined_output_plugin_configs_;
 };
 
 } // namespace Client

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -114,6 +114,11 @@ public:
   absl::optional<Envoy::SystemTime> scheduled_start() const override { return scheduled_start_; }
   absl::optional<std::string> executionId() const override { return execution_id_; }
 
+  const std::vector<envoy::config::core::v3::TypedExtensionConfig>&
+  userDefinedOutputPluginConfigs() const override {
+    return user_defined_output_plugin_configs_;
+  }
+
 private:
   void parsePredicates(const TCLAP::MultiArg<std::string>& arg,
                        TerminationPredicateMap& predicates);
@@ -178,6 +183,7 @@ private:
   std::string latency_response_header_name_;
   absl::optional<Envoy::SystemTime> scheduled_start_;
   absl::optional<std::string> execution_id_;
+  std::vector<envoy::config::core::v3::TypedExtensionConfig> user_defined_output_plugin_configs_{};
 };
 
 } // namespace Client

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -425,7 +425,7 @@ absl::StatusOr<ProcessPtr> ProcessImpl::CreateProcessImpl(
                                                        std::move(typed_dns_resolver_config),
                                                        process_wide));
 
-  if (options.userDefinedOutputPluginConfigs().size() > 0) {
+  if (!options.userDefinedOutputPluginConfigs().empty()) {
     ENVOY_LOG(error, "User Defined Output Plugin feature is still being implemented.");
     process->shutdown();
     return absl::UnimplementedError(

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -425,6 +425,13 @@ absl::StatusOr<ProcessPtr> ProcessImpl::CreateProcessImpl(
                                                        std::move(typed_dns_resolver_config),
                                                        process_wide));
 
+  if (options.userDefinedOutputPluginConfigs().size() > 0) {
+    ENVOY_LOG(error, "User Defined Output Plugin feature is still being implemented.");
+    process->shutdown();
+    return absl::UnimplementedError(
+        "User Defined Output Plugin feature is still being implemented.");
+  }
+
   absl::StatusOr<Bootstrap> bootstrap = createBootstrapConfiguration(
       *process->dispatcher_, *process->api_, process->options_, process->dns_resolver_factory_,
       process->typed_dns_resolver_config_, process->number_of_workers_);

--- a/test/BUILD
+++ b/test/BUILD
@@ -110,6 +110,7 @@ envoy_cc_test(
         "//test/client:utility_lib",
         "//test/test_common:environment_lib",
         "//test/test_common:proto_matchers",
+        "//test/user_defined_output/fake_plugin:fake_user_defined_output",
     ],
 )
 
@@ -155,6 +156,7 @@ envoy_cc_test(
         "//test/client:utility_lib",
         "//test/sink:test_stats_sink_config_proto_cc_proto",
         "//test/test_common:environment_lib",
+        "//test/user_defined_output/fake_plugin:fake_user_defined_output",
         "@envoy//test/test_common:network_utility_lib",
         "@envoy//test/test_common:registry_lib",
         "@envoy//test/test_common:simulated_time_system_lib",

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -71,6 +71,8 @@ public:
   MOCK_METHOD(bool, allowEnvoyDeprecatedV2Api, (), (const));
   MOCK_METHOD(absl::optional<Envoy::SystemTime>, scheduled_start, (), (const, override));
   MOCK_METHOD(absl::optional<std::string>, executionId, (), (const, override));
+  MOCK_METHOD(const std::vector<envoy::config::core::v3::TypedExtensionConfig>&,
+              userDefinedOutputPluginConfigs, (), (const, override));
 };
 
 } // namespace Client

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -1183,5 +1183,17 @@ TEST_F(OptionsImplTest, H1ConnectionReuseStrategyValuesAreConstrained) {
       MalformedArgvException, "experimental-h1-connection-reuse-strategy");
 }
 
+// TODO(nbperry): Add unit test for instantiating multiple User Defined Output Plugins once a second
+// plugin exists.
+
+TEST_F(OptionsImplTest, ThrowsMalformedArgvExceptionForInvalidTypedExtensionConfig) {
+  // Invalid configuration because it's missing a typed_config field.
+  std::string config = "{name:\"nighthawk.fake_user_defined_output\"}";
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(fmt::format("{} {} --user-defined-plugin-config {}",
+                                                 client_name_, good_test_uri_, config)),
+      MalformedArgvException, "UserDefinedPluginConfigs");
+}
+
 } // namespace Client
 } // namespace Nighthawk

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -204,6 +204,22 @@ TEST_P(ProcessTest, NoFlushWhenCancelExecutionBeforeLoadTestBegin) {
   EXPECT_EQ(numFlushes, 0);
 }
 
+TEST_P(ProcessTest, FailsIfUserDefinedOutputPluginSpecified) {
+  const std::string user_defined_output_plugin =
+      "{name:\"nighthawk.fake_user_defined_output\",typed_config:"
+      "{\"@type\":\"type.googleapis.com/nighthawk.FakeUserDefinedOutputConfig\"}}";
+  OptionsPtr options =
+      TestUtility::createOptionsImpl(fmt::format("foo --user-defined-plugin-config {} https://{}/",
+                                                 user_defined_output_plugin, loopback_address_));
+  envoy::config::core::v3::TypedExtensionConfig typed_dns_resolver_config;
+  Envoy::Network::DnsResolverFactory& dns_resolver_factory =
+      Envoy::Network::createDefaultDnsResolverFactory(typed_dns_resolver_config);
+
+  absl::StatusOr<ProcessPtr> process_or_status = ProcessImpl::CreateProcessImpl(
+      *options, dns_resolver_factory, std::move(typed_dns_resolver_config), time_system_);
+  EXPECT_EQ(process_or_status.status().code(), absl::StatusCode::kUnimplemented);
+}
+
 /**
  * Fixture for executing the Nighthawk process with simulated time.
  */

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -208,16 +208,16 @@ TEST_P(ProcessTest, FailsIfUserDefinedOutputPluginSpecified) {
   const std::string user_defined_output_plugin =
       "{name:\"nighthawk.fake_user_defined_output\",typed_config:"
       "{\"@type\":\"type.googleapis.com/nighthawk.FakeUserDefinedOutputConfig\"}}";
-  OptionsPtr options =
+  OptionsPtr options(
       TestUtility::createOptionsImpl(fmt::format("foo --user-defined-plugin-config {} https://{}/",
-                                                 user_defined_output_plugin, loopback_address_));
+                                                 user_defined_output_plugin, loopback_address_)));
   envoy::config::core::v3::TypedExtensionConfig typed_dns_resolver_config;
   Envoy::Network::DnsResolverFactory& dns_resolver_factory =
       Envoy::Network::createDefaultDnsResolverFactory(typed_dns_resolver_config);
 
-  absl::StatusOr<ProcessPtr> process_or_status = ProcessImpl::CreateProcessImpl(
+  absl::StatusOr<ProcessPtr> process = ProcessImpl::CreateProcessImpl(
       *options, dns_resolver_factory, std::move(typed_dns_resolver_config), time_system_);
-  EXPECT_EQ(process_or_status.status().code(), absl::StatusCode::kUnimplemented);
+  EXPECT_EQ(process.status().code(), absl::StatusCode::kUnimplemented);
 }
 
 /**


### PR DESCRIPTION
Adds in the scaffolding pieces of passing around user defined plugin options.

Deferring the actual use of the plugins to a later PR, in an effort to keep these PRs small/readable.

Signed-off-by: Nathan Perry <nbperry@google.com>