### PR TITLE
Remove dependency on the implicit cast of Stats::Store to Stats::Scope.

### DIFF
--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -730,7 +730,7 @@ void ProcessImpl::maybeCreateTracingDriver(const envoy::config::trace::v3::Traci
     auto zipkin_config = dynamic_cast<const envoy::config::trace::v3::ZipkinConfig&>(*message);
     Envoy::Tracing::DriverPtr zipkin_driver =
         std::make_unique<Envoy::Extensions::Tracers::Zipkin::Driver>(
-            zipkin_config, *cluster_manager_, store_root_, tls_,
+            zipkin_config, *cluster_manager_, scope_root_, tls_,
             Envoy::Runtime::LoaderSingleton::get(), *local_info_, generator_, time_system_);
     http_tracer_ =
         std::make_unique<Envoy::Tracing::TracerImpl>(std::move(zipkin_driver), *local_info_);

--- a/source/client/process_impl.h
+++ b/source/client/process_impl.h
@@ -175,6 +175,7 @@ private:
   Envoy::Stats::AllocatorImpl stats_allocator_;
   Envoy::ThreadLocal::InstanceImpl tls_;
   Envoy::Stats::ThreadLocalStoreImpl store_root_;
+  Envoy::Stats::Scope& scope_root_{*store_root_.rootScope()};
   Envoy::Quic::QuicStatNames quic_stat_names_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   Envoy::Api::ApiPtr api_;

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -190,8 +190,9 @@ public:
   // verifyBenchmarkClientProcessesExpectedInflightRequests.
   void setupBenchmarkClient(const RequestGenerator& request_generator) {
     client_ = std::make_unique<Client::BenchmarkClientHttpImpl>(
-        *api_, *dispatcher_, *store_.rootScope(), statistic_, Envoy::Http::Protocol::Http11, cluster_manager_,
-        http_tracer_, "benchmark", request_generator, /*provide_resource_backpressure*/ true,
+        *api_, *dispatcher_, *store_.rootScope(), statistic_, Envoy::Http::Protocol::Http11,
+        cluster_manager_, http_tracer_, "benchmark", request_generator,
+        /*provide_resource_backpressure*/ true,
         /*response_header_with_latency_input=*/"", std::move(user_defined_output_plugins_));
   }
 

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -190,7 +190,7 @@ public:
   // verifyBenchmarkClientProcessesExpectedInflightRequests.
   void setupBenchmarkClient(const RequestGenerator& request_generator) {
     client_ = std::make_unique<Client::BenchmarkClientHttpImpl>(
-        *api_, *dispatcher_, store_, statistic_, Envoy::Http::Protocol::Http11, cluster_manager_,
+        *api_, *dispatcher_, *store_.rootScope(), statistic_, Envoy::Http::Protocol::Http11, cluster_manager_,
         http_tracer_, "benchmark", request_generator, /*provide_resource_backpressure*/ true,
         /*response_header_with_latency_input=*/"", std::move(user_defined_output_plugins_));
   }

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -27,6 +27,7 @@ public:
 
   Envoy::Api::ApiPtr api_;
   Envoy::Stats::MockIsolatedStatsStore stats_store_;
+  Envoy::Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   Envoy::Event::MockDispatcher dispatcher_;
   MockOptions options_;
   Envoy::Tracing::HttpTracerSharedPtr http_tracer_;
@@ -47,7 +48,7 @@ TEST_F(FactoriesTest, CreateBenchmarkClient) {
   StaticRequestSourceImpl request_generator(
       std::make_unique<Envoy::Http::TestRequestHeaderMapImpl>());
   auto benchmark_client =
-      factory.create(*api_, dispatcher_, stats_store_, cluster_manager, http_tracer_, "foocluster",
+      factory.create(*api_, dispatcher_, stats_scope_, cluster_manager, http_tracer_, "foocluster",
                      /*worker_id=*/0, request_generator, {});
   EXPECT_NE(nullptr, benchmark_client.get());
 }
@@ -86,7 +87,7 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithWorkingJsonReturnsWorkingRequ
   RequestSourceFactoryImpl factory(options_, *api_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   Nighthawk::RequestSourcePtr request_source = factory.create(
-      cluster_manager, dispatcher_, *stats_store_.createScope("foo."), "requestsource");
+      cluster_manager, dispatcher_, *stats_scope_.createScope("foo."), "requestsource");
   EXPECT_NE(nullptr, request_source.get());
   Nighthawk::RequestGenerator generator = request_source->get();
   Nighthawk::RequestPtr request = generator();
@@ -126,7 +127,7 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithNonWorkingJsonThrowsError) {
   RequestSourceFactoryImpl factory(options_, *api_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   EXPECT_THROW_WITH_REGEX(
-      factory.create(cluster_manager, dispatcher_, *stats_store_.createScope("foo."),
+      factory.create(cluster_manager, dispatcher_, *stats_scope_.createScope("foo."),
                      "requestsource"),
       NighthawkException,
       "Request Source plugin loading error should have been caught during input validation");
@@ -150,7 +151,7 @@ TEST_F(FactoriesTest, CreateRequestSource) {
   RequestSourceFactoryImpl factory(options_, *api_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   RequestSourcePtr request_generator = factory.create(
-      cluster_manager, dispatcher_, *stats_store_.createScope("foo."), "requestsource");
+      cluster_manager, dispatcher_, *stats_scope_.createScope("foo."), "requestsource");
   EXPECT_NE(nullptr, request_generator.get());
 }
 
@@ -170,7 +171,7 @@ TEST_F(FactoriesTest, CreateRemoteRequestSource) {
   RequestSourceFactoryImpl factory(options_, *api_);
   Envoy::Upstream::ClusterManagerPtr cluster_manager;
   RequestSourcePtr request_generator = factory.create(
-      cluster_manager, dispatcher_, *stats_store_.createScope("foo."), "requestsource");
+      cluster_manager, dispatcher_, *stats_scope_.createScope("foo."), "requestsource");
   EXPECT_NE(nullptr, request_generator.get());
 }
 
@@ -196,7 +197,7 @@ public:
       return true;
     };
     auto sequencer = factory.create(api_->timeSource(), dispatcher_, dummy_sequencer_target,
-                                    std::make_unique<MockTerminationPredicate>(), stats_store_,
+                                    std::make_unique<MockTerminationPredicate>(), stats_scope_,
                                     time_system.monotonicTime() + 10ms);
     EXPECT_NE(nullptr, sequencer.get());
   }

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -431,7 +431,7 @@ TYPED_TEST_SUITE(SinkableStatisticTest, SinkableTypes);
 
 TYPED_TEST(SinkableStatisticTest, EmptySinkableStatistic) {
   Envoy::Stats::MockIsolatedStatsStore mock_store;
-  TypeParam stat(mock_store);
+  TypeParam stat(*mock_store.rootScope());
   EXPECT_EQ(0, stat.count());
   EXPECT_TRUE(std::isnan(stat.mean()));
   EXPECT_TRUE(std::isnan(stat.pvariance()));
@@ -448,7 +448,7 @@ TYPED_TEST(SinkableStatisticTest, EmptySinkableStatistic) {
 TYPED_TEST(SinkableStatisticTest, SimpleSinkableStatistic) {
   Envoy::Stats::MockIsolatedStatsStore mock_store;
   const int worker_id = 0;
-  TypeParam stat(mock_store, worker_id);
+  TypeParam stat(*mock_store.rootScope(), worker_id);
   const uint64_t sample_value = 123;
   const std::string stat_name = "stat_name";
 


### PR DESCRIPTION
Prepared with the help of @jmarantz, see https://github.com/envoyproxy/envoy/issues/24007.

Signed-off-by: Jakub Sobon <mumak@google.com>