### PR TITLE
Update Envoy to 6ef1bb4 (Oct 13, 2023)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -514,6 +514,18 @@ build:rbe-engflow --remote_timeout=3600s
 build:rbe-engflow --bes_timeout=3600s
 build:rbe-engflow --bes_upload_mode=fully_async
 
+build:rbe-envoy-engflow --google_default_credentials=false
+build:rbe-envoy-engflow --remote_cache=grpcs://morganite.cluster.engflow.com
+build:rbe-envoy-engflow --remote_executor=grpcs://morganite.cluster.engflow.com
+build:rbe-envoy-engflow --bes_backend=grpcs://morganite.cluster.engflow.com/
+build:rbe-envoy-engflow --bes_results_url=https://morganite.cluster.engflow.com/invocation/
+build:rbe-envoy-engflow --credential_helper=*.engflow.com=%workspace%/bazel/engflow-bazel-credential-helper.sh
+build:rbe-envoy-engflow --grpc_keepalive_time=30s
+build:rbe-envoy-engflow --remote_timeout=3600s
+build:rbe-envoy-engflow --bes_timeout=3600s
+build:rbe-envoy-engflow --bes_upload_mode=fully_async
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902
+
 #############################################################################
 # debug: Various Bazel debugging flags
 #############################################################################

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "e4992b9c2ce8986b535f2a79e01c08c31edf15dd"
-ENVOY_SHA = "51fff46e21a931131b5e55ecb6d3e1a2062c2104ab5deba1eace0ab96edf3130"
+ENVOY_COMMIT = "6ef1bb476da8d050347b462b2d8efa1cddeb420f"
+ENVOY_SHA = "22a12c8bef5e476a4894143344d6aa386dced755ea2a1da798b573d0620a4f8a"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -11,11 +11,10 @@ function is_windows() {
 
 read -ra ENVOY_DOCKER_OPTIONS <<< "${ENVOY_DOCKER_OPTIONS:-}"
 
-# TODO(phlax): uppercase these env vars
-export HTTP_PROXY="${http_proxy:-}"
-export HTTPS_PROXY="${https_proxy:-}"
-export NO_PROXY="${no_proxy:-}"
-export GOPROXY="${go_proxy:-}"
+export HTTP_PROXY="${HTTP_PROXY:-${http_proxy:-}}"
+export HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-}}"
+export NO_PROXY="${NO_PROXY:-${no_proxy:-}}"
+export GOPROXY="${GOPROXY:-${go_proxy:-}}"
 
 if is_windows; then
   [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-windows2019"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -98,6 +98,7 @@ paths:
     # legacy core files which throw exceptions. We can add to this list but strongly prefer
     # StausOr where possible.
     - source/common/upstream/thread_aware_lb_impl.cc
+    - source/common/upstream/subset_lb_config.cc
     - source/common/upstream/load_balancer_impl.cc
     - source/common/upstream/cluster_manager_impl.cc
     - source/common/upstream/outlier_detection_impl.cc
@@ -151,10 +152,8 @@ paths:
     - source/common/router/header_parser.cc
     - source/common/filesystem/inotify/watcher_impl.cc
     - source/common/filesystem/posix/directory_iterator_impl.cc
-    - source/common/filesystem/posix/filesystem_impl.cc
     - source/common/filesystem/kqueue/watcher_impl.cc
     - source/common/filesystem/win32/directory_iterator_impl.cc
-    - source/common/filesystem/win32/filesystem_impl.cc
     - source/common/filesystem/win32/watcher_impl.cc
     - source/common/common/utility.cc
     - source/common/common/regex.cc
@@ -165,7 +164,6 @@ paths:
     - source/server/config_validation/server.cc
     - source/server/admin/html/active_stats.js
     - source/server/server.cc
-    - source/server/utils.cc
     - source/server/hot_restarting_base.cc
     - source/server/hot_restart_impl.cc
     - source/server/ssl_context_manager.cc
@@ -199,7 +197,7 @@ paths:
   protobuf:
     include:
     - api/test
-    - bazel/cc_proto_descriptor_library
+    - api/bazel/cc_proto_descriptor_library
     - ci/prebuilt
     - source/common/protobuf
     - source/extensions/filters/http/grpc_field_extraction
@@ -252,7 +250,7 @@ paths:
   # Files in these paths can use MessageLite::SerializeAsString
   serialize_as_string:
     include:
-    - bazel/cc_proto_descriptor_library/file_descriptor_generator.cc
+    - api/bazel/cc_proto_descriptor_library/file_descriptor_generator.cc
     - contrib/config/source/kv_store_xds_delegate.cc
     - source/common/protobuf/utility.h
     - source/common/protobuf/utility.cc
@@ -421,3 +419,7 @@ visibility_excludes:
 - source/extensions/config_subscription/grpc/BUILD
 - source/extensions/load_balancing_policies/subset/BUILD
 - source/extensions/load_balancing_policies/ring_hash/BUILD
+- source/extensions/load_balancing_policies/round_robin/
+- source/extensions/load_balancing_policies/least_request/
+- source/extensions/load_balancing_policies/random/
+- source/extensions/load_balancing_policies/cluster_provided/


### PR DESCRIPTION
Updated nighthawk to envoy commit #6ef1bb4:
- bazel/repositories.bzl
- .bazelrc
- ci/run_envoy_docker.sh
- tools/code_format/config.yaml