### PR TITLE
Update Envoy to 328fda7 (Feb 27th 2023)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -306,7 +306,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:7304f974de2724617b7492ccb4c9c58cd420353a
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:458cb49ca2013c0ccf057d00ad1d4407920c4e52
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "1ac0a5948ca317fd418777dab2ffe27935c0a276"
-ENVOY_SHA = "fba1e38588705dfc3b8424c177687c4905fff9d77df08f9c05c4a45b1dd7b862"
+ENVOY_COMMIT = "328fda722631ecb264119ee8dbe3f9740e0baf9c"
+ENVOY_SHA = "5b73e1ba5f404639b3081acf7bd50411e5628d9e966876553a7aa5b99a741aaf"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
Updates ubuntu image and envoy_commit/envoy_sha in bazel/repositories.bzl.