### PR TITLE
Update Envoy to e5ec3da (Oct 10th 2022)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,7 +47,7 @@ common --experimental_allow_tags_propagation
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
 build:linux --copt=-fPIC
 build:linux --copt=-Wno-deprecated-declarations
-build:linux --cxxopt=-std=c++17
+build:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
 build:linux --features=per_object_debug_info
@@ -109,7 +109,7 @@ build:clang-asan --linkopt --rtlib=compiler-rt
 build:clang-asan --linkopt --unwindlib=libgcc
 
 # macOS
-build:macos --cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --define tcmalloc=disabled

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -3,7 +3,7 @@
 Install VSCode and click `file->open workspace` in the menu.
 Next, open [nighthawk.code-workspace](../nighthawk.code-workspace).
 
-You can now use `shift+ctrl+p` or `shitf-command+p` (osx) to run
+You can now use `shift+ctrl+p` or `shift-command+p` (osx) to run
 various [tasks](tasks.json) associated to Nighthawk development,
 by selecting `Tasks: run task` in the dropdown:
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "3fe2e475b14d7408d35ea6c574296a3649aa1962"
-ENVOY_SHA = "e235c5655a0bf488a5fb37b181348b7963143c2ba9790f360f8b713193e7bf1b"
+ENVOY_COMMIT = "e5ec3dad31a0588227586750f77cae7d93c3cdf1"
+ENVOY_SHA = "9c2cbc4eec0a003b644ccb54a1619fe9a03b3986753ef3a14bcdf88ed03c0fa4"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in [bazel/repositories.bzl](https://github.com/envoyproxy/nighthawk/blob/main/bazel/repositories.bzl) to the latest Envoy's commit.
- Update [.bazelrc](https://github.com/envoyproxy/nighthawk/blob/main/.bazelrc) to match Envoy commit https://github.com/envoyproxy/envoy/pull/23396
- Small typo fix.

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>