### PR TITLE
Log and re-throw on NigthhawkException same as on EnvoyException.

### DIFF
--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -858,7 +858,10 @@ bool ProcessImpl::run(OutputCollector& collector) {
   try {
     return runInternal(collector, tracing_uri, dns_resolver, options_.scheduled_start());
   } catch (Envoy::EnvoyException& ex) {
-    ENVOY_LOG(error, "Fatal exception: {}", ex.what());
+    ENVOY_LOG(error, "Fatal EnvoyException exception: {}", ex.what());
+    throw;
+  } catch (NighthawkException& ex) {
+    ENVOY_LOG(error, "Fatal NighthawkException exception: {}", ex.what());
     throw;
   }
 }


### PR DESCRIPTION
Our process code can throw NigthhawkException (e.g. incorrect request source config). The code currently doesn't log any information about it. This PR adds a logging statement for these cases.

Signed-off-by: Jakub Sobon <mumak@google.com>