### PR TITLE
Update Envoy to f3edd6d (Jan 10, 2023)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "d7df348816b21112922bcf7cf6efd9d26c193314"
-ENVOY_SHA = "4805baabc42c06da477e4ded20b8ac452bf006e0cb6d9da0979f23fd0bc10592"
+ENVOY_COMMIT = "f3edd6d5698cfa2609b979d8abc84947b9c833e0"
+ENVOY_SHA = "511a76d3ebce9cade40e6717c9a5f847cc6d87a7ef7524e2c33bc4b10c9c7255"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,26 @@
-# Last updated 2022-12-05
+# Last updated 2023-01-10
 apipkg==3.0.1
-chardet==5.0.0
-importlib_metadata==5.0.0
+chardet==5.1.0
+importlib_metadata==6.0.0
 more_itertools==9.0.0
 py==1.11.0
 pytest==7.2.0
 pytest-dependency==0.5.1 # versions below 1.0.0 are unstable, so we should only take in bugfixes automatically
-pytest-xdist==3.0.2
+pytest-xdist==3.1.0
 pyyaml==6.0.0
 requests==2.28.1
 six==1.16.0
-zipp==3.10.0
+zipp==3.11.0
 # TODO(935): Remove all below dependencies after using actual dependency manager if possible.
 certifi==2022.12.7
-urllib3==1.26.12
+urllib3==1.26.13
 idna==3.4
-pluggy==0.13.1
-packaging==21.3
-attrs==22.1.0
-iniconfig==1.1.1
+pluggy==1.0.0
+packaging==23
+attrs==22.2.0
+iniconfig==2.0.0
 execnet==1.9.0
 tomli==2.0.1
-pyparsing==3.0.7
-charset_normalizer==3.0.0
-exceptiongroup==1.0.0
+pyparsing==3.0.9
+charset_normalizer==2.1.1 # Don't update charset_normalizer to 3.x.x; the latest requests==2.28.1 can only use >=2 <3.
+exceptiongroup==1.1.0

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -9,8 +9,8 @@ namespace Nighthawk {
 class MockTerminationPredicate : public TerminationPredicate {
 public:
   MockTerminationPredicate();
-  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr&&), (override));
-  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr&&), (override));
+  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr &&), (override));
+  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr &&), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluateChain, (), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluate, (), (override));
 };

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -9,8 +9,8 @@ namespace Nighthawk {
 class MockTerminationPredicate : public TerminationPredicate {
 public:
   MockTerminationPredicate();
-  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr &&), (override));
-  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr &&), (override));
+  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr&&), (override));
+  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr&&), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluateChain, (), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluate, (), (override));
 };


### PR DESCRIPTION
- Manually checked:
  - `.bazelrc`
  - `.bazelversion`
  - `ci/run_envoy_docker.sh`
  - `tools/gen_compilation_database.py`
  - `tools/code_format/config.yaml`
- Updated `requirements.txt`
  - Note: During the [update procedure](https://github.com/envoyproxy/nighthawk/blob/main/MAINTAINERS.md#finding-python-dependencies), discovered that the previous `charset_normalizer==3.0.0` was actually unusable; reduced it to `charset_normalizer==2.1.1`


Signed-off-by: eric846 <56563761+eric846@users.noreply.github.com>