### PR TITLE
Update Envoy to 2d25a81 (Mar 6th 2023).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "328fda722631ecb264119ee8dbe3f9740e0baf9c"
-ENVOY_SHA = "5b73e1ba5f404639b3081acf7bd50411e5628d9e966876553a7aa5b99a741aaf"
+ENVOY_COMMIT = "2d25a81b3ab8577bd3bbcc035bd4f6cbbbbcb05e"
+ENVOY_SHA = "a0cfe1fd06ed156a3b880e480831184a9b5f2cb90f29637c49e997a2a493cc6f"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -84,12 +84,14 @@ if [[ -n "${ENVOY_DOCKER_PULL}" ]]; then
     time docker pull "${ENVOY_BUILD_IMAGE}"
 fi
 
+
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
 docker run --rm \
        "${ENVOY_DOCKER_OPTIONS[@]}" \
        "${VOLUMES[@]}" \
        -e AZP_BRANCH \
        -e AZP_SHA1 `# unique` \
+       -e AZP_TARGET_BRANCH \
        -e HTTP_PROXY \
        -e HTTPS_PROXY \
        -e NO_PROXY \

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -323,5 +323,6 @@ visibility_excludes:
 - source/extensions/path/match/uri_template/BUILD
 - source/extensions/path/rewrite/uri_template/BUILD
 - source/extensions/quic/connection_id_generator/BUILD
+- source/extensions/quic/server_preferred_address/BUILD
 - source/extensions/listener_managers/listener_manager/BUILD
 - source/extensions/upstreams/tcp/BUILD


### PR DESCRIPTION
Update Envoy to 2d25a81 (Mar 6th 2023).

- no changes to `.bazelrc`, `.bazelversion`, `tools/gen_compilation_database.py`
- syncing changes in `ci/run_envoy_docker.sh` and `tools/code_format/config.yaml` from the Envoy versions.