### PR TITLE
Copy built binaries to a directory when running in Docker.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -66,7 +66,14 @@ function run_on_build_parts() {
 function maybe_copy_binaries_to_directory () {
     if [ -n "${BUILD_DIR}" ]; then
       echo "Copying built binaries to ${BUILD_DIR}."
-      cp -vf bazel-bin/* ${BUILD_DIR}
+      for BINARY_NAME in \
+        "nighthawk_adaptive_load_client" \
+        "nighthawk_client" \
+        "nighthawk_output_transform" \
+        "nighthawk_service" \
+        "nighthawk_test_server"; do
+        cp -vf bazel-bin/${BINARY_NAME} ${BUILD_DIR}
+      done
     fi
 }
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -19,7 +19,7 @@ export CLANG_FORMAT=clang-format
 export NIGHTHAWK_BUILD_ARCH=$(uname -m)
 export BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:=""}
 # The directory to copy built binaries to.
-export BUILD_DIR="/tmp/bins"
+export BUILD_DIR=""
 
 # We build in steps to avoid running out of memory in CI.
 # This list doesn't have to be complete, execution of bazel test will build any


### PR DESCRIPTION
Allows for extraction of binaries built when running inside a Docker container. The `BUILD_DIR` will be mounted to a directory on the host.

Also removes an extra space in the script's help output.