### PR TITLE
[WIP] Update Envoy to e4992b9 (Oct 09, 2023)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -57,6 +57,8 @@ build --action_env=BAZEL_FAKE_SCM_REVISION --host_action_env=BAZEL_FAKE_SCM_REVI
 
 build --test_summary=terse
 
+build:docs-ci --action_env=DOCS_RST_CHECK=1 --host_action_env=DOCS_RST_CHECK=1
+
 # TODO(keith): Remove once these 2 are the default
 build --incompatible_config_setting_private_default_visibility
 build --incompatible_enforce_config_setting_visibility

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "7a450564be47f910d3c7832e7cdf8e5ae45b9653"
-ENVOY_SHA = "7a394b5d3cbb3823ac01e72494b4cc4e604933385ea3ce5b1ce8c0322f056f74"
+ENVOY_COMMIT = "e4992b9c2ce8986b535f2a79e01c08c31edf15dd"
+ENVOY_SHA = "51fff46e21a931131b5e55ecb6d3e1a2062c2104ab5deba1eace0ab96edf3130"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -166,7 +166,6 @@ docker run --rm \
        -e ENVOY_BUILD_ARCH \
        -e SYSTEM_STAGEDISPLAYNAME \
        -e SYSTEM_JOBDISPLAYNAME \
-       -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
        -e DOCKERHUB_USERNAME `# unique` \
        -e DOCKERHUB_PASSWORD `# unique` \
        "${ENVOY_BUILD_IMAGE}" \

--- a/extensions_build_config.bzl
+++ b/extensions_build_config.bzl
@@ -13,6 +13,7 @@ EXTENSIONS = {
     "envoy.network.dns_resolver.cares": "//source/extensions/network/dns_resolver/cares:config",
     "envoy.config_subscription.filesystem": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
     "envoy.config_subscription.filesystem_collection": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
+    "envoy.resource_monitors.downstream_connections":   "//source/extensions/resource_monitors/downstream_connections:config",
 }
 
 DISABLED_BY_DEFAULT_EXTENSIONS = {

--- a/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
@@ -541,7 +541,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.downstream_connections"
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
@@ -541,7 +541,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: "envoy.resource_monitors.downstream_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
@@ -536,3 +536,12 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
+overload_manager:
+  refresh_interval:
+    seconds: 0
+    nanos: 250000000
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_5_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_5_listeners_http_origin.yaml
@@ -189,7 +189,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.downstream_connections"
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_5_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_5_listeners_http_origin.yaml
@@ -189,7 +189,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: "envoy.resource_monitors.downstream_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_5_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_5_listeners_http_origin.yaml
@@ -184,3 +184,12 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
+overload_manager:
+  refresh_interval:
+    seconds: 0
+    nanos: 250000000
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_http_origin.yaml
@@ -49,7 +49,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: "envoy.resource_monitors.downstream_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_http_origin.yaml
@@ -49,7 +49,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.downstream_connections"
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_http_origin.yaml
@@ -44,3 +44,12 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
+overload_manager:
+  refresh_interval:
+    seconds: 0
+    nanos: 250000000
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin.yaml
+++ b/test/integration/configurations/nighthawk_https_origin.yaml
@@ -58,7 +58,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.downstream_connections"
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin.yaml
+++ b/test/integration/configurations/nighthawk_https_origin.yaml
@@ -58,7 +58,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: "envoy.resource_monitors.downstream_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin.yaml
+++ b/test/integration/configurations/nighthawk_https_origin.yaml
@@ -53,3 +53,12 @@ static_resources:
                     private_key:
                       inline_string: |
                         @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem
+overload_manager:
+  refresh_interval:
+    seconds: 0
+    nanos: 250000000
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin_dsa.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_dsa.yaml
@@ -58,7 +58,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.downstream_connections"
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin_dsa.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_dsa.yaml
@@ -58,7 +58,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: "envoy.resource_monitors.downstream_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin_dsa.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_dsa.yaml
@@ -53,3 +53,12 @@ static_resources:
                     private_key:
                       inline_string: |
                         @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/server_ecdsakey.pem
+overload_manager:
+  refresh_interval:
+    seconds: 0
+    nanos: 250000000
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -63,7 +63,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: "envoy.resource_monitors.downstream_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -63,7 +63,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.downstream_connections"
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -58,3 +58,12 @@ static_resources:
                       private_key:
                           inline_string: |
                             @inject-runfile:nighthawk/external/envoy/test/config/integration/certs/serverkey.pem
+overload_manager:
+  refresh_interval:
+    seconds: 0
+    nanos: 250000000
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_track_timings.yaml
+++ b/test/integration/configurations/nighthawk_track_timings.yaml
@@ -49,7 +49,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: "envoy.resource_monitors.downstream_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_track_timings.yaml
+++ b/test/integration/configurations/nighthawk_track_timings.yaml
@@ -49,7 +49,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.downstream_connections"
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/nighthawk_track_timings.yaml
+++ b/test/integration/configurations/nighthawk_track_timings.yaml
@@ -44,3 +44,12 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
+overload_manager:
+  refresh_interval:
+    seconds: 0
+    nanos: 250000000
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 100000

--- a/test/integration/configurations/sni_origin.yaml
+++ b/test/integration/configurations/sni_origin.yaml
@@ -104,7 +104,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.downstream_connections"
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/configurations/sni_origin.yaml
+++ b/test/integration/configurations/sni_origin.yaml
@@ -99,3 +99,12 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               dynamic_stats: false
+overload_manager:
+  refresh_interval:
+    seconds: 0
+    nanos: 250000000
+  resource_monitors:
+    - name: "envoy.resource_monitors.global_downstream_max_connections"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 100000

--- a/test/integration/configurations/sni_origin.yaml
+++ b/test/integration/configurations/sni_origin.yaml
@@ -104,7 +104,7 @@ overload_manager:
     seconds: 0
     nanos: 250000000
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: "envoy.resource_monitors.downstream_connections"
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 100000

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -69,7 +69,6 @@ _TEST_SERVER_WARN_ERROR_IGNORE_LIST = frozenset([
             "Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size",
             "Unable to use runtime singleton for feature envoy.reloadable_features.header_map_correctly_coalesce_cookies",
             "Using deprecated extension name 'envoy.listener.tls_inspector' for 'envoy.filters.listener.tls_inspector'.",
-            "there is no configured limit to the number of allowed active connections. Set a limit via the runtime key overload.global_downstream_max_connections",
 
             # A few of our filters use the same typed configuration, specifically
             # 'test-server', 'time-tracking' and 'dynamic-delay'.

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -69,6 +69,7 @@ _TEST_SERVER_WARN_ERROR_IGNORE_LIST = frozenset([
             "Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size",
             "Unable to use runtime singleton for feature envoy.reloadable_features.header_map_correctly_coalesce_cookies",
             "Using deprecated extension name 'envoy.listener.tls_inspector' for 'envoy.filters.listener.tls_inspector'.",
+            "'envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig' is contained in proto file 'envoy/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto' marked as work-in-progress",
 
             # A few of our filters use the same typed configuration, specifically
             # 'test-server', 'time-tracking' and 'dynamic-delay'.

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -421,3 +421,4 @@ visibility_excludes:
 - source/extensions/config_subscription/grpc/BUILD
 - source/extensions/load_balancing_policies/subset/BUILD
 - source/extensions/load_balancing_policies/ring_hash/BUILD
+- source/extensions/resource_monitors/downstream_connections/BUILD


### PR DESCRIPTION
- sync .bazelrc etc
- configure envoy.resource_monitors.global_downstream_max_connections in test server overload_manager which become required in https://github.com/envoyproxy/envoy/pull/28202
- enable extension envoy.resource_monitors.downstream_connections in nighthawk