### PR TITLE
Upload coverage report as a pipeline artifact.

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -4,102 +4,101 @@ trigger:
     - "main"
 
 stages:
-#- stage: check
-#  dependsOn: []
-#  pool: "x64-large"
-#  jobs:
-#  - job: build_and_format
-#    displayName: "do_ci.sh"
-#    dependsOn: []
-#    strategy:
-#      maxParallel: 2
-#      matrix:
-#        build:
-#          CI_TARGET: "build"
-#        format:
-#          CI_TARGET: "check_format"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: test
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: test_and_benchmark
-#    displayName: "do_ci.sh"
-#    strategy:
-#      # Both test and benchmark need dedicated resources for stability.
-#      maxParallel: 1
-#      matrix:
-#        test:
-#          CI_TARGET: "test"
-#        benchmark:
-#          CI_TARGET: "benchmark_with_own_binaries"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: clang_tidy
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: clang_tidy
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        clang_tidy:
-#          CI_TARGET: "clang_tidy"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: test_gcc
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: test_gcc
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        test_gcc:
-#          CI_TARGET: "test_gcc"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: sanitizers
-#  dependsOn: ["test"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: sanitizers
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 2
-#      matrix:
-#        asan:
-#          CI_TARGET: "asan"
-#        tsan:
-#          CI_TARGET: "tsan"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
+- stage: check
+  dependsOn: []
+  pool: "x64-large"
+  jobs:
+  - job: build_and_format
+    displayName: "do_ci.sh"
+    dependsOn: []
+    strategy:
+      maxParallel: 2
+      matrix:
+        build:
+          CI_TARGET: "build"
+        format:
+          CI_TARGET: "check_format"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: test
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: test_and_benchmark
+    displayName: "do_ci.sh"
+    strategy:
+      # Both test and benchmark need dedicated resources for stability.
+      maxParallel: 1
+      matrix:
+        test:
+          CI_TARGET: "test"
+        benchmark:
+          CI_TARGET: "benchmark_with_own_binaries"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: clang_tidy
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: clang_tidy
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        clang_tidy:
+          CI_TARGET: "clang_tidy"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: test_gcc
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: test_gcc
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        test_gcc:
+          CI_TARGET: "test_gcc"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: sanitizers
+  dependsOn: ["test"]
+  pool: "x64-large"
+  jobs:
+  - job: sanitizers
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 2
+      matrix:
+        asan:
+          CI_TARGET: "asan"
+        tsan:
+          CI_TARGET: "tsan"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
 
 - stage: coverage
-  #dependsOn: ["test"]
-  dependsOn: []
+  dependsOn: ["test"]
   pool: "x64-large"
   jobs:
   - job: coverage
@@ -109,8 +108,8 @@ stages:
       matrix:
         coverage:
           CI_TARGET: "coverage"
-        #coverage_integration:
-        #  CI_TARGET: "coverage_integration"
+        coverage_integration:
+          CI_TARGET: "coverage_integration"
     timeoutInMinutes: 120
     steps:
     - template: bazel.yml
@@ -133,23 +132,23 @@ stages:
         targetPath: $(Build.SourcesDirectory)/coverage_html.zip
         artifactName: CoverageReport
 
-#- stage: release
-#  dependsOn:
-#  - "clang_tidy"
-#  - "test_gcc"
-#  - "sanitizers"
-#  - "coverage"
-#  condition: eq(variables['PostSubmit'], true)
-#  pool: "x64-large"
-#  jobs:
-#  - job: release
-#    displayName: "do_ci.sh"
-#    strategy:
-#      matrix:
-#        release:
-#          CI_TARGET: "docker"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
+- stage: release
+  dependsOn:
+  - "clang_tidy"
+  - "test_gcc"
+  - "sanitizers"
+  - "coverage"
+  condition: eq(variables['PostSubmit'], true)
+  pool: "x64-large"
+  jobs:
+  - job: release
+    displayName: "do_ci.sh"
+    strategy:
+      matrix:
+        release:
+          CI_TARGET: "docker"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -116,6 +116,26 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
+    - task: Bash@3
+      displayName: 'Find the zip file in Build.StagingDirectory.'
+      inputs:
+        workingDirectory: $(Build.StagingDirectory)
+        script: find . -iname \*.zip
+    - task: Bash@3
+      displayName: 'List all the files in Build.StagingDirectory'
+      inputs:
+        workingDirectory: $(Build.StagingDirectory)
+        script: find . -iname \*.zip
+    - task: Bash@3
+      displayName: 'Find the zip file in System.DefaultWorkingDirectory.'
+      inputs:
+        workingDirectory: $(System.DefaultWorkingDirectory)
+        script: find . -iname \*.zip
+    - task: Bash@3
+      displayName: 'List all the files in System.DefaultWorkingDirectory'
+      inputs:
+        workingDirectory: $(System.DefaultWorkingDirectory)
+        script: find . -iname \*.zip
     - task: PublishPipelineArtifact@1
       displayName: 'Publish the line coverage report'
       inputs:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -123,7 +123,7 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish the line coverage report'
       inputs:
-        targetPath: $(Build.StagingDirectory)/source/coverage_html.zip
+        targetPath: $(Build.StagingDirectory)/coverage_html.zip
         artifactName: CoverageReport
 
 #- stage: release

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -97,17 +97,38 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
 
-- stage: coverage
+- stage: coverage_unit
   dependsOn: ["test"]
   pool: "x64-large"
   jobs:
-  - job: coverage
+  - job: coverage_unit
     displayName: "do_ci.sh"
     strategy:
-      maxParallel: 2
+      maxParallel: 1
       matrix:
         coverage:
           CI_TARGET: "coverage"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+    - task: PublishPipelineArtifact@1
+      condition: always()
+      displayName: 'Publish the line coverage report'
+      inputs:
+        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
+        artifactName: UnitTestCoverageReport
+
+- stage: coverage_integration
+  dependsOn: ["test"]
+  pool: "x64-large"
+  jobs:
+  - job: coverage_integration
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
         coverage_integration:
           CI_TARGET: "coverage_integration"
     timeoutInMinutes: 120
@@ -120,14 +141,16 @@ stages:
       displayName: 'Publish the line coverage report'
       inputs:
         targetPath: $(Build.SourcesDirectory)/coverage_html.zip
-        artifactName: CoverageReport
+        artifactName: IntegrationTestCoverageReport
+
 
 - stage: release
   dependsOn:
   - "clang_tidy"
   - "test_gcc"
   - "sanitizers"
-  - "coverage"
+  - "coverage_unit"
+  - "coverage_integration"
   condition: eq(variables['PostSubmit'], true)
   pool: "x64-large"
   jobs:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -119,7 +119,7 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish the line coverage report'
       inputs:
-        targetPath: $(System.DefaultWorkingDirectory)/source/coverage_html.zip
+        targetPath: $(System.DefaultWorkingDirectory)/nighthawk/source/coverage_html.zip
         artifactName: CoverageReport
 
 #- stage: release

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -4,101 +4,102 @@ trigger:
     - "main"
 
 stages:
-- stage: check
-  dependsOn: []
-  pool: "x64-large"
-  jobs:
-  - job: build_and_format
-    displayName: "do_ci.sh"
-    dependsOn: []
-    strategy:
-      maxParallel: 2
-      matrix:
-        build:
-          CI_TARGET: "build"
-        format:
-          CI_TARGET: "check_format"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: test
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: test_and_benchmark
-    displayName: "do_ci.sh"
-    strategy:
-      # Both test and benchmark need dedicated resources for stability.
-      maxParallel: 1
-      matrix:
-        test:
-          CI_TARGET: "test"
-        benchmark:
-          CI_TARGET: "benchmark_with_own_binaries"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: clang_tidy
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: clang_tidy
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        clang_tidy:
-          CI_TARGET: "clang_tidy"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: test_gcc
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: test_gcc
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        test_gcc:
-          CI_TARGET: "test_gcc"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: sanitizers
-  dependsOn: ["test"]
-  pool: "x64-large"
-  jobs:
-  - job: sanitizers
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 2
-      matrix:
-        asan:
-          CI_TARGET: "asan"
-        tsan:
-          CI_TARGET: "tsan"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
+#- stage: check
+#  dependsOn: []
+#  pool: "x64-large"
+#  jobs:
+#  - job: build_and_format
+#    displayName: "do_ci.sh"
+#    dependsOn: []
+#    strategy:
+#      maxParallel: 2
+#      matrix:
+#        build:
+#          CI_TARGET: "build"
+#        format:
+#          CI_TARGET: "check_format"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: test
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: test_and_benchmark
+#    displayName: "do_ci.sh"
+#    strategy:
+#      # Both test and benchmark need dedicated resources for stability.
+#      maxParallel: 1
+#      matrix:
+#        test:
+#          CI_TARGET: "test"
+#        benchmark:
+#          CI_TARGET: "benchmark_with_own_binaries"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: clang_tidy
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: clang_tidy
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        clang_tidy:
+#          CI_TARGET: "clang_tidy"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: test_gcc
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: test_gcc
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        test_gcc:
+#          CI_TARGET: "test_gcc"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: sanitizers
+#  dependsOn: ["test"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: sanitizers
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 2
+#      matrix:
+#        asan:
+#          CI_TARGET: "asan"
+#        tsan:
+#          CI_TARGET: "tsan"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
 
 - stage: coverage
-  dependsOn: ["test"]
+  #dependsOn: ["test"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: coverage
@@ -121,23 +122,23 @@ stages:
         targetPath: $(System.DefaultWorkingDirectory)/source/coverage_html.zip
         artifactName: CoverageReport
 
-- stage: release
-  dependsOn:
-  - "clang_tidy"
-  - "test_gcc"
-  - "sanitizers"
-  - "coverage"
-  condition: eq(variables['PostSubmit'], true)
-  pool: "x64-large"
-  jobs:
-  - job: release
-    displayName: "do_ci.sh"
-    strategy:
-      matrix:
-        release:
-          CI_TARGET: "docker"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
+#- stage: release
+#  dependsOn:
+#  - "clang_tidy"
+#  - "test_gcc"
+#  - "sanitizers"
+#  - "coverage"
+#  condition: eq(variables['PostSubmit'], true)
+#  pool: "x64-large"
+#  jobs:
+#  - job: release
+#    displayName: "do_ci.sh"
+#    strategy:
+#      matrix:
+#        release:
+#          CI_TARGET: "docker"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -115,16 +115,6 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
-    - task: CmdLine@2
-      condition: always()
-      displayName: "Tree of Build.SourcesDirectory."
-      inputs:
-        script: 'ls -R $(Build.SourcesDirectory)'
-    - task: CmdLine@2
-      condition: always()
-      displayName: "Tree of Agent.WorkFolder."
-      inputs:
-        script: 'ls -R $(Agent.WorkFolder)'
     - task: PublishPipelineArtifact@1
       condition: always()
       displayName: 'Publish the line coverage report'

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -117,10 +117,12 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
     - task: CmdLine@2
+      condition: always()
       displayName: "Tree of Build.StagingDirectory."
       inputs:
         script: 'tree $(Build.StagingDirectory)'
     - task: PublishPipelineArtifact@1
+      condition: always()
       displayName: 'Publish the line coverage report'
       inputs:
         targetPath: $(Build.StagingDirectory)/coverage_html.zip

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -118,9 +118,9 @@ stages:
         ciTarget: $(CI_TARGET)
     - task: CmdLine@2
       condition: always()
-      displayName: "Tree of Build.StagingDirectory."
+      displayName: "Tree of Build.SourcesDirectory."
       inputs:
-        script: 'ls -R $(Build.StagingDirectory)'
+        script: 'ls -R $(Build.SourcesDirectory)'
     - task: CmdLine@2
       condition: always()
       displayName: "Tree of Agent.WorkFolder."
@@ -130,7 +130,7 @@ stages:
       condition: always()
       displayName: 'Publish the line coverage report'
       inputs:
-        targetPath: $(Agent.WorkFolder)/coverage_html.zip
+        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
         artifactName: CoverageReport
 
 #- stage: release

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -109,33 +109,17 @@ stages:
       matrix:
         coverage:
           CI_TARGET: "coverage"
-        coverage_integration:
-          CI_TARGET: "coverage_integration"
+        #coverage_integration:
+        #  CI_TARGET: "coverage_integration"
     timeoutInMinutes: 120
     steps:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
-    - task: Bash@3
-      displayName: 'Find the zip file in Build.StagingDirectory.'
+    - task: CmdLine@2
+      displayName: "Tree of Build.StagingDirectory."
       inputs:
-        workingDirectory: $(Build.StagingDirectory)
-        script: find . -iname \*.zip
-    - task: Bash@3
-      displayName: 'List all the files in Build.StagingDirectory'
-      inputs:
-        workingDirectory: $(Build.StagingDirectory)
-        script: find . -iname \*.zip
-    - task: Bash@3
-      displayName: 'Find the zip file in System.DefaultWorkingDirectory.'
-      inputs:
-        workingDirectory: $(System.DefaultWorkingDirectory)
-        script: find . -iname \*.zip
-    - task: Bash@3
-      displayName: 'List all the files in System.DefaultWorkingDirectory'
-      inputs:
-        workingDirectory: $(System.DefaultWorkingDirectory)
-        script: find . -iname \*.zip
+        script: 'tree $(Build.StagingDirectory)'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish the line coverage report'
       inputs:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -115,6 +115,11 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish the line coverage report'
+      inputs:
+        targetPath: $(System.DefaultWorkingDirectory)/source/coverage_html.zip
+        artifactName: CoverageReport
 
 - stage: release
   dependsOn:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -119,7 +119,7 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish the line coverage report'
       inputs:
-        targetPath: $(System.DefaultWorkingDirectory)/nighthawk/source/coverage_html.zip
+        targetPath: $(Build.StagingDirectory)/source/coverage_html.zip
         artifactName: CoverageReport
 
 #- stage: release

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -120,12 +120,17 @@ stages:
       condition: always()
       displayName: "Tree of Build.StagingDirectory."
       inputs:
-        script: 'tree $(Build.StagingDirectory)'
+        script: 'ls -R $(Build.StagingDirectory)'
+    - task: CmdLine@2
+      condition: always()
+      displayName: "Tree of Agent.WorkFolder."
+      inputs:
+        script: 'ls -R $(Agent.WorkFolder)'
     - task: PublishPipelineArtifact@1
       condition: always()
       displayName: 'Publish the line coverage report'
       inputs:
-        targetPath: $(Build.StagingDirectory)/coverage_html.zip
+        targetPath: $(Agent.WorkFolder)/coverage_html.zip
         artifactName: CoverageReport
 
 #- stage: release

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -78,8 +78,7 @@ function do_clang_tidy() {
 }
 
 function do_unit_test_coverage() {
-    #export TEST_TARGETS="//test/... -//test:python_test"
-    export TEST_TARGETS="//test:options_test"
+    export TEST_TARGETS="//test/... -//test:python_test"
     # TODO(https://github.com/envoyproxy/nighthawk/issues/747): Increase back to 93.2 when coverage flakiness address
     export COVERAGE_THRESHOLD=92
     echo "bazel coverage build with tests ${TEST_TARGETS}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -78,7 +78,8 @@ function do_clang_tidy() {
 }
 
 function do_unit_test_coverage() {
-    export TEST_TARGETS="//test/... -//test:python_test"
+    #export TEST_TARGETS="//test/... -//test:python_test"
+    export TEST_TARGETS="//test:options_test"
     # TODO(https://github.com/envoyproxy/nighthawk/issues/747): Increase back to 93.2 when coverage flakiness address
     export COVERAGE_THRESHOLD=92
     echo "bazel coverage build with tests ${TEST_TARGETS}"

--- a/test/run_nighthawk_bazel_coverage.sh
+++ b/test/run_nighthawk_bazel_coverage.sh
@@ -58,3 +58,4 @@ then
   fi
 fi
 echo "HTML coverage report is in ${COVERAGE_DIR}/index.html"
+echo "If running in Azure Pipelines, the coverage report is published as a pipeline artifact."

--- a/test/run_nighthawk_bazel_coverage.sh
+++ b/test/run_nighthawk_bazel_coverage.sh
@@ -2,7 +2,7 @@
 
 # derived from test/run_envoy_bazel_coverage.sh over the Envoy repo.
 
-set -eo pipefail
+#set -eo pipefail
 set +x
 set -u
 

--- a/test/run_nighthawk_bazel_coverage.sh
+++ b/test/run_nighthawk_bazel_coverage.sh
@@ -42,6 +42,8 @@ cp bazel-out/_coverage/_coverage_report.dat "${COVERAGE_DATA}"
 
 COVERAGE_VALUE=$(genhtml --prefix ${PWD} --output "${COVERAGE_DIR}" "${COVERAGE_DATA}" | grep lines... | cut -d ' ' -f 4)
 COVERAGE_VALUE=${COVERAGE_VALUE%?}
+echo "Zipping coverage report to ${SRCDIR}/coverage_html.zip".
+zip -r "${COVERAGE_DIR}" "${SRCDIR}/coverage_html.zip"
 
 [[ -z "${ENVOY_COVERAGE_DIR}" ]] || rsync -av "${COVERAGE_DIR}"/ "${ENVOY_COVERAGE_DIR}"
 

--- a/test/run_nighthawk_bazel_coverage.sh
+++ b/test/run_nighthawk_bazel_coverage.sh
@@ -2,7 +2,7 @@
 
 # derived from test/run_envoy_bazel_coverage.sh over the Envoy repo.
 
-#set -eo pipefail
+set -eo pipefail
 set +x
 set -u
 

--- a/test/run_nighthawk_bazel_coverage.sh
+++ b/test/run_nighthawk_bazel_coverage.sh
@@ -43,7 +43,7 @@ cp bazel-out/_coverage/_coverage_report.dat "${COVERAGE_DATA}"
 COVERAGE_VALUE=$(genhtml --prefix ${PWD} --output "${COVERAGE_DIR}" "${COVERAGE_DATA}" | grep lines... | cut -d ' ' -f 4)
 COVERAGE_VALUE=${COVERAGE_VALUE%?}
 echo "Zipping coverage report to ${SRCDIR}/coverage_html.zip".
-zip -r "${COVERAGE_DIR}" "${SRCDIR}/coverage_html.zip"
+zip -r "${SRCDIR}/coverage_html.zip" "${COVERAGE_DIR}"
 
 [[ -z "${ENVOY_COVERAGE_DIR}" ]] || rsync -av "${COVERAGE_DIR}"/ "${ENVOY_COVERAGE_DIR}"
 


### PR DESCRIPTION
The PR splits the coverage AZP stage into two, so that we can publish two artifacts with unique names.

Signed-off-by: Jakub Sobon <mumak@google.com>