### PR TITLE
Update python dependencies to new major versions

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -101,8 +101,8 @@ update these dependencies monthly. Here is an easy way to check for major depend
    virtualenv pip_update_env
    source pip_update_env/bin/activate
    ```
-   NOTE: if `pip_update_env/bin/activate` appears to not exist, try
-   `pip_update_env/local/bin/activate` instead.
+   NOTE: if `pip_update_env/bin/activate` appears to not exist, try setting
+   `export DEB_PYTHON_INSTALL_LAYOUT='deb'` and recreating the virtualenv.
 
 1. Install dependencies:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ apipkg>=3.0.1, <4.0.0
 chardet>=5.0.0, <6.0.0
 importlib_metadata>=5.0.0, <6.0.0
 more_itertools>=9.0.0, <10.0.0
+py>=1.11.0, <2.0.0
 pytest>=7.1.2, <8.0.0
 pytest-dependency>=0.5.1, <0.6.0 # versions below 1.0.0 are unstable, so we should only take in bugfixes automatically
 pytest-xdist>=3.0.2, <4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 apipkg>=3.0.1, <4.0.0
 chardet>=5.0.0, <6.0.0
 importlib_metadata>=5.0.0, <6.0.0
-more_itertools>=8.13.0, <9.0.0
+more_itertools>=9.0.0, <10.0.0
 pytest>=7.1.2, <8.0.0
 pytest-dependency>=0.5.1, <0.6.0 # versions below 1.0.0 are unstable, so we should only take in bugfixes automatically
-pytest-xdist>=2.5.0, <3.0.0
+pytest-xdist>=3.0.2, <4.0.0
 pyyaml>=6.0.0, <7.0.0
 requests>=2.28.1, <3.0.0
 six>=1.16.0, <2.0.0


### PR DESCRIPTION
Integration tests have been failing with an error that looks like:

```
2022-10-28T16:21:42.2524307Z INTERNALERROR>     from py.log import Producer
2022-10-28T16:21:42.2525457Z INTERNALERROR> ModuleNotFoundError: No module named 'py.log'; 'py' is not a package
```

Updating dependencies and adding in a dependency on `py` appears to address this failure.

Signed-off-by: Nathan Perry <nbperry@google.com>