### PR TITLE
Fix C++20 compliance issue for fmtlib format parameter

### DIFF
--- a/source/sink/sink_impl.cc
+++ b/source/sink/sink_impl.cc
@@ -13,7 +13,7 @@ namespace {
 absl::Status verifyCanBeUsedAsDirectoryName(absl::string_view s) {
   Envoy::Random::RandomGeneratorImpl random;
   const std::string reference_value = random.uuid();
-  const std::string err_template = "'{}' is not a guid: {}";
+  constexpr absl::string_view err_template = "'{}' is not a guid: {}";
 
   if (s.size() != reference_value.size()) {
     return absl::InvalidArgumentError(fmt::format(err_template, s, "bad string length."));


### PR DESCRIPTION
Signed-off-by: Yan Avlasov <yavlasov@google.com>