### PR TITLE
Update Envoy to f97e3d8 (Jun 26th 2023)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "4222f18fe3eb34a9530d3b1d916bcb8f18dc627d"
-ENVOY_SHA = "25f7f65b3214e5544a3bdb8688e7ccb98388e1c34e8aef1faa5858af13879d8a"
+ENVOY_COMMIT = "f97e3d8e7e772aa0fd58c7a8f1df98e4e049d706"
+ENVOY_SHA = "60d12232982adeb896bd7e5696f158317c1dba838168b8bd66cf657f386a5b61"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-# Last updated 2023-05-22
+# Last updated 2023-06-26
 apipkg==3.0.1
 chardet==5.1.0
 importlib_metadata==6.4.1
 more_itertools==9.1.0
 py==1.11.0
-pytest==7.3.1
+pytest==7.4.0
 pytest-dependency==0.5.1 # versions below 1.0.0 are unstable, so we should only take in bugfixes automatically
 pytest-xdist==3.3.1
 pyyaml==6.0.0
@@ -13,14 +13,14 @@ six==1.16.0
 zipp==3.15.0
 # TODO(935): Remove all below dependencies after using actual dependency manager if possible.
 certifi==2023.5.7
-urllib3==2.0.2
+urllib3==2.0.3
 idna==3.4
-pluggy==1.0.0
+pluggy==1.2.0
 packaging==23.1
 attrs==23.1.0
 iniconfig==2.0.0
 execnet==1.9.0
 tomli==2.0.1
-pyparsing==3.0.9
+pyparsing==3.1.0
 charset_normalizer==2.1.1 # Don't update charset_normalizer to 3.x.x; the latest requests==2.28.1 can only use >=2 <3.
 exceptiongroup==1.1.1

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -116,7 +116,7 @@ public:
 
   void addSink(Envoy::Stats::SinkPtr sink) { sinks_.emplace_back(std::move(sink)); }
 
-  bool enableDeferredCreationStats() const { return false; }
+  bool enableDeferredCreationStats() const override { return false; }
 
 private:
   std::list<Envoy::Stats::SinkPtr> sinks_;


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in [bazel/repositories.bzl](https://github.com/envoyproxy/nighthawk/blob/main/bazel/repositories.bzl) to the latest Envoy's commit.
- Update [requirements.txt](https://github.com/envoyproxy/nighthawk/blob/main/requirements.txt]) with latest python dependencies
- Small function signature change to support compilation with new dependencies

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>