### PR TITLE
Update Envoy to 91fd294 (Sep 25, 2023)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -354,7 +354,7 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:56f235b141079013e64912d676fe7da981368402@sha256:d44499c6fd28a8a6a75dc61668b8a9e7bc3d99db11f9a61e8ea1d1f39c20a236
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "782bb0c102ffbd9880615526c54c00301a6f3f82"
-ENVOY_SHA = "2362abda74c5568bd78faa6467c6e5b0b9613e081d1dec71fc474a4762d67e2d"
+ENVOY_COMMIT = "91fd29408f0e788f2180746c55bc34d395d24e11"
+ENVOY_SHA = "0f654b1fd3ae69ee7add5c551d3775ed6573fdec09e4924f04facb59a24c6f73"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -117,8 +117,6 @@ fi
 docker run --rm \
        "${ENVOY_DOCKER_OPTIONS[@]}" \
        "${VOLUMES[@]}" \
-       -e AZP_BRANCH \
-       -e AZP_SHA1 `# unique` \
        -e HTTP_PROXY \
        -e HTTPS_PROXY \
        -e NO_PROXY \
@@ -129,6 +127,8 @@ docker run --rm \
        -e BAZEL_FAKE_SCM_REVISION \
        -e BAZEL_REMOTE_CACHE \
        -e BAZEL_STARTUP_EXTRA_OPTIONS \
+       -e CI_BRANCH \
+       -e CI_SHA1 \
        -e CI_TARGET_BRANCH \
        -e DOCKERHUB_USERNAME \
        -e DOCKERHUB_PASSWORD \
@@ -150,6 +150,7 @@ docker run --rm \
        -e ENVOY_HEAD_REF \
        -e ENVOY_PUBLISH_DRY_RUN \
        -e ENVOY_REPO \
+       -e ENVOY_TARBALL_DIR \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
        -e GCS_ARTIFACT_BUCKET \
        -e GITHUB_REF_NAME \
@@ -157,6 +158,7 @@ docker run --rm \
        -e GITHUB_TOKEN \
        -e GITHUB_APP_ID \
        -e GITHUB_INSTALL_ID \
+       -e MOBILE_DOCS_CHECKOUT_DIR \
        -e NETLIFY_TRIGGER_URL \
        -e BUILD_SOURCEBRANCHNAME \
        -e BAZELISK_BASE_URL \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
-# Last updated 2023-08-28
-apipkg==3.0.1
+# Last updated 2023-09-25
+apipkg==3.0.2
 chardet==5.2.0
 importlib_metadata==6.8.0
-more_itertools==10.0.0
+more_itertools==10.1.0
 py==1.11.0
-pytest==7.4.0
+pytest==7.4.2
 pytest-dependency==0.5.1 # versions below 1.0.0 are unstable, so we should only take in bugfixes automatically
 pytest-xdist==3.3.1
 pyyaml==6.0.1
 requests==2.31.0
 six==1.16.0
-zipp==3.16.2
+zipp==3.17.0
 # TODO(935): Remove all below dependencies after using actual dependency manager if possible.
 certifi==2023.7.22
-urllib3==2.0.4
+urllib3==2.0.5
 idna==3.4
 pluggy==1.3.0
 packaging==23.1

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -97,12 +97,9 @@ paths:
     - envoy/common/exception.h
     # legacy core files which throw exceptions. We can add to this list but strongly prefer
     # StausOr where possible.
-    - source/common/upstream/cds_api_helper.cc
     - source/common/upstream/thread_aware_lb_impl.cc
     - source/common/upstream/load_balancer_impl.cc
     - source/common/upstream/cluster_manager_impl.cc
-    - source/common/upstream/od_cds_api_impl.cc
-    - source/common/upstream/cds_api_impl.cc
     - source/common/upstream/outlier_detection_impl.cc
     - source/common/upstream/upstream_impl.cc
     - source/common/upstream/default_local_address_selector_factory.cc
@@ -134,7 +131,6 @@ paths:
     - source/common/protobuf/message_validator_impl.cc
     - source/common/access_log/access_log_manager_impl.cc
     - source/common/secret/secret_manager_impl.cc
-    - source/common/secret/sds_api.cc
     - source/common/grpc/async_client_manager_impl.cc
     - source/common/grpc/google_grpc_utils.cc
     - source/common/tcp_proxy/tcp_proxy.cc
@@ -142,7 +138,6 @@ paths:
     - source/common/config/xds_resource.cc
     - source/common/config/datasource.cc
     - source/common/config/utility.cc
-    - source/common/config/xds_context_params.cc
     - source/common/runtime/runtime_impl.cc
     - source/common/quic/quic_transport_socket_factory.cc
     - source/common/filter/config_discovery_impl.cc
@@ -154,7 +149,6 @@ paths:
     - source/common/router/vhds.cc
     - source/common/router/config_utility.cc
     - source/common/router/header_parser.cc
-    - source/common/rds/rds_route_config_subscription.cc
     - source/common/filesystem/inotify/watcher_impl.cc
     - source/common/filesystem/posix/directory_iterator_impl.cc
     - source/common/filesystem/posix/filesystem_impl.cc


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update to .bazelrc to https://github.com/envoyproxy/envoy/pull/29732
- Update ci/run_envoy_docker.sh to https://github.com/envoyproxy/envoy/pull/29772
- Update requirements.txt to up to date dependencies
- Update source/client/process_impl.cc to support pure virtual function change introduced in https://github.com/envoyproxy/envoy/pull/29173
- Update tools/code_format/config.yaml to https://github.com/envoyproxy/envoy/pull/29497