### PR TITLE
CDS churn: Fix TLS error for connecting to upstream.

### DIFF
--- a/dynamic_config/dynamic_config_manager.py
+++ b/dynamic_config/dynamic_config_manager.py
@@ -97,11 +97,6 @@ class DynamicClusterConfigManager(DynamicConfigManager):
 
   cluster_template_string = b"""
     name: some_service
-    # Upstream TLS configuration.
-    transport_socket:
-      name: envoy.transport_sockets.tls
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
     load_assignment:
       cluster_name: some_service
       # Static endpoint assignment.


### PR DESCRIPTION
TLS is not used in any of the churn tests, and the nighthawk origin server settings aren't configured for it. Remove expectation of TLS upstream so the nighthawk origin server can be correctly contacted.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>