### PR TITLE
Update Envoy to 3a4d224 (Apr 7th 2023).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,10 @@ build --action_env=CXX --host_action_env=CXX
 build --action_env=LLVM_CONFIG --host_action_env=LLVM_CONFIG
 build --action_env=PATH --host_action_env=PATH
 
+# Allow stamped caches to bust when local filesystem changes.
+# Requires setting `BAZEL_VOLATILE_DIRTY` in the env.
+build --action_env=BAZEL_VOLATILE_DIRTY --host_action_env=BAZEL_VOLATILE_DIRTY
+
 build --enable_platform_specific_config
 build --test_summary=terse
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "fe3e54fce125e2574eaccbf9bc8daeeb68d8ff5a"
-ENVOY_SHA = "66a50dd0ece09a4f4baf2be15003efa24763fcba7dbc1f7c24675ad466f810ef"
+ENVOY_COMMIT = "3a4d2244f2611f2a614ee969a2de917fbc0cd3b4"
+ENVOY_SHA = "c1f2d0a453a3516ed1ce1d1a9aeb34ca6bc39a9a3fa67e44e2ce565bbde0f3a8"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -107,6 +107,7 @@ docker run --rm \
        -e ENVOY_STDLIB \
        -e BUILD_REASON \
        -e BAZEL_REMOTE_INSTANCE \
+       -e BAZEL_REMOTE_INSTANCE_BRANCH \
        -e GOOGLE_BES_PROJECT_ID \
        -e GCP_SERVICE_ACCOUNT_KEY \
        -e NUM_CPUS \

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -329,3 +329,5 @@ visibility_excludes:
 - source/extensions/health_checkers/BUILD
 - source/extensions/health_checkers/BUILD
 - source/extensions/health_checkers/BUILD
+- source/extensions/config_subscription/rest/BUILD
+- source/extensions/config_subscription/filesystem/BUILD


### PR DESCRIPTION
- synced changes to `.bazelrc`, `ci/run_envoy_docker.sh`, `tools/code_format/config.yaml` from Envoy.
- no changes in `.bazelversion`, `tools/gen_compilation_database.py`.