### PR TITLE
Update Envoy to 7db0b4a (Oct 20th 2023).

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -16,8 +16,9 @@ stages:
       matrix:
         build:
           CI_TARGET: "build"
-        format:
-          CI_TARGET: "check_format"
+        # TODO(#1032): Re-enable the format CI check.
+        #format:
+        #  CI_TARGET: "check_format"
     timeoutInMinutes: 120
     steps:
     - template: bazel.yml

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -16,9 +16,8 @@ stages:
       matrix:
         build:
           CI_TARGET: "build"
-        # TODO(#1032): Re-enable the format CI check.
-        #format:
-        #  CI_TARGET: "check_format"
+        format:
+          CI_TARGET: "check_format"
     timeoutInMinutes: 120
     steps:
     - template: bazel.yml

--- a/.bazelrc
+++ b/.bazelrc
@@ -366,8 +366,8 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-# TODO(#1032): Change to the latest. # unique
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902 # unique
+# TODO(#1032): Change to the latest. Don't update the hash until the bug is fixed. # unique
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
@@ -527,8 +527,8 @@ build:rbe-envoy-engflow --grpc_keepalive_time=30s
 build:rbe-envoy-engflow --remote_timeout=3600s
 build:rbe-envoy-engflow --bes_timeout=3600s
 build:rbe-envoy-engflow --bes_upload_mode=fully_async
-# TODO(#1032): Change to the latest. # unique
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902 # unique
+# TODO(#1032): Change to the latest. Don't update the hash until the bug is fixed. # unique
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/.bazelrc
+++ b/.bazelrc
@@ -366,7 +366,7 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-# TODO(#1032): Change to "build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e" # unique
+# TODO(#1032): Change to the latest. # unique
 build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902 # unique
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
@@ -527,7 +527,7 @@ build:rbe-envoy-engflow --grpc_keepalive_time=30s
 build:rbe-envoy-engflow --remote_timeout=3600s
 build:rbe-envoy-engflow --bes_timeout=3600s
 build:rbe-envoy-engflow --bes_upload_mode=fully_async
-# TODO(#1032): Change to "build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e" # unique
+# TODO(#1032): Change to the latest. # unique
 build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902 # unique
 
 #############################################################################

--- a/.bazelrc
+++ b/.bazelrc
@@ -366,7 +366,8 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e
+# TODO(#1032): Change to "build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e" # unique
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902 # unique
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
@@ -526,7 +527,8 @@ build:rbe-envoy-engflow --grpc_keepalive_time=30s
 build:rbe-envoy-engflow --remote_timeout=3600s
 build:rbe-envoy-engflow --bes_timeout=3600s
 build:rbe-envoy-engflow --bes_upload_mode=fully_async
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e
+# TODO(#1032): Change to "build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e" # unique
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902 # unique
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/.bazelrc
+++ b/.bazelrc
@@ -246,6 +246,8 @@ build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
 build:fuzz-coverage --test_tag_filters=-nocoverage
 
+build:cache-local --remote_cache=grpc://localhost:9092
+
 # Remote execution: https://docs.bazel.build/versions/master/remote-execution.html
 build:rbe-toolchain --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
@@ -364,7 +366,7 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
@@ -524,7 +526,7 @@ build:rbe-envoy-engflow --grpc_keepalive_time=30s
 build:rbe-envoy-engflow --remote_timeout=3600s
 build:rbe-envoy-engflow --bes_timeout=3600s
 build:rbe-envoy-engflow --bes_upload_mode=fully_async
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:94e5d873c145ae86f205117e76276161c9af4806@sha256:8d3763e19d5b71fdc95666d75073ce4581e566ce28ca09106607b6a3ef7ba902
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "6ef1bb476da8d050347b462b2d8efa1cddeb420f"
-ENVOY_SHA = "22a12c8bef5e476a4894143344d6aa386dced755ea2a1da798b573d0620a4f8a"
+ENVOY_COMMIT = "7db0b4a299730e9c4dd4872788bd56cc7b11018a"
+ENVOY_SHA = "52f76e1d2e35cbe454f8bff389c5ba74d630830c38e3b619c0207db3bee567a8"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -18,10 +18,6 @@ export GOPROXY="${GOPROXY:-${go_proxy:-}}"
 
 if is_windows; then
   [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-windows2019"
-  # Container networking is unreliable in the most recently built images, pin Windows to a known
-  # good container. This can create a mismatch between the host environment, and the toolchain
-  # environment.
-  ENVOY_BUILD_SHA=41c5a05d708972d703661b702a63ef5060125c33
   # TODO(sunjayBhatia): Currently ENVOY_DOCKER_OPTIONS is ignored on Windows because
   # CI sets it to a Linux-specific value. Undo this once https://github.com/envoyproxy/envoy/issues/13272
   # is resolved.
@@ -95,13 +91,13 @@ VOLUMES=(
     -v "${ENVOY_DOCKER_BUILD_DIR}":"${BUILD_DIR_MOUNT_DEST}"
     -v "${SOURCE_DIR}":"${SOURCE_DIR_MOUNT_DEST}")
 
-if ! is_windows && [[ -n "$ENVOY_DOCKER_IN_DOCKER" ]]; then
+if [[ -n "$ENVOY_DOCKER_IN_DOCKER" || -n "$ENVOY_SHARED_TMP_DIR" ]]; then
     # Create a "shared" directory that has the same path in/outside the container
     # This allows the host docker engine to see artefacts using a temporary path created inside the container,
     # at the same path.
     # For example, a directory created with `mktemp -d --tmpdir /tmp/bazel-shared` can be mounted as a volume
     # from within the build container.
-    SHARED_TMP_DIR=/tmp/bazel-shared
+    SHARED_TMP_DIR="${ENVOY_SHARED_TMP_DIR:-/tmp/bazel-shared}"
     mkdir -p "${SHARED_TMP_DIR}"
     chmod +rwx "${SHARED_TMP_DIR}"
     VOLUMES+=(-v "${SHARED_TMP_DIR}":"${SHARED_TMP_DIR}")
@@ -110,7 +106,6 @@ fi
 if [[ -n "${ENVOY_DOCKER_PULL}" ]]; then
     time docker pull "${ENVOY_BUILD_IMAGE}"
 fi
-
 
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
 docker run --rm \
@@ -135,10 +130,9 @@ docker run --rm \
        -e DOCKERHUB_PASSWORD \
        -e ENVOY_STDLIB \
        -e BUILD_REASON \
-       -e BAZEL_NO_CACHE_TEST_RESULTS \
        -e BAZEL_REMOTE_INSTANCE \
-       -e GOOGLE_BES_PROJECT_ID \
        -e GCP_SERVICE_ACCOUNT_KEY \
+       -e GCP_SERVICE_ACCOUNT_KEY_PATH \
        -e NUM_CPUS \
        -e ENVOY_BRANCH \
        -e ENVOY_RBE \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Last updated 2023-09-25
+# Last updated 2023-10-20
 apipkg==3.0.2
 chardet==5.2.0
 importlib_metadata==6.8.0
@@ -13,10 +13,10 @@ six==1.16.0
 zipp==3.17.0
 # TODO(935): Remove all below dependencies after using actual dependency manager if possible.
 certifi==2023.7.22
-urllib3==2.0.5
+urllib3==2.0.7
 idna==3.4
 pluggy==1.3.0
-packaging==23.1
+packaging==23.2
 attrs==23.1.0
 iniconfig==2.0.0
 execnet==2.0.2

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -142,6 +142,9 @@ public:
         local_info_(local_info), validation_context_(validation_context),
         grpc_context_(grpc_context), router_context_(router_context) {}
 
+  void run() override {
+    PANIC("NighthawkServerInstance::run not implemented");
+  }
   Envoy::OptRef<Envoy::Server::Admin> admin() override { return admin_; }
   Envoy::Api::Api& api() override { return api_; }
   Envoy::Upstream::ClusterManager& clusterManager() override {


### PR DESCRIPTION
- synced `.bazelrc`, `ci/run_envoy_docker.sh` from Envoy's version.
- no changes in `.bazelversion`, `tools/gen_compilation_database.py`, `tools/code_format/config.yaml`.
- updated Python dependencies in `requirements.txt`.
- added new unimplemented method `NighthawkServerInstance::run` as per the Envoy API change in https://github.com/envoyproxy/envoy/pull/30121.
- froze the docker image at its current version. Our Python tests and checks use on-host Python which has been removed from the Docker image in https://github.com/envoyproxy/envoy-build-tools/pull/290. Going to address this in #1032.