### PR TITLE
Update Envoy to cab680b (May 26th 2023)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "fb61801c03c544968606e97303439ebcade240bd"
-ENVOY_SHA = "cb0b6b4382cf1ca3df4f7ea6d29ecc4f0b5d3eb0b2cd5c04012f9344a16c4da4"
+ENVOY_COMMIT = "cab680b0ef801e269f9a50cd745728d4ae8b86e6"
+ENVOY_SHA = "75f9b5e7ce4a764c5579c7b3261e610eb0b4feb8c4239a14f7c1d0fcb757c33a"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -124,15 +124,21 @@ docker run --rm \
        -e GOOGLE_BES_PROJECT_ID \
        -e GCP_SERVICE_ACCOUNT_KEY \
        -e NUM_CPUS \
+       -e ENVOY_BRANCH \
        -e ENVOY_RBE \
        -e ENVOY_BUILD_IMAGE \
        -e ENVOY_SRCDIR \
        -e ENVOY_BUILD_TARGET \
        -e ENVOY_BUILD_DEBUG_INFORMATION \
        -e ENVOY_BUILD_FILTER_EXAMPLE \
+       -e ENVOY_COMMIT \
+       -e ENVOY_HEAD_REF \
+       -e ENVOY_REPO \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
        -e GCS_ARTIFACT_BUCKET \
        -e GITHUB_TOKEN \
+       -e GITHUB_APP_ID \
+       -e GITHUB_INSTALL_ID \
        -e NETLIFY_TRIGGER_URL \
        -e BUILD_SOURCEBRANCHNAME \
        -e BAZELISK_BASE_URL \

--- a/source/common/statistic_impl.h
+++ b/source/common/statistic_impl.h
@@ -229,6 +229,7 @@ public:
   // Envoy::Stats::Histogram
   void recordValue(uint64_t value) override;
   bool used() const override { return count() > 0; }
+  bool hidden() const override { return false; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
   // Overriding tagExtractedName() to return string(worker_id) + "." + Nighthawk::Statistic::id()
@@ -250,6 +251,7 @@ public:
   // Envoy::Stats::Histogram
   void recordValue(uint64_t value) override;
   bool used() const override { return count() > 0; }
+  bool hidden() const override { return false; }
   // Overriding name() to return Nighthawk::Statistic::id().
   std::string name() const override { return id(); }
   // Overriding tagExtractedName() to return string(worker_id) + "." + Nighthawk::Statistic::id()

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -450,6 +450,7 @@ visibility_excludes:
 - source/extensions/quic/server_preferred_address/BUILD
 - source/extensions/listener_managers/listener_manager/BUILD
 - source/extensions/upstreams/tcp/BUILD
+- source/extensions/health_check/event_sinks/BUILD
 - source/extensions/health_checkers/BUILD
 - source/extensions/health_checkers/BUILD
 - source/extensions/health_checkers/BUILD


### PR DESCRIPTION
- Fix build error `Unimplemented Pure Virtual Method` regarding virtual method `hidden()` introduced in Envoy [19231ba](https://github.com/envoyproxy/envoy/commit/19231ba2b311a115ba85391a18dc73370e1f28d3).
- Sync `ci/run_envoy_docker.sh` and `tools/code_format/config.yaml` from the Envoy repository.
