### PR TITLE
Minor fix: Correct int size for threshold, clarify readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ experimental and may be removed or changed in the future!
 --failure-predicate <string, uint64_t>  (accepted multiple times)
 Failure predicate. Allows specifying a counter name plus threshold
 value for failing execution. Defaults to not tolerating error status
-codes and connection errors.
+codes and connection errors. Example: benchmark.http_5xx:4294967295.
 
 --termination-predicate <string, uint64_t>  (accepted multiple times)
 Termination predicate. Allows specifying a counter name plus threshold

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -693,7 +693,7 @@ void OptionsImpl::parsePredicates(const TCLAP::MultiArg<std::string>& arg,
           fmt::format("Termination predicate '{}' is badly formatted.", predicate));
     }
 
-    uint32_t threshold = 0;
+    uint64_t threshold = 0;
     if (absl::SimpleAtoi(split_predicate[1], &threshold)) {
       predicates[split_predicate[0]] = threshold;
     } else {

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -233,7 +233,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::MultiArg<std::string> failure_predicates(
       "", "failure-predicate",
       "Failure predicate. Allows specifying a counter name plus threshold value for "
-      "failing execution. Defaults to not tolerating error status codes and connection errors.",
+      "failing execution. Defaults to not tolerating error status codes and connection errors. "
+      "Example: benchmark.http_5xx:4294967295.",
       false, "string, uint64_t", cmd);
 
   std::vector<std::string> h1_connection_reuse_strategies = {"mru", "lru"};


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

In the README, proto it accepts uint64_t but we were using uint32_t for parsing -> out of range error for valid values