### PR TITLE
Update Envoy to de3ae4a (Jun 9th 2023).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "068adb188b025c48442d440d7942828e258ed467"
-ENVOY_SHA = "2b390f96e31b446a9f01ce4bd1bd362cc0f6cf37541d7c4b0636a0168d372851"
+ENVOY_COMMIT = "de3ae4a6e996ef7e6356c62b44990a6cf01e3a1c"
+ENVOY_SHA = "798d463664e1a31a963688647d90f07f25bfbae4aaaca1ade03348aed6edb9d5"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -118,7 +118,6 @@ paths:
     - source/common/network/lc_trie.h
     - source/common/network/socket_impl.cc
     - source/common/ssl/tls_certificate_config_impl.cc
-    - source/common/ssl/certificate_validation_context_config_impl.cc
     - source/common/formatter/substitution_formatter.cc
     - source/common/formatter/substitution_format_string.cc
     - source/common/stats/tag_extractor_impl.cc
@@ -132,7 +131,6 @@ paths:
     - source/common/http/filter_chain_helper.h
     - source/common/http/conn_manager_utility.cc
     - source/common/http/match_delegate/config.cc
-    - source/common/http/http_server_properties_cache_manager_impl.cc
     - source/common/protobuf/yaml_utility.cc
     - source/common/protobuf/visitor_helper.h
     - source/common/protobuf/visitor.cc


### PR DESCRIPTION
- no changes to `.bazelrc`, `.bazelversion`, `ci/run_envoy_docker.sh`, `tools/gen_compilation_database.py`.
- synced changes from `tools/code_format/config.yaml`.