### PR TITLE
Update Envoy to 47d28ec (Mar 13, 2023)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "2d25a81b3ab8577bd3bbcc035bd4f6cbbbbcb05e"
-ENVOY_SHA = "a0cfe1fd06ed156a3b880e480831184a9b5f2cb90f29637c49e997a2a493cc6f"
+ENVOY_COMMIT = "47d28ec3ecea45486305fb850cdbd85428d90fa3"
+ENVOY_SHA = "dc13df848e920a2908afdb3ede21c731f358efe07d56714b04c0c5d4c7fd0f30"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -35,15 +35,19 @@ else
   # in useradd below, which is need for correct Python execution in the Docker
   # environment.
   ENVOY_DOCKER_OPTIONS+=(-u root:root)
-  ENVOY_DOCKER_OPTIONS+=(-v /var/run/docker.sock:/var/run/docker.sock)
-  ENVOY_DOCKER_OPTIONS+=(--cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN)
+  DOCKER_USER_ARGS=()
+  DOCKER_GROUP_ARGS=()
   DEFAULT_ENVOY_DOCKER_BUILD_DIR=/tmp/envoy-docker-build
+  if [[ -n "$ENVOY_DOCKER_IN_DOCKER" ]]; then
+      ENVOY_DOCKER_OPTIONS+=(-v /var/run/docker.sock:/var/run/docker.sock)
+      DOCKER_GID="$(stat -c %g /var/run/docker.sock 2>/dev/null || stat -f %g /var/run/docker.sock)"
+      DOCKER_USER_ARGS=(--gid "${DOCKER_GID}")
+      DOCKER_GROUP_ARGS=(--gid "${DOCKER_GID}")
+  fi
   BUILD_DIR_MOUNT_DEST=/build
   SOURCE_DIR="${PWD}"
   SOURCE_DIR_MOUNT_DEST=/source
-  DOCKER_GID="$(stat -c %g /var/run/docker.sock 2>/dev/null || stat -f %g /var/run/docker.sock)"
-  START_COMMAND=("/bin/bash" "-lc" "groupadd --gid ${DOCKER_GID} -f envoygroup \
-    && useradd -o --uid $(id -u) --gid ${DOCKER_GID} --no-create-home --home-dir /build envoybuild \
+  START_COMMAND=("/bin/bash" "-lc" "groupadd ${DOCKER_GROUP_ARGS[*]} -f envoygroup && useradd -o --uid $(id -u) ${DOCKER_USER_ARGS[*]} --no-create-home --home-dir /build envoybuild \
     && usermod -a -G pcap envoybuild \
     && chown envoybuild:envoygroup /build \
     && chown envoybuild /proc/self/fd/2 \
@@ -68,7 +72,7 @@ VOLUMES=(
     -v "${ENVOY_DOCKER_BUILD_DIR}":"${BUILD_DIR_MOUNT_DEST}"
     -v "${SOURCE_DIR}":"${SOURCE_DIR_MOUNT_DEST}")
 
-if ! is_windows; then
+if ! is_windows && [[ -n "$ENVOY_DOCKER_IN_DOCKER" ]]; then
     # Create a "shared" directory that has the same path in/outside the container
     # This allows the host docker engine to see artefacts using a temporary path created inside the container,
     # at the same path.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
-# Last updated 2023-02-13
+# Last updated 2023-03-14
 apipkg==3.0.1
 chardet==5.1.0
 importlib_metadata==6.0.0
-more_itertools==9.0.0
+more_itertools==9.1.0
 py==1.11.0
-pytest==7.2.1
+pytest==7.2.2
 pytest-dependency==0.5.1 # versions below 1.0.0 are unstable, so we should only take in bugfixes automatically
-pytest-xdist==3.2.0
+pytest-xdist==3.2.1
 pyyaml==6.0.0
 requests==2.28.2
 six==1.16.0
-zipp==3.13.0
+zipp==3.15.0
 # TODO(935): Remove all below dependencies after using actual dependency manager if possible.
 certifi==2022.12.7
-urllib3==1.26.14
+urllib3==1.26.15
 idna==3.4
 pluggy==1.0.0
 packaging==23
@@ -23,4 +23,4 @@ execnet==1.9.0
 tomli==2.0.1
 pyparsing==3.0.9
 charset_normalizer==2.1.1 # Don't update charset_normalizer to 3.x.x; the latest requests==2.28.1 can only use >=2 <3.
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -9,8 +9,8 @@ namespace Nighthawk {
 class MockTerminationPredicate : public TerminationPredicate {
 public:
   MockTerminationPredicate();
-  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr&&), (override));
-  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr&&), (override));
+  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr &&), (override));
+  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr &&), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluateChain, (), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluate, (), (override));
 };

--- a/test/mocks/common/mock_termination_predicate.h
+++ b/test/mocks/common/mock_termination_predicate.h
@@ -9,8 +9,8 @@ namespace Nighthawk {
 class MockTerminationPredicate : public TerminationPredicate {
 public:
   MockTerminationPredicate();
-  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr &&), (override));
-  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr &&), (override));
+  MOCK_METHOD(TerminationPredicate&, link, (TerminationPredicatePtr&&), (override));
+  MOCK_METHOD(TerminationPredicate&, appendToChain, (TerminationPredicatePtr&&), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluateChain, (), (override));
   MOCK_METHOD(TerminationPredicate::Status, evaluate, (), (override));
 };


### PR DESCRIPTION
- Imported updates from Envoy's `run_envoy_docker.sh`: https://github.com/envoyproxy/envoy/commit/c62437836b2dd6937c49196928051ae59fc7538e
- Refreshed `requirements.txt`
- No updates in Envoy's:
  -  `.bazelrc`
  - `.bazelversion`
  - `tools/gen_compilation_database.py`
  - `tools/code_format/config.yaml`