### PR TITLE
Use RBE when Building Nighthawk.

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -3,6 +3,11 @@ parameters:
   displayName: "CI target"
   type: string
   default: build
+- name: rbe
+  # If set to true, build is performed using the RBE service.
+  displayName: "Enable RBE"
+  type: boolean
+  default: true
 
 steps:
 - bash: |
@@ -14,6 +19,7 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)
   displayName: "Run the CI script"
   env:
+    ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
     BAZEL_REMOTE_CACHE: $(LocalBuildCache)
     AZP_BRANCH: $(Build.SourceBranch)
     AZP_SHA1: $(Build.SourceVersion)
@@ -21,6 +27,19 @@ steps:
     DOCKERHUB_PASSWORD: $(DockerPassword)
     # Ideally this is only enabled when actually required.
     ENVOY_DOCKER_IN_DOCKER: 1
+    ${{ if parameters.rbe }}:
+      GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
+      ENVOY_RBE: "1"
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs) ${{ parameters.bazelBuildExtraOptions }}"
+      BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+      BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+    ${{ if eq(parameters.rbe, false) }}:
+      BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
+      BAZEL_REMOTE_CACHE: $(LocalBuildCache)
+      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        BAZEL_REMOTE_INSTANCE: "instances/$(System.PullRequest.TargetBranch)"
+      ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+        BAZEL_REMOTE_INSTANCE: "instances/$(Build.SourceBranchName)"
 
 - bash: |
     echo "disk space at end of build:"

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -3,6 +3,11 @@ parameters:
   displayName: "CI target"
   type: string
   default: build
+- name: bazelBuildExtraOptions
+  # Additional options to pass to Bazel while building.
+  displayName: "Bazel extra build options"
+  type: string
+  default: ""
 - name: rbe
   # If set to true, build is performed using the RBE service.
   displayName: "Enable RBE"
@@ -20,7 +25,6 @@ steps:
   displayName: "Run the CI script"
   env:
     ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
-    BAZEL_REMOTE_CACHE: $(LocalBuildCache)
     AZP_BRANCH: $(Build.SourceBranch)
     AZP_SHA1: $(Build.SourceVersion)
     DOCKERHUB_USERNAME: $(DockerUsername)

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -39,7 +39,6 @@ steps:
       BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
-      BAZEL_REMOTE_CACHE: $(LocalBuildCache)
 
 - bash: |
     echo "disk space at end of build:"

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -12,7 +12,7 @@ parameters:
   # If set to true, build is performed using the RBE service.
   displayName: "Enable RBE"
   type: boolean
-  default: true
+  default: false
 
 steps:
 - bash: |
@@ -40,10 +40,6 @@ steps:
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
       BAZEL_REMOTE_CACHE: $(LocalBuildCache)
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        BAZEL_REMOTE_INSTANCE: "instances/$(System.PullRequest.TargetBranch)"
-      ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        BAZEL_REMOTE_INSTANCE: "instances/$(Build.SourceBranchName)"
 
 - bash: |
     echo "disk space at end of build:"

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -6,9 +6,8 @@ trigger:
 stages:
 - stage: check
   dependsOn: []
-  pool: "x64-large"
-  #pool:
-  #  vmImage: "ubuntu-20.04"
+  pool:
+    vmImage: "ubuntu-20.04"
   jobs:
   - job: build_and_format
     displayName: "do_ci.sh"
@@ -145,7 +144,6 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
-        rbe: false
     - task: PublishPipelineArtifact@1
       condition: always()
       displayName: 'Publish the line coverage report'

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -6,18 +6,19 @@ trigger:
 stages:
 - stage: check
   dependsOn: []
-  pool: "x64-large"
+  pool:
+    vmImage: "ubuntu-20.04"
   jobs:
   - job: build_and_format
     displayName: "do_ci.sh"
     dependsOn: []
     strategy:
-      maxParallel: 2
+      maxParallel: 1
       matrix:
         build:
           CI_TARGET: "build"
-        format:
-          CI_TARGET: "check_format"
+        #format:
+        #  CI_TARGET: "check_format"
     timeoutInMinutes: 120
     steps:
     - template: bazel.yml

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -48,25 +48,6 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
 
-- stage: benchmark
-  #dependsOn: ["check"]
-  dependsOn: []
-  pool: "x64-large"
-  jobs:
-  - job: benchmark
-    displayName: "do_ci.sh"
-    strategy:
-      # Both test and benchmark need dedicated resources for stability.
-      maxParallel: 1
-      matrix:
-        benchmark:
-          CI_TARGET: "benchmark_with_own_binaries"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
 - stage: clang_tidy
   #dependsOn: ["check"]
   dependsOn: []

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -28,6 +28,7 @@ stages:
 
 - stage: test
   #dependsOn: ["check"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: test
@@ -45,6 +46,7 @@ stages:
 
 - stage: benchmark
   #dependsOn: ["check"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: benchmark
@@ -64,6 +66,7 @@ stages:
 
 - stage: clang_tidy
   #dependsOn: ["check"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: clang_tidy
@@ -82,6 +85,7 @@ stages:
 
 - stage: test_gcc
   #dependsOn: ["check"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: test_gcc
@@ -99,6 +103,7 @@ stages:
 
 - stage: sanitizers
   #dependsOn: ["test"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: sanitizers
@@ -118,6 +123,7 @@ stages:
 
 - stage: coverage_unit
   #dependsOn: ["test"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: coverage_unit
@@ -142,6 +148,7 @@ stages:
 
 - stage: coverage_integration
   #dependsOn: ["test"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: coverage_integration

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -6,14 +6,15 @@ trigger:
 stages:
 - stage: check
   dependsOn: []
-  pool:
-    vmImage: "ubuntu-20.04"
+  pool: "x64-large"
+  #pool:
+  #  vmImage: "ubuntu-20.04"
   jobs:
   - job: build_and_format
     displayName: "do_ci.sh"
     dependsOn: []
     strategy:
-      maxParallel: 1
+      maxParallel: 2
       matrix:
         build:
           CI_TARGET: "build"

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -9,14 +9,31 @@ stages:
   pool:
     vmImage: "ubuntu-20.04"
   jobs:
-  - job: build_and_format
+  - job: build
     displayName: "do_ci.sh"
     dependsOn: []
     strategy:
-      maxParallel: 2
+      maxParallel: 1
       matrix:
         build:
           CI_TARGET: "build"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+        rbe: true
+
+- stage: format
+  dependsOn: []
+  pool: "x64-large"
+  jobs:
+  - job: format
+    displayName: "do_ci.sh"
+    dependsOn: []
+    strategy:
+      maxParallel: 1
+      matrix:
         format:
           CI_TARGET: "check_format"
     timeoutInMinutes: 120
@@ -24,7 +41,6 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
-        rbe: true
 
 - stage: test
   #dependsOn: ["check"]

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -27,17 +27,32 @@ stages:
         ciTarget: $(CI_TARGET)
 
 - stage: test
-  dependsOn: ["check"]
+  #dependsOn: ["check"]
   pool: "x64-large"
   jobs:
-  - job: test_and_benchmark
+  - job: test
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        test:
+          CI_TARGET: "test"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: benchmark
+  #dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: benchmark
     displayName: "do_ci.sh"
     strategy:
       # Both test and benchmark need dedicated resources for stability.
       maxParallel: 1
       matrix:
-        test:
-          CI_TARGET: "test"
         benchmark:
           CI_TARGET: "benchmark_with_own_binaries"
     timeoutInMinutes: 120
@@ -45,9 +60,10 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
+        rbe: false
 
 - stage: clang_tidy
-  dependsOn: ["check"]
+  #dependsOn: ["check"]
   pool: "x64-large"
   jobs:
   - job: clang_tidy
@@ -62,9 +78,10 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
+        rbe: false
 
 - stage: test_gcc
-  dependsOn: ["check"]
+  #dependsOn: ["check"]
   pool: "x64-large"
   jobs:
   - job: test_gcc
@@ -81,7 +98,7 @@ stages:
         ciTarget: $(CI_TARGET)
 
 - stage: sanitizers
-  dependsOn: ["test"]
+  #dependsOn: ["test"]
   pool: "x64-large"
   jobs:
   - job: sanitizers
@@ -100,7 +117,7 @@ stages:
         ciTarget: $(CI_TARGET)
 
 - stage: coverage_unit
-  dependsOn: ["test"]
+  #dependsOn: ["test"]
   pool: "x64-large"
   jobs:
   - job: coverage_unit
@@ -124,7 +141,7 @@ stages:
         artifactName: UnitTestCoverageReport-$(System.JobAttempt)
 
 - stage: coverage_integration
-  dependsOn: ["test"]
+  #dependsOn: ["test"]
   pool: "x64-large"
   jobs:
   - job: coverage_integration

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -25,6 +25,7 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
+        rbe: true
 
 #- stage: test
 #  dependsOn: ["check"]

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -18,153 +18,154 @@ stages:
       matrix:
         build:
           CI_TARGET: "build"
-        #format:
-        #  CI_TARGET: "check_format"
+        format:
+          CI_TARGET: "check_format"
     timeoutInMinutes: 120
     steps:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
-        rbe: true
 
-#- stage: test
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: test_and_benchmark
-#    displayName: "do_ci.sh"
-#    strategy:
-#      # Both test and benchmark need dedicated resources for stability.
-#      maxParallel: 1
-#      matrix:
-#        test:
-#          CI_TARGET: "test"
-#        benchmark:
-#          CI_TARGET: "benchmark_with_own_binaries"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: clang_tidy
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: clang_tidy
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        clang_tidy:
-#          CI_TARGET: "clang_tidy"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: test_gcc
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: test_gcc
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        test_gcc:
-#          CI_TARGET: "test_gcc"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: sanitizers
-#  dependsOn: ["test"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: sanitizers
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 2
-#      matrix:
-#        asan:
-#          CI_TARGET: "asan"
-#        tsan:
-#          CI_TARGET: "tsan"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: coverage_unit
-#  dependsOn: ["test"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: coverage_unit
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        coverage:
-#          CI_TARGET: "coverage"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#    - task: PublishPipelineArtifact@1
-#      condition: always()
-#      displayName: 'Publish the line coverage report'
-#      inputs:
-#        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
-#        artifactName: UnitTestCoverageReport-$(System.JobAttempt)
-#
-#- stage: coverage_integration
-#  dependsOn: ["test"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: coverage_integration
-#    displayName: "do_ci.sh"
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        coverage_integration:
-#          CI_TARGET: "coverage_integration"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#    - task: PublishPipelineArtifact@1
-#      condition: always()
-#      displayName: 'Publish the line coverage report'
-#      inputs:
-#        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
-#        artifactName: IntegrationTestCoverageReport
-#
-#
-#- stage: release
-#  dependsOn:
-#  - "clang_tidy"
-#  - "test_gcc"
-#  - "sanitizers"
-#  - "coverage_unit"
-#  - "coverage_integration"
-#  condition: eq(variables['PostSubmit'], true)
-#  pool: "x64-large"
-#  jobs:
-#  - job: release
-#    displayName: "do_ci.sh"
-#    strategy:
-#      matrix:
-#        release:
-#          CI_TARGET: "docker"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
+- stage: test
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: test_and_benchmark
+    displayName: "do_ci.sh"
+    strategy:
+      # Both test and benchmark need dedicated resources for stability.
+      maxParallel: 1
+      matrix:
+        test:
+          CI_TARGET: "test"
+        benchmark:
+          CI_TARGET: "benchmark_with_own_binaries"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: clang_tidy
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: clang_tidy
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        clang_tidy:
+          CI_TARGET: "clang_tidy"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: test_gcc
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: test_gcc
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        test_gcc:
+          CI_TARGET: "test_gcc"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: sanitizers
+  dependsOn: ["test"]
+  pool: "x64-large"
+  jobs:
+  - job: sanitizers
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 2
+      matrix:
+        asan:
+          CI_TARGET: "asan"
+        tsan:
+          CI_TARGET: "tsan"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: coverage_unit
+  dependsOn: ["test"]
+  pool: "x64-large"
+  jobs:
+  - job: coverage_unit
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        coverage:
+          CI_TARGET: "coverage"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+        rbe: false
+    - task: PublishPipelineArtifact@1
+      condition: always()
+      displayName: 'Publish the line coverage report'
+      inputs:
+        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
+        artifactName: UnitTestCoverageReport-$(System.JobAttempt)
+
+- stage: coverage_integration
+  dependsOn: ["test"]
+  pool: "x64-large"
+  jobs:
+  - job: coverage_integration
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        coverage_integration:
+          CI_TARGET: "coverage_integration"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+        rbe: false
+    - task: PublishPipelineArtifact@1
+      condition: always()
+      displayName: 'Publish the line coverage report'
+      inputs:
+        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
+        artifactName: IntegrationTestCoverageReport
+
+
+- stage: release
+  dependsOn:
+  - "clang_tidy"
+  - "test_gcc"
+  - "sanitizers"
+  - "coverage_unit"
+  - "coverage_integration"
+  condition: eq(variables['PostSubmit'], true)
+  pool: "x64-large"
+  jobs:
+  - job: release
+    displayName: "do_ci.sh"
+    strategy:
+      matrix:
+        release:
+          CI_TARGET: "docker"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -25,19 +25,23 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
+        rbe: true
 
 - stage: test
   #dependsOn: ["check"]
   dependsOn: []
   pool: "x64-large"
   jobs:
-  - job: test
+  - job: test_and_benchmark
     displayName: "do_ci.sh"
     strategy:
+      # Both test and benchmark need dedicated resources for stability.
       maxParallel: 1
       matrix:
         test:
           CI_TARGET: "test"
+        benchmark:
+          CI_TARGET: "benchmark_with_own_binaries"
     timeoutInMinutes: 120
     steps:
     - template: bazel.yml
@@ -62,7 +66,6 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
-        rbe: false
 
 - stage: clang_tidy
   #dependsOn: ["check"]
@@ -81,7 +84,6 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
-        rbe: false
 
 - stage: test_gcc
   #dependsOn: ["check"]
@@ -138,7 +140,6 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
-        rbe: false
     - task: PublishPipelineArtifact@1
       condition: always()
       displayName: 'Publish the line coverage report'
@@ -170,7 +171,6 @@ stages:
       inputs:
         targetPath: $(Build.SourcesDirectory)/coverage_html.zip
         artifactName: IntegrationTestCoverageReport
-
 
 - stage: release
   dependsOn:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -24,144 +24,144 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
 
-- stage: test
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: test_and_benchmark
-    displayName: "do_ci.sh"
-    strategy:
-      # Both test and benchmark need dedicated resources for stability.
-      maxParallel: 1
-      matrix:
-        test:
-          CI_TARGET: "test"
-        benchmark:
-          CI_TARGET: "benchmark_with_own_binaries"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: clang_tidy
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: clang_tidy
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        clang_tidy:
-          CI_TARGET: "clang_tidy"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: test_gcc
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: test_gcc
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        test_gcc:
-          CI_TARGET: "test_gcc"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: sanitizers
-  dependsOn: ["test"]
-  pool: "x64-large"
-  jobs:
-  - job: sanitizers
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 2
-      matrix:
-        asan:
-          CI_TARGET: "asan"
-        tsan:
-          CI_TARGET: "tsan"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: coverage_unit
-  dependsOn: ["test"]
-  pool: "x64-large"
-  jobs:
-  - job: coverage_unit
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        coverage:
-          CI_TARGET: "coverage"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-    - task: PublishPipelineArtifact@1
-      condition: always()
-      displayName: 'Publish the line coverage report'
-      inputs:
-        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
-        artifactName: UnitTestCoverageReport-$(System.JobAttempt)
-
-- stage: coverage_integration
-  dependsOn: ["test"]
-  pool: "x64-large"
-  jobs:
-  - job: coverage_integration
-    displayName: "do_ci.sh"
-    strategy:
-      maxParallel: 1
-      matrix:
-        coverage_integration:
-          CI_TARGET: "coverage_integration"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-    - task: PublishPipelineArtifact@1
-      condition: always()
-      displayName: 'Publish the line coverage report'
-      inputs:
-        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
-        artifactName: IntegrationTestCoverageReport
-
-
-- stage: release
-  dependsOn:
-  - "clang_tidy"
-  - "test_gcc"
-  - "sanitizers"
-  - "coverage_unit"
-  - "coverage_integration"
-  condition: eq(variables['PostSubmit'], true)
-  pool: "x64-large"
-  jobs:
-  - job: release
-    displayName: "do_ci.sh"
-    strategy:
-      matrix:
-        release:
-          CI_TARGET: "docker"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
+#- stage: test
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: test_and_benchmark
+#    displayName: "do_ci.sh"
+#    strategy:
+#      # Both test and benchmark need dedicated resources for stability.
+#      maxParallel: 1
+#      matrix:
+#        test:
+#          CI_TARGET: "test"
+#        benchmark:
+#          CI_TARGET: "benchmark_with_own_binaries"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: clang_tidy
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: clang_tidy
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        clang_tidy:
+#          CI_TARGET: "clang_tidy"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: test_gcc
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: test_gcc
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        test_gcc:
+#          CI_TARGET: "test_gcc"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: sanitizers
+#  dependsOn: ["test"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: sanitizers
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 2
+#      matrix:
+#        asan:
+#          CI_TARGET: "asan"
+#        tsan:
+#          CI_TARGET: "tsan"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: coverage_unit
+#  dependsOn: ["test"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: coverage_unit
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        coverage:
+#          CI_TARGET: "coverage"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#    - task: PublishPipelineArtifact@1
+#      condition: always()
+#      displayName: 'Publish the line coverage report'
+#      inputs:
+#        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
+#        artifactName: UnitTestCoverageReport-$(System.JobAttempt)
+#
+#- stage: coverage_integration
+#  dependsOn: ["test"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: coverage_integration
+#    displayName: "do_ci.sh"
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        coverage_integration:
+#          CI_TARGET: "coverage_integration"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#    - task: PublishPipelineArtifact@1
+#      condition: always()
+#      displayName: 'Publish the line coverage report'
+#      inputs:
+#        targetPath: $(Build.SourcesDirectory)/coverage_html.zip
+#        artifactName: IntegrationTestCoverageReport
+#
+#
+#- stage: release
+#  dependsOn:
+#  - "clang_tidy"
+#  - "test_gcc"
+#  - "sanitizers"
+#  - "coverage_unit"
+#  - "coverage_integration"
+#  condition: eq(variables['PostSubmit'], true)
+#  pool: "x64-large"
+#  jobs:
+#  - job: release
+#    displayName: "do_ci.sh"
+#    strategy:
+#      matrix:
+#        release:
+#          CI_TARGET: "docker"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -77,6 +77,9 @@ important maintenance task. When performing the update, follow this procedure:
    [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/tools/code_format/config.yaml) to
    update our format checker configuration. Be sure to retain our local modifications,
    all lines that are unique to Nighthawk are marked with comment `# unique`.
+1. Sync (copy) [ci/setup_cache.sh](ci/setup_cache.sh) from
+   [Envoy's version](https://github.com/envoyproxy/envoy/blob/main/ci/setup_cache.sh) to
+   update our RBE configuration.
 1. If [requirements.txt](requirements.txt) has not been updated in the last 30 days (based on comment at top
    of file), check for major dependency updates. See
    [Finding python dependencies](#finding-python-dependencies) below for instructions.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -52,9 +52,8 @@ BUILD_PARTS=(
 #   0 on success, exits with return code 1 on failure.
 #######################################
 function run_on_build_parts() {
-    local command="$1"
+    local command="$@"
     for part in ${BUILD_PARTS[@]}; do
-        echo "run_on_build_parts: running command $command $part"
         eval "$command $part"
         if (( $? != 0 )); then
             echo "Error executing $command $part."
@@ -162,7 +161,7 @@ function setup_gcc_toolchain() {
       echo "local $CC/$CXX toolchain configured"
     else
       BAZEL_BUILD_OPTIONS+=("--config=remote-gcc")
-      echo "remote $CC/$CXX toolchain configured"
+      echo "remote-gcc toolchain configured"
     fi
 
     echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS[@]}"
@@ -185,7 +184,7 @@ function setup_clang_toolchain() {
         echo "remote libc++ toolchain configured"
       else
         BAZEL_BUILD_OPTIONS+=("--config=remote-clang")
-        echo "remote $CC/$CXX toolchain configured"
+        echo "remote-clang toolchain configured"
       fi
     fi
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -284,7 +284,7 @@ fi
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"
 export BAZEL_BUILD_OPTIONS=" \
 --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
-${BAZEL_BUILD_EXTRA_OPTIONS}
+${BAZEL_BUILD_EXTRA_OPTIONS}"
 #--experimental_local_memory_estimate \
 #--experimental_generate_json_trace_profile ${BAZEL_BUILD_EXTRA_OPTIONS}"
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -284,8 +284,9 @@ fi
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"
 export BAZEL_BUILD_OPTIONS=" \
 --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
---experimental_local_memory_estimate \
---experimental_generate_json_trace_profile ${BAZEL_BUILD_EXTRA_OPTIONS}"
+${BAZEL_BUILD_EXTRA_OPTIONS}
+#--experimental_local_memory_estimate \
+#--experimental_generate_json_trace_profile ${BAZEL_BUILD_EXTRA_OPTIONS}"
 
 echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -21,6 +21,8 @@ export ENVOY_RBE=${ENVOY_RBE:=""}
 # The directory to copy built binaries to.
 export BUILD_DIR=""
 
+BAZEL_BUILD_EXTRA_OPTIONS="--config=remote-ci --jobs=33"
+
 read -ra BAZEL_BUILD_EXTRA_OPTIONS <<< "${BAZEL_BUILD_EXTRA_OPTIONS:-}"
 read -ra BAZEL_EXTRA_TEST_OPTIONS <<< "${BAZEL_EXTRA_TEST_OPTIONS:-}"
 read -ra BAZEL_OPTIONS <<< "${BAZEL_OPTIONS:-}"
@@ -162,8 +164,8 @@ function setup_gcc_toolchain() {
       export CC=gcc
       export CXX=g++
       export BAZEL_COMPILER=gcc
-      [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=("--copt -march=armv8-a+crypto")
-      [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_TEST_OPTIONS+=("--copt -march=armv8-a+crypto")
+      [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=("--copt" "-march=armv8-a+crypto")
+      [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_TEST_OPTIONS+=("--copt" "-march=armv8-a+crypto")
       echo "local $CC/$CXX toolchain configured"
     else
       BAZEL_BUILD_OPTIONS+=("--config=remote-gcc")
@@ -195,7 +197,6 @@ function setup_clang_toolchain() {
     fi
 
     echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS[@]}"
-    #exit 1
 }
 
 function run_bazel() {
@@ -309,10 +310,6 @@ if grep 'docker\|lxc' /proc/1/cgroup; then
     export TEST_TMPDIR=/build/tmp
     export BAZEL="bazel"
 fi
-
-#if [ -n "${BAZEL_REMOTE_CACHE}" ]; then
-#  export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} --remote_cache=${BAZEL_REMOTE_CACHE}"
-#fi
 
 export BAZEL_EXTRA_TEST_OPTIONS+=("--test_env=ENVOY_IP_TEST_VERSIONS=v4only")
 export BAZEL_BUILD_OPTIONS=(

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -156,7 +156,6 @@ function setup_gcc_toolchain() {
     [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS="$BAZEL_BUILD_OPTIONS --copt -march=armv8-a+crypto"
     [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_TEST_OPTIONS="$BAZEL_TEST_OPTIONS --copt -march=armv8-a+crypto"
     echo "$CC/$CXX toolchain configured"
-    BAZEL_BUILD_OPTIONS+=("--config=gcc")
 
     echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS[@]}"
 }
@@ -172,7 +171,7 @@ function setup_clang_toolchain() {
     else
       if [[ "${ENVOY_STDLIB}" == "libc++" ]]; then
         BAZEL_BUILD_OPTIONS+=("--config=remote-clang-libc++")
-        echo "remote libc++ toolchain configured"
+        echo "remote-clang-libc++ toolchain configured"
       else
         BAZEL_BUILD_OPTIONS+=("--config=remote-clang")
         echo "remote-clang toolchain configured"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -21,6 +21,10 @@ export BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:=""}
 # The directory to copy built binaries to.
 export BUILD_DIR=""
 
+if [[ -z "$NO_BUILD_SETUP" ]]; then
+    . "$(dirname "$0")"/setup_cache.sh
+fi
+
 # We build in steps to avoid running out of memory in CI.
 # This list doesn't have to be complete, execution of bazel test will build any
 # remaining targets.
@@ -272,9 +276,9 @@ if grep 'docker\|lxc' /proc/1/cgroup; then
     export BAZEL="bazel"
 fi
 
-if [ -n "${BAZEL_REMOTE_CACHE}" ]; then
-  export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} --remote_cache=${BAZEL_REMOTE_CACHE}"
-fi
+#if [ -n "${BAZEL_REMOTE_CACHE}" ]; then
+#  export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} --remote_cache=${BAZEL_REMOTE_CACHE}"
+#fi
 
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"
 export BAZEL_BUILD_OPTIONS=" \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -167,6 +167,8 @@ function setup_gcc_toolchain() {
       BAZEL_BUILD_OPTIONS+=("--config=remote-gcc")
       echo "remote $CC/$CXX toolchain configured"
     fi
+
+    echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
 }
 
 function setup_clang_toolchain() {
@@ -189,7 +191,8 @@ function setup_clang_toolchain() {
         echo "remote $CC/$CXX toolchain configured"
       fi
     fi
-    echo "clang toolchain with ${ENVOY_STDLIB} configured"
+
+    echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
 }
 
 function run_bazel() {
@@ -312,8 +315,6 @@ export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZE
 export BAZEL_BUILD_OPTIONS=" \
 --verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
 --experimental_generate_json_trace_profile ${BAZEL_BUILD_EXTRA_OPTIONS}"
-
-echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS}"
 
 export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
 --test_env=UBSAN_OPTIONS=print_stacktrace=1 \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -150,34 +150,25 @@ function do_integration_test_coverage() {
 }
 
 function setup_gcc_toolchain() {
+    export CC=gcc
+    export CXX=g++
+    export BAZEL_COMPILER=gcc
+    [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS="$BAZEL_BUILD_OPTIONS --copt -march=armv8-a+crypto"
+    [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_TEST_OPTIONS="$BAZEL_TEST_OPTIONS --copt -march=armv8-a+crypto"
+    echo "$CC/$CXX toolchain configured"
     BAZEL_BUILD_OPTIONS+=("--config=gcc")
-
-    if [[ -z "${ENVOY_RBE}" ]]; then
-      export CC=gcc
-      export CXX=g++
-      export BAZEL_COMPILER=gcc
-      [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=("--copt" "-march=armv8-a+crypto")
-      [[ "${NIGHTHAWK_BUILD_ARCH}" == "aarch64" ]] && BAZEL_TEST_OPTIONS+=("--copt" "-march=armv8-a+crypto")
-      echo "local $CC/$CXX toolchain configured"
-    else
-      BAZEL_BUILD_OPTIONS+=("--config=remote-gcc")
-      echo "remote-gcc toolchain configured"
-    fi
 
     echo "Running with ${NUM_CPUS} cpus and BAZEL_BUILD_OPTIONS: ${BAZEL_BUILD_OPTIONS[@]}"
 }
 
 function setup_clang_toolchain() {
-    export PATH=/opt/llvm/bin:$PATH
-    ENVOY_STDLIB="${ENVOY_STDLIB:-libc++}"
     if [[ -z "${ENVOY_RBE}" ]]; then
-      if [[ "${ENVOY_STDLIB}" == "libc++" ]]; then
-        BAZEL_BUILD_OPTIONS+=("--config=libc++")
-        echo "local libc++ toolchain configured"
-      else
-        BAZEL_BUILD_OPTIONS+=("--config=clang")
-        echo "local $CC/$CXX toolchain configured"
-      fi
+      export PATH=/opt/llvm/bin:$PATH
+      export CC=clang
+      export CXX=clang++
+      export ASAN_SYMBOLIZER_PATH=/opt/llvm/bin/llvm-symbolizer
+      export BAZEL_COMPILER=clang
+      echo "$CC/$CXX toolchain configured"
     else
       if [[ "${ENVOY_STDLIB}" == "libc++" ]]; then
         BAZEL_BUILD_OPTIONS+=("--config=remote-clang-libc++")

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -17,6 +17,7 @@ export NIGHTHAWK_BUILD_ARCH=$(uname -m)
 export BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:=""}
 export GCP_SERVICE_ACCOUNT_KEY=${GCP_SERVICE_ACCOUNT_KEY:=""}
 export NO_BUILD_SETUP=${NO_BUILD_SETUP:=""}
+export ENVOY_STDLIB="${ENVOY_STDLIB:-libc++}"
 export ENVOY_RBE=${ENVOY_RBE:=""}
 # The directory to copy built binaries to.
 export BUILD_DIR=""
@@ -296,8 +297,6 @@ fi
 export BAZEL_EXTRA_TEST_OPTIONS+=("--test_env=ENVOY_IP_TEST_VERSIONS=v4only")
 export BAZEL_BUILD_OPTIONS=(
     --verbose_failures
-    --noshow_progress
-    --noshow_loading_progress
     --experimental_generate_json_trace_profile
     --experimental_repository_cache_hardlinks
     "${BAZEL_OPTIONS[@]}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -151,11 +151,6 @@ function do_integration_test_coverage() {
 }
 
 function setup_gcc_toolchain() {
-    if [[ -n "${ENVOY_STDLIB}" && "${ENVOY_STDLIB}" != "libstdc++" ]]; then
-      echo "gcc toolchain doesn't support ${ENVOY_STDLIB}."
-      exit 1
-    fi
-
     BAZEL_BUILD_OPTIONS+=("--config=gcc")
 
     if [[ -z "${ENVOY_RBE}" ]]; then

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -18,6 +18,7 @@ export SRCDIR=${SRCDIR:="${PWD}"}
 export CLANG_FORMAT=clang-format
 export NIGHTHAWK_BUILD_ARCH=$(uname -m)
 export BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:=""}
+export NO_BUILD_SETUP=${NO_BUILD_SETUP:=""}
 # The directory to copy built binaries to.
 export BUILD_DIR=""
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -21,15 +21,13 @@ export ENVOY_RBE=${ENVOY_RBE:=""}
 # The directory to copy built binaries to.
 export BUILD_DIR=""
 
-BAZEL_BUILD_EXTRA_OPTIONS="--config=remote-ci --jobs=33"
+if [[ -z "$NO_BUILD_SETUP" ]]; then
+    . "$(dirname "$0")"/setup_cache.sh
+fi
 
 read -ra BAZEL_BUILD_EXTRA_OPTIONS <<< "${BAZEL_BUILD_EXTRA_OPTIONS:-}"
 read -ra BAZEL_EXTRA_TEST_OPTIONS <<< "${BAZEL_EXTRA_TEST_OPTIONS:-}"
 read -ra BAZEL_OPTIONS <<< "${BAZEL_OPTIONS:-}"
-
-if [[ -z "$NO_BUILD_SETUP" ]]; then
-    . "$(dirname "$0")"/setup_cache.sh
-fi
 
 # We build in steps to avoid running out of memory in CI.
 # This list doesn't have to be complete, execution of bazel test will build any

--- a/ci/setup_cache.sh
+++ b/ci/setup_cache.sh
@@ -16,26 +16,26 @@ if [[ -n "${GCP_SERVICE_ACCOUNT_KEY:0:1}" ]]; then
 
   bash -c 'echo "${GCP_SERVICE_ACCOUNT_KEY}"' | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_FILE}"
 
-  export BAZEL_BUILD_EXTRA_OPTIONS+=("--google_credentials=${GCP_SERVICE_ACCOUNT_KEY_FILE}")
+  export BAZEL_BUILD_EXTRA_OPTIONS+=" --google_credentials=${GCP_SERVICE_ACCOUNT_KEY_FILE}"
 
   if [[ -n "${GOOGLE_BES_PROJECT_ID}" ]]; then
-    export BAZEL_BUILD_EXTRA_OPTIONS+=("--config=google-bes" "--bes_instance_name=${GOOGLE_BES_PROJECT_ID}")
+    export BAZEL_BUILD_EXTRA_OPTIONS+=" --config=google-bes --bes_instance_name=${GOOGLE_BES_PROJECT_ID}"
   fi
 
 fi
 
 
 if [[ -n "${BAZEL_REMOTE_CACHE}" ]]; then
-  export BAZEL_BUILD_EXTRA_OPTIONS+=("--remote_cache=${BAZEL_REMOTE_CACHE}")
+  export BAZEL_BUILD_EXTRA_OPTIONS+=" --remote_cache=${BAZEL_REMOTE_CACHE}"
   echo "Set up bazel remote read/write cache at ${BAZEL_REMOTE_CACHE}."
 
   if [[ -n "${BAZEL_REMOTE_INSTANCE}" ]]; then
-    export BAZEL_BUILD_EXTRA_OPTIONS+=("--remote_instance_name=${BAZEL_REMOTE_INSTANCE}")
+    export BAZEL_BUILD_EXTRA_OPTIONS+=" --remote_instance_name=${BAZEL_REMOTE_INSTANCE}"
     echo "instance_name: ${BAZEL_REMOTE_INSTANCE}."
   fi
 
   if [[ -z "${ENVOY_RBE}" ]]; then
-    export BAZEL_BUILD_EXTRA_OPTIONS+=("--jobs=HOST_CPUS*.99" "--remote_timeout=600")
+    export BAZEL_BUILD_EXTRA_OPTIONS+=" --jobs=HOST_CPUS*.99 --remote_timeout=600"
     echo "using local build cache."
   fi
 

--- a/ci/setup_cache.sh
+++ b/ci/setup_cache.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${GCP_SERVICE_ACCOUNT_KEY:0:1}" ]]; then
+  # mktemp will create a tempfile with u+rw permission minus umask, it will not be readable by all
+  # users by default.
+  GCP_SERVICE_ACCOUNT_KEY_FILE=$(mktemp -t gcp_service_account.XXXXXX.json)
+
+  gcp_service_account_cleanup() {
+    echo "Deleting service account key file..."
+    rm -rf "${GCP_SERVICE_ACCOUNT_KEY_FILE}"
+  }
+
+  trap gcp_service_account_cleanup EXIT
+
+  bash -c 'echo "${GCP_SERVICE_ACCOUNT_KEY}"' | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_FILE}"
+
+  export BAZEL_BUILD_EXTRA_OPTIONS+=" --google_credentials=${GCP_SERVICE_ACCOUNT_KEY_FILE}"
+
+  if [[ -n "${GOOGLE_BES_PROJECT_ID}" ]]; then
+    export BAZEL_BUILD_EXTRA_OPTIONS+=" --config=google-bes --bes_instance_name=${GOOGLE_BES_PROJECT_ID}"
+  fi
+
+fi
+
+
+if [[ -n "${BAZEL_REMOTE_CACHE}" ]]; then
+  export BAZEL_BUILD_EXTRA_OPTIONS+=" --remote_cache=${BAZEL_REMOTE_CACHE}"
+  echo "Set up bazel remote read/write cache at ${BAZEL_REMOTE_CACHE}."
+
+  if [[ -n "${BAZEL_REMOTE_INSTANCE}" ]]; then
+    export BAZEL_BUILD_EXTRA_OPTIONS+=" --remote_instance_name=${BAZEL_REMOTE_INSTANCE}"
+    echo "instance_name: ${BAZEL_REMOTE_INSTANCE}."
+  fi
+
+  if [[ -z "${ENVOY_RBE}" ]]; then
+    export BAZEL_BUILD_EXTRA_OPTIONS+=" --jobs=HOST_CPUS*.99 --remote_timeout=600"
+    echo "using local build cache."
+  fi
+
+else
+  echo "No remote cache is set, skipping setup remote cache."
+fi

--- a/ci/setup_cache.sh
+++ b/ci/setup_cache.sh
@@ -16,26 +16,26 @@ if [[ -n "${GCP_SERVICE_ACCOUNT_KEY:0:1}" ]]; then
 
   bash -c 'echo "${GCP_SERVICE_ACCOUNT_KEY}"' | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_FILE}"
 
-  export BAZEL_BUILD_EXTRA_OPTIONS+=" --google_credentials=${GCP_SERVICE_ACCOUNT_KEY_FILE}"
+  export BAZEL_BUILD_EXTRA_OPTIONS+=("--google_credentials=${GCP_SERVICE_ACCOUNT_KEY_FILE}")
 
   if [[ -n "${GOOGLE_BES_PROJECT_ID}" ]]; then
-    export BAZEL_BUILD_EXTRA_OPTIONS+=" --config=google-bes --bes_instance_name=${GOOGLE_BES_PROJECT_ID}"
+    export BAZEL_BUILD_EXTRA_OPTIONS+=("--config=google-bes" "--bes_instance_name=${GOOGLE_BES_PROJECT_ID}")
   fi
 
 fi
 
 
 if [[ -n "${BAZEL_REMOTE_CACHE}" ]]; then
-  export BAZEL_BUILD_EXTRA_OPTIONS+=" --remote_cache=${BAZEL_REMOTE_CACHE}"
+  export BAZEL_BUILD_EXTRA_OPTIONS+=("--remote_cache=${BAZEL_REMOTE_CACHE}")
   echo "Set up bazel remote read/write cache at ${BAZEL_REMOTE_CACHE}."
 
   if [[ -n "${BAZEL_REMOTE_INSTANCE}" ]]; then
-    export BAZEL_BUILD_EXTRA_OPTIONS+=" --remote_instance_name=${BAZEL_REMOTE_INSTANCE}"
+    export BAZEL_BUILD_EXTRA_OPTIONS+=("--remote_instance_name=${BAZEL_REMOTE_INSTANCE}")
     echo "instance_name: ${BAZEL_REMOTE_INSTANCE}."
   fi
 
   if [[ -z "${ENVOY_RBE}" ]]; then
-    export BAZEL_BUILD_EXTRA_OPTIONS+=" --jobs=HOST_CPUS*.99 --remote_timeout=600"
+    export BAZEL_BUILD_EXTRA_OPTIONS+=("--jobs=HOST_CPUS*.99" "--remote_timeout=600")
     echo "using local build cache."
   fi
 


### PR DESCRIPTION
This PR only moves the `build` stage onto RBE and AZP hosted VM. The other stages remain non-RBE and self-hosted for now, since there is more work needed to make them pass with RBE.

The additional stages will be moved in future PRs.

Done here:
- brought the `setup_cache.sh` script in from Envoy.
- converted bash variables that hold build options to bash arrays to be compatible with Envoy scripts.
- configured the pipeline to accept a new `rbe` parameter that enables RBE builds when set.
- split the `format` step into its own stage, since it currently does not work on an AZP hosted VM.