### PR TITLE
update Envoy to 8a26244 (2022-11-21)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "d79d5543a785e28cfb725e235d5bc0eb8db2f200"
-ENVOY_SHA = "269895430ede3105463e66bdd45e98c4f13d6dfaaf6cd65144fdba87635e3bd7"
+ENVOY_COMMIT = "8a26244b2804a00820b2f6dd55ea69cb97bfa996"
+ENVOY_SHA = "297da30e3ec5f7fcb2ab8d8662df8f9cc217a91a9e81360c1dfa3a2440125f41"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/extensions_build_config.bzl
+++ b/extensions_build_config.bzl
@@ -20,6 +20,7 @@ DISABLED_BY_DEFAULT_EXTENSIONS = {
 EXTENSION_CONFIG_VISIBILITY = ["//visibility:public"]
 EXTENSION_PACKAGE_VISIBILITY = ["//visibility:public"]
 CONTRIB_EXTENSION_PACKAGE_VISIBILITY = ["//:contrib_library"]
+MOBILE_PACKAGE_VISIBILITY = ["//:mobile_library"]
 
 # Set this variable to true to disable alwayslink for envoy_cc_library.
 LEGACY_ALWAYSLINK = 1

--- a/extensions_build_config.bzl
+++ b/extensions_build_config.bzl
@@ -7,6 +7,7 @@ EXTENSIONS = {
     "envoy.tracers.zipkin": "//source/extensions/tracers/zipkin:config",
     "envoy.transport_sockets.raw_buffer": "//source/extensions/transport_sockets/raw_buffer:config",
     "envoy.access_loggers.file": "//source/extensions/access_loggers/file:config",
+    "envoy.clusters.eds": "//source/extensions/clusters/eds:eds_lib",
     "envoy.clusters.static": "//source/extensions/clusters/static:static_cluster_lib",
     "envoy.clusters.strict_dns": "//source/extensions/clusters/strict_dns:strict_dns_cluster_lib",
     "envoy.network.dns_resolver.cares": "//source/extensions/network/dns_resolver/cares:config",

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -133,6 +133,7 @@ envoy_cc_library(
         "@envoy//source/extensions/transport_sockets/tls:context_lib_with_external_headers",
         "@envoy//source/server:server_lib_with_external_headers",
         "@envoy//source/server/config_validation:admin_lib_with_external_headers",
+        "@envoy//envoy/common:base_includes",
         "@envoy//envoy/http:protocol_interface_with_external_headers",
         "@envoy//envoy/network:address_interface",
         "@envoy//envoy/server:instance_interface",

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -133,7 +133,6 @@ envoy_cc_library(
         "@envoy//source/extensions/transport_sockets/tls:context_lib_with_external_headers",
         "@envoy//source/server:server_lib_with_external_headers",
         "@envoy//source/server/config_validation:admin_lib_with_external_headers",
-        "@envoy//envoy/common:base_includes",
         "@envoy//envoy/http:protocol_interface_with_external_headers",
         "@envoy//envoy/network:address_interface",
         "@envoy//envoy/server:instance_interface",

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <random>
 
+#include "envoy/common/optref.h"
 #include "envoy/network/address.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/sink.h"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -108,7 +108,7 @@ public:
 // when Nighthawk is running are implemented.
 class NighthawkServerInstance : public Envoy::Server::Instance {
 public:
-  NighthawkServerInstance(Envoy::Server::Admin& admin, Envoy::Api::Api& api,
+  NighthawkServerInstance(OptRef<Envoy::Server::Admin> admin, Envoy::Api::Api& api,
                           Envoy::Event::Dispatcher& dispatcher,
                           Envoy::AccessLog::AccessLogManager& log_manager,
                           Envoy::Server::Options& options, Envoy::Runtime::Loader& runtime,
@@ -119,7 +119,7 @@ public:
         options_(options), runtime_(runtime), singleton_manager_(singleton_manager), tls_(tls),
         local_info_(local_info) {}
 
-  Envoy::Server::Admin& admin() override { return admin_; }
+  OptRef<Envoy::Server::Admin> admin() override { return admin_; }
   Envoy::Api::Api& api() override { return api_; }
   Envoy::Upstream::ClusterManager& clusterManager() override {
     PANIC("NighthawkServerInstance::clusterManager not implemented");
@@ -226,7 +226,7 @@ public:
   }
 
 private:
-  Envoy::Server::Admin& admin_;
+  OptRef<Envoy::Server::Admin> admin_;
   Envoy::Api::Api& api_;
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::AccessLog::AccessLogManager& log_manager_;
@@ -250,7 +250,7 @@ public:
 
   Envoy::LocalInfo::LocalInfo& localInfo() const override { return server_.localInfo(); }
 
-  Envoy::Server::Admin& admin() override { return server_.admin(); }
+  OptRef<Envoy::Server::Admin> admin() override { return server_.admin(); }
 
   Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
 

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -109,7 +109,7 @@ public:
 // when Nighthawk is running are implemented.
 class NighthawkServerInstance : public Envoy::Server::Instance {
 public:
-  NighthawkServerInstance(OptRef<Envoy::Server::Admin> admin, Envoy::Api::Api& api,
+  NighthawkServerInstance(Envoy::OptRef<Envoy::Server::Admin> admin, Envoy::Api::Api& api,
                           Envoy::Event::Dispatcher& dispatcher,
                           Envoy::AccessLog::AccessLogManager& log_manager,
                           Envoy::Server::Options& options, Envoy::Runtime::Loader& runtime,
@@ -120,7 +120,7 @@ public:
         options_(options), runtime_(runtime), singleton_manager_(singleton_manager), tls_(tls),
         local_info_(local_info) {}
 
-  OptRef<Envoy::Server::Admin> admin() override { return admin_; }
+  Envoy::OptRef<Envoy::Server::Admin> admin() override { return admin_; }
   Envoy::Api::Api& api() override { return api_; }
   Envoy::Upstream::ClusterManager& clusterManager() override {
     PANIC("NighthawkServerInstance::clusterManager not implemented");
@@ -227,7 +227,7 @@ public:
   }
 
 private:
-  OptRef<Envoy::Server::Admin> admin_;
+  Envoy::OptRef<Envoy::Server::Admin> admin_;
   Envoy::Api::Api& api_;
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::AccessLog::AccessLogManager& log_manager_;
@@ -251,7 +251,7 @@ public:
 
   Envoy::LocalInfo::LocalInfo& localInfo() const override { return server_.localInfo(); }
 
-  OptRef<Envoy::Server::Admin> admin() override { return server_.admin(); }
+  Envoy::OptRef<Envoy::Server::Admin> admin() override { return server_.admin(); }
 
   Envoy::Runtime::Loader& runtime() override { return server_.runtime(); }
 

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -304,6 +304,7 @@ unsorted_flags:
 # https://github.com/envoyproxy/envoy/issues/9953
 # PLEASE DO NOT ADD FILES TO THIS LIST WITHOUT SENIOR MAINTAINER APPROVAL
 visibility_excludes:
+- source/extensions/clusters/eds/
 - source/extensions/clusters/strict_dns/
 - source/extensions/clusters/static/
 - source/extensions/clusters/original_dst/


### PR DESCRIPTION
- Synced [tools/code_format/config.yaml](https://github.com/envoyproxy/nighthawk/blob/main/tools/code_format/config.yaml)
- define `MOBILE_PACKAGE_VISIBILITY = ["//:mobile_library"]` in `extensions_build_config.bzl` because of https://github.com/envoyproxy/envoy/pull/23935/
- include eds clusters extension in `extensions_build_config.bzl` because of https://github.com/envoyproxy/envoy/pull/23920/
- switch to `Envoy::OptRef<Envoy::Server::Admin>` per https://github.com/envoyproxy/envoy/pull/23903/ 

Signed-off-by: Qin Qin <qqin@google.com>