### PR TITLE
Align parameter names between .h and .cc files.

### DIFF
--- a/source/user_defined_output/log_response_headers_plugin.cc
+++ b/source/user_defined_output/log_response_headers_plugin.cc
@@ -124,9 +124,9 @@ Envoy::ProtobufTypes::MessagePtr LogResponseHeadersPluginFactory::createEmptyCon
 
 absl::StatusOr<UserDefinedOutputPluginPtr>
 LogResponseHeadersPluginFactory::createUserDefinedOutputPlugin(
-    const Envoy::ProtobufWkt::Any& message, const WorkerMetadata& worker_metadata) {
+    const Envoy::ProtobufWkt::Any& config_any, const WorkerMetadata& worker_metadata) {
   LogResponseHeadersConfig config;
-  absl::Status unpack_status = Envoy::MessageUtil::unpackToNoThrow(message, config);
+  absl::Status unpack_status = Envoy::MessageUtil::unpackToNoThrow(config_any, config);
   if (!unpack_status.ok()) {
     return unpack_status;
   }


### PR DESCRIPTION
This is a clang-tidy error.

Signed-off-by: Nathan Perry <nbperry@google.com>