### PR TITLE
Allow pipeline retries after artifacts were published.

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -4,101 +4,102 @@ trigger:
     - "main"
 
 stages:
-- stage: check
-  dependsOn: []
-  pool: "x64-large"
-  jobs:
-  - job: build_and_format
-    displayName: "do_ci.sh"
-    dependsOn: []
-    strategy:
-      maxParallel: 2
-      matrix:
-        build:
-          CI_TARGET: "build"
-        format:
-          CI_TARGET: "check_format"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: test
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: test_and_benchmark
-    displayName: "do_ci.sh"
-    strategy:
-      # Both test and benchmark need dedicated resources for stability.
-      maxParallel: 1
-      matrix:
-        test:
-          CI_TARGET: "test"
-        benchmark:
-          CI_TARGET: "benchmark_with_own_binaries"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: clang_tidy
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: clang_tidy
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        clang_tidy:
-          CI_TARGET: "clang_tidy"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: test_gcc
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: test_gcc
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        test_gcc:
-          CI_TARGET: "test_gcc"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: sanitizers
-  dependsOn: ["test"]
-  pool: "x64-large"
-  jobs:
-  - job: sanitizers
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 2
-      matrix:
-        asan:
-          CI_TARGET: "asan"
-        tsan:
-          CI_TARGET: "tsan"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
+#- stage: check
+#  dependsOn: []
+#  pool: "x64-large"
+#  jobs:
+#  - job: build_and_format
+#    displayName: "do_ci.sh"
+#    dependsOn: []
+#    strategy:
+#      maxParallel: 2
+#      matrix:
+#        build:
+#          CI_TARGET: "build"
+#        format:
+#          CI_TARGET: "check_format"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: test
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: test_and_benchmark
+#    displayName: "do_ci.sh"
+#    strategy:
+#      # Both test and benchmark need dedicated resources for stability.
+#      maxParallel: 1
+#      matrix:
+#        test:
+#          CI_TARGET: "test"
+#        benchmark:
+#          CI_TARGET: "benchmark_with_own_binaries"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: clang_tidy
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: clang_tidy
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        clang_tidy:
+#          CI_TARGET: "clang_tidy"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: test_gcc
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: test_gcc
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        test_gcc:
+#          CI_TARGET: "test_gcc"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: sanitizers
+#  dependsOn: ["test"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: sanitizers
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 2
+#      matrix:
+#        asan:
+#          CI_TARGET: "asan"
+#        tsan:
+#          CI_TARGET: "tsan"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
 
 - stage: coverage_unit
-  dependsOn: ["test"]
+  dependsOn: []
+  #dependsOn: ["test"]
   pool: "x64-large"
   jobs:
   - job: coverage_unit
@@ -120,48 +121,48 @@ stages:
         targetPath: $(Build.SourcesDirectory)/coverage_html.zip
         artifactName: UnitTestCoverageReport-$(System.JobAttempt)
 
-- stage: coverage_integration
-  dependsOn: ["test"]
-  pool: "x64-large"
-  jobs:
-  - job: coverage_integration
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        coverage_integration:
-          CI_TARGET: "coverage_integration"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-    - task: PublishPipelineArtifact@1
-      condition: always()
-      displayName: 'Publish the line coverage report'
-      inputs:
-        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
-        artifactName: IntegrationTestCoverageReport
-
-
-- stage: release
-  dependsOn:
-  - "clang_tidy"
-  - "test_gcc"
-  - "sanitizers"
-  - "coverage_unit"
-  - "coverage_integration"
-  condition: eq(variables['PostSubmit'], true)
-  pool: "x64-large"
-  jobs:
-  - job: release
-    displayName: "do_ci.sh"
-    strategy:
-      matrix:
-        release:
-          CI_TARGET: "docker"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
+#- stage: coverage_integration
+#  dependsOn: ["test"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: coverage_integration
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        coverage_integration:
+#          CI_TARGET: "coverage_integration"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#    - task: PublishPipelineArtifact@1
+#      condition: always()
+#      displayName: 'Publish the line coverage report'
+#      inputs:
+#        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
+#        artifactName: IntegrationTestCoverageReport
+#
+#
+#- stage: release
+#  dependsOn:
+#  - "clang_tidy"
+#  - "test_gcc"
+#  - "sanitizers"
+#  - "coverage_unit"
+#  - "coverage_integration"
+#  condition: eq(variables['PostSubmit'], true)
+#  pool: "x64-large"
+#  jobs:
+#  - job: release
+#    displayName: "do_ci.sh"
+#    strategy:
+#      matrix:
+#        release:
+#          CI_TARGET: "docker"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -118,7 +118,7 @@ stages:
       displayName: 'Publish the line coverage report'
       inputs:
         targetPath: $(Build.SourcesDirectory)/coverage_html.zip
-        artifactName: UnitTestCoverageReport
+        artifactName: UnitTestCoverageReport-$(System.JobAttempt)
 
 - stage: coverage_integration
   dependsOn: ["test"]

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -4,102 +4,101 @@ trigger:
     - "main"
 
 stages:
-#- stage: check
-#  dependsOn: []
-#  pool: "x64-large"
-#  jobs:
-#  - job: build_and_format
-#    displayName: "do_ci.sh"
-#    dependsOn: []
-#    strategy:
-#      maxParallel: 2
-#      matrix:
-#        build:
-#          CI_TARGET: "build"
-#        format:
-#          CI_TARGET: "check_format"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: test
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: test_and_benchmark
-#    displayName: "do_ci.sh"
-#    strategy:
-#      # Both test and benchmark need dedicated resources for stability.
-#      maxParallel: 1
-#      matrix:
-#        test:
-#          CI_TARGET: "test"
-#        benchmark:
-#          CI_TARGET: "benchmark_with_own_binaries"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: clang_tidy
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: clang_tidy
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        clang_tidy:
-#          CI_TARGET: "clang_tidy"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: test_gcc
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: test_gcc
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        test_gcc:
-#          CI_TARGET: "test_gcc"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: sanitizers
-#  dependsOn: ["test"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: sanitizers
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 2
-#      matrix:
-#        asan:
-#          CI_TARGET: "asan"
-#        tsan:
-#          CI_TARGET: "tsan"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
+- stage: check
+  dependsOn: []
+  pool: "x64-large"
+  jobs:
+  - job: build_and_format
+    displayName: "do_ci.sh"
+    dependsOn: []
+    strategy:
+      maxParallel: 2
+      matrix:
+        build:
+          CI_TARGET: "build"
+        format:
+          CI_TARGET: "check_format"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: test
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: test_and_benchmark
+    displayName: "do_ci.sh"
+    strategy:
+      # Both test and benchmark need dedicated resources for stability.
+      maxParallel: 1
+      matrix:
+        test:
+          CI_TARGET: "test"
+        benchmark:
+          CI_TARGET: "benchmark_with_own_binaries"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: clang_tidy
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: clang_tidy
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        clang_tidy:
+          CI_TARGET: "clang_tidy"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: test_gcc
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: test_gcc
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        test_gcc:
+          CI_TARGET: "test_gcc"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: sanitizers
+  dependsOn: ["test"]
+  pool: "x64-large"
+  jobs:
+  - job: sanitizers
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 2
+      matrix:
+        asan:
+          CI_TARGET: "asan"
+        tsan:
+          CI_TARGET: "tsan"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
 
 - stage: coverage_unit
-  dependsOn: []
-  #dependsOn: ["test"]
+  dependsOn: ["test"]
   pool: "x64-large"
   jobs:
   - job: coverage_unit
@@ -121,48 +120,48 @@ stages:
         targetPath: $(Build.SourcesDirectory)/coverage_html.zip
         artifactName: UnitTestCoverageReport-$(System.JobAttempt)
 
-#- stage: coverage_integration
-#  dependsOn: ["test"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: coverage_integration
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        coverage_integration:
-#          CI_TARGET: "coverage_integration"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#    - task: PublishPipelineArtifact@1
-#      condition: always()
-#      displayName: 'Publish the line coverage report'
-#      inputs:
-#        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
-#        artifactName: IntegrationTestCoverageReport
-#
-#
-#- stage: release
-#  dependsOn:
-#  - "clang_tidy"
-#  - "test_gcc"
-#  - "sanitizers"
-#  - "coverage_unit"
-#  - "coverage_integration"
-#  condition: eq(variables['PostSubmit'], true)
-#  pool: "x64-large"
-#  jobs:
-#  - job: release
-#    displayName: "do_ci.sh"
-#    strategy:
-#      matrix:
-#        release:
-#          CI_TARGET: "docker"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
+- stage: coverage_integration
+  dependsOn: ["test"]
+  pool: "x64-large"
+  jobs:
+  - job: coverage_integration
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        coverage_integration:
+          CI_TARGET: "coverage_integration"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+    - task: PublishPipelineArtifact@1
+      condition: always()
+      displayName: 'Publish the line coverage report'
+      inputs:
+        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
+        artifactName: IntegrationTestCoverageReport
+
+
+- stage: release
+  dependsOn:
+  - "clang_tidy"
+  - "test_gcc"
+  - "sanitizers"
+  - "coverage_unit"
+  - "coverage_integration"
+  condition: eq(variables['PostSubmit'], true)
+  pool: "x64-large"
+  jobs:
+  - job: release
+    displayName: "do_ci.sh"
+    strategy:
+      matrix:
+        release:
+          CI_TARGET: "docker"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -83,7 +83,7 @@ function do_unit_test_coverage() {
     export COVERAGE_THRESHOLD=92
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
-    exit 0
+    exit 1
 }
 
 function do_integration_test_coverage() {

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -83,7 +83,7 @@ function do_unit_test_coverage() {
     export COVERAGE_THRESHOLD=92
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
-    exit 1
+    exit 0
 }
 
 function do_integration_test_coverage() {


### PR DESCRIPTION
Include the `System.JobAttempt` in the artifact name to ensure unique artifact names for each retry.

Fixes #960 

Signed-off-by: Jakub Sobon <mumak@google.com>