### PR TITLE
Update Envoy to 7479b6c (Sep 29, 2023)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -99,6 +99,14 @@ build:clang-pch --define=ENVOY_CLANG_PCH=1
 # Use gold linker for gcc compiler.
 build:gcc --linkopt=-fuse-ld=gold
 
+# Clang-tidy
+# TODO(phlax): enable this, its throwing some errors as well as finding more issues
+# build:clang-tidy --@envoy_toolshed//format/clang_tidy:executable=@envoy//tools/clang-tidy
+build:clang-tidy --@envoy_toolshed//format/clang_tidy:config=//:clang_tidy_config
+build:clang-tidy --aspects @envoy_toolshed//format/clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report
+build:clang-tidy --build_tag_filters=-notidy
+
 # Basic ASAN/UBSAN that works for gcc
 build:asan --action_env=ENVOY_ASAN=1
 build:asan --config=sanitizer

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "91fd29408f0e788f2180746c55bc34d395d24e11"
-ENVOY_SHA = "0f654b1fd3ae69ee7add5c551d3775ed6573fdec09e4924f04facb59a24c6f73"
+ENVOY_COMMIT = "7a450564be47f910d3c7832e7cdf8e5ae45b9653"
+ENVOY_SHA = "7a394b5d3cbb3823ac01e72494b4cc4e604933385ea3ce5b1ce8c0322f056f74"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -161,7 +161,6 @@ docker run --rm \
        -e GITHUB_APP_ID \
        -e GITHUB_INSTALL_ID \
        -e MOBILE_DOCS_CHECKOUT_DIR \
-       -e NETLIFY_TRIGGER_URL \
        -e BUILD_SOURCEBRANCHNAME \
        -e BAZELISK_BASE_URL \
        -e ENVOY_BUILD_ARCH \

--- a/source/adaptive_load/adaptive_load_client_main.cc
+++ b/source/adaptive_load/adaptive_load_client_main.cc
@@ -101,15 +101,14 @@ AdaptiveLoadClientMain::AdaptiveLoadClientMain(int argc, const char* const* argv
 
 uint32_t AdaptiveLoadClientMain::Run() {
   ENVOY_LOG(info, "Attempting adaptive load session: {}", DescribeInputs());
-  absl::StatusOr<std::string> spec_textproto_or_error = filesystem_.fileReadToEnd(spec_filename_);
-  if (!spec_textproto_or_error.ok()) {
+  absl::StatusOr<std::string> spec_textproto = filesystem_.fileReadToEnd(spec_filename_);
+  if (!spec_textproto.ok()) {
     throw Nighthawk::NighthawkException("Failed to read spec textproto file \"" + spec_filename_ +
-                                        "\": " + std::string(spec_textproto_or_error.status().message()));
+                                        "\": " + std::string(spec_textproto.status().message()));
   }   
-  std::string spec_textproto = spec_textproto_or_error.value();
   
   nighthawk::adaptive_load::AdaptiveLoadSessionSpec spec;
-  if (!Envoy::Protobuf::TextFormat::ParseFromString(spec_textproto, &spec)) {
+  if (!Envoy::Protobuf::TextFormat::ParseFromString(*spec_textproto, &spec)) {
     throw Nighthawk::NighthawkException("Unable to parse file \"" + spec_filename_ +
                                         "\" as a text protobuf (type " + spec.GetTypeName() + ")");
   }

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -241,7 +241,7 @@ public:
   }
 
 private:
-  Envoy::OptRef<Envoy::Server::Admin> admin_;
+Envoy::OptRef<Envoy::Server::Admin> admin_;
   Envoy::Api::Api& api_;
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::AccessLog::AccessLogManager& log_manager_;
@@ -310,7 +310,7 @@ public:
     PANIC("NighthawkServerFactoryContext::initManager not implemented");
   };
 
-  Envoy::Http::Context& httpContext() override { return server_.httpContext(); }
+
 
   Envoy::Grpc::Context& grpcContext() override { return server_.grpcContext(); };
 

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -241,7 +241,7 @@ public:
   }
 
 private:
-Envoy::OptRef<Envoy::Server::Admin> admin_;
+  Envoy::OptRef<Envoy::Server::Admin> admin_;
   Envoy::Api::Api& api_;
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::AccessLog::AccessLogManager& log_manager_;

--- a/test/adaptive_load/adaptive_load_client_main_test.cc
+++ b/test/adaptive_load/adaptive_load_client_main_test.cc
@@ -184,7 +184,7 @@ TEST(AdaptiveLoadClientMainTest, FailsIfOpeningOutputFileFails) {
 
   std::string infile_contents =
       Envoy::Filesystem::fileSystemForTest().fileReadToEnd(Nighthawk::TestEnvironment::runfilesPath(
-          std::string("test/adaptive_load/test_data/valid_session_spec.textproto")));
+          std::string("test/adaptive_load/test_data/valid_session_spec.textproto"))).value();
   EXPECT_CALL(filesystem, fileReadToEnd(_)).WillOnce(Return(infile_contents));
 
   auto* mock_file = new NiceMock<Envoy::Filesystem::MockFile>;
@@ -214,7 +214,7 @@ TEST(AdaptiveLoadClientMainTest, FailsIfWritingOutputFileFails) {
 
   std::string infile_contents =
       Envoy::Filesystem::fileSystemForTest().fileReadToEnd(Nighthawk::TestEnvironment::runfilesPath(
-          std::string("test/adaptive_load/test_data/valid_session_spec.textproto")));
+          std::string("test/adaptive_load/test_data/valid_session_spec.textproto"))).value();
   EXPECT_CALL(filesystem, fileReadToEnd(_)).WillOnce(Return(infile_contents));
 
   auto* mock_file = new NiceMock<Envoy::Filesystem::MockFile>;
@@ -247,7 +247,7 @@ TEST(AdaptiveLoadClientMainTest, FailsIfClosingOutputFileFails) {
 
   std::string infile_contents =
       Envoy::Filesystem::fileSystemForTest().fileReadToEnd(Nighthawk::TestEnvironment::runfilesPath(
-          std::string("test/adaptive_load/test_data/valid_session_spec.textproto")));
+          std::string("test/adaptive_load/test_data/valid_session_spec.textproto"))).value();
   EXPECT_CALL(filesystem, fileReadToEnd(_)).WillOnce(Return(infile_contents));
 
   auto* mock_file = new NiceMock<Envoy::Filesystem::MockFile>;
@@ -286,7 +286,7 @@ TEST(AdaptiveLoadClientMainTest, WritesOutputProtoToFile) {
 
   std::string infile_contents =
       Envoy::Filesystem::fileSystemForTest().fileReadToEnd(Nighthawk::TestEnvironment::runfilesPath(
-          std::string("test/adaptive_load/test_data/valid_session_spec.textproto")));
+          std::string("test/adaptive_load/test_data/valid_session_spec.textproto"))).value();
   EXPECT_CALL(filesystem, fileReadToEnd(_)).WillOnce(Return(infile_contents));
 
   std::string actual_outfile_contents;
@@ -315,7 +315,7 @@ TEST(AdaptiveLoadClientMainTest, WritesOutputProtoToFile) {
 
   std::string golden_text =
       Envoy::Filesystem::fileSystemForTest().fileReadToEnd(Nighthawk::TestEnvironment::runfilesPath(
-          std::string("test/adaptive_load/test_data/golden_output.textproto")));
+          std::string("test/adaptive_load/test_data/golden_output.textproto"))).value();
   nighthawk::adaptive_load::AdaptiveLoadSessionOutput golden_proto;
   Envoy::Protobuf::TextFormat::ParseFromString(golden_text, &golden_proto);
   EXPECT_EQ(actual_outfile_contents, golden_proto.DebugString());

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -79,7 +79,7 @@ public:
 
   std::string readGoldFile(absl::string_view path) {
     std::string s = Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
-        TestEnvironment::runfilesPath(std::string(path)));
+        TestEnvironment::runfilesPath(std::string(path))).value();
     const auto version = VersionInfo::buildVersion().version();
     const std::string major = fmt::format("{}", version.major_number());
     const std::string minor = fmt::format("{}", version.minor_number());
@@ -212,7 +212,7 @@ public:
   nighthawk::client::Output loadProtoFromFile(absl::string_view path) {
     nighthawk::client::Output proto;
     const auto contents = Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
-        TestEnvironment::runfilesPath(std::string(path)));
+        TestEnvironment::runfilesPath(std::string(path))).value();
     Envoy::MessageUtil::loadFromJson(contents, proto,
                                      Envoy::ProtobufMessage::getStrictValidationVisitor());
     return proto;

--- a/test/statistic_test.cc
+++ b/test/statistic_test.cc
@@ -341,7 +341,7 @@ TEST(StatisticTest, HdrStatisticPercentilesProto) {
 
   Envoy::MessageUtil util;
   util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
-                        TestEnvironment::runfilesPath("test/test_data/hdr_proto_json.gold")),
+                        TestEnvironment::runfilesPath("test/test_data/hdr_proto_json.gold")).value(),
                     parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
   const std::string json = util.getJsonStringFromMessageOrError(
       statistic.toProto(Statistic::SerializationDomain::DURATION), true, true);
@@ -364,7 +364,7 @@ TEST(StatisticTest, CircllhistStatisticPercentilesProto) {
 
   Envoy::MessageUtil util;
   util.loadFromJson(Envoy::Filesystem::fileSystemForTest().fileReadToEnd(
-                        TestEnvironment::runfilesPath("test/test_data/circllhist_proto_json.gold")),
+                        TestEnvironment::runfilesPath("test/test_data/circllhist_proto_json.gold")).value(),
                     parsed_json_proto, Envoy::ProtobufMessage::getStrictValidationVisitor());
   const std::string json = util.getJsonStringFromMessageOrError(
       statistic.toProto(Statistic::SerializationDomain::DURATION), true, true);


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update to .bazelrc to https://github.com/envoyproxy/envoy/pull/29874
- Update ci/run_envoy_docker.sh to https://github.com/envoyproxy/envoy/pull/29811
- Update source/client/process_impl.cc to adopt deprecation of `Envoy::Http::Context& httpContext()` in envoy ServerFactoryContext introduced in https://github.com/envoyproxy/envoy/pull/29779
- Update source/adaptive_load/adaptive_load_client_main.cc and a few tests which use `fileReadToEnd` to adopt return type change of `fileReadToEnd` introduced in https://github.com/envoyproxy/envoy/pull/29700