### PR TITLE
Update Envoy to 05457bb (Oct 30, 2023)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,6 +70,7 @@ common --experimental_allow_tags_propagation
 
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
+build:linux --copt=-fdebug-types-section
 build:linux --copt=-fPIC
 build:linux --copt=-Wno-deprecated-declarations
 build:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
@@ -312,6 +313,7 @@ build:remote-windows --spawn_strategy=remote,local
 build:remote-windows --strategy=Javac=remote,local
 build:remote-windows --strategy=Closure=remote,local
 build:remote-windows --strategy=Genrule=remote,local
+build:remote-windows --strategy=CppLink=local
 build:remote-windows --remote_timeout=7200
 build:remote-windows --google_default_credentials=true
 build:remote-windows --remote_download_toplevel
@@ -366,7 +368,7 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:7467652575122d8d54e767a68f141598bd855383@sha256:8781bc7e431b754c142edbfc937905fdf343db91f3fe19bbf54c362828db9849
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
@@ -452,7 +454,7 @@ build:windows --define hot_restart=disabled
 build:windows --define tcmalloc=disabled
 build:windows --define wasm=disabled
 build:windows --define manual_stamp=manual_stamp
-build:windows --cxxopt="/std:c++17"
+build:windows --cxxopt="/std:c++20"
 build:windows --output_groups=+pdb_file
 
 # TODO(wrowe,sunjayBhatia): Resolve bugs upstream in curl and rules_foreign_cc
@@ -495,11 +497,12 @@ build:windows --features=static_link_msvcrt
 build:windows --dynamic_mode=off
 
 # RBE (Google)
-build:rbe-google --google_default_credentials=true
-build:rbe-google --remote_cache=grpcs://remotebuildexecution.googleapis.com
+build:cache-google --google_default_credentials=true
+build:cache-google --remote_cache=grpcs://remotebuildexecution.googleapis.com
+build:cache-google --remote_instance_name=projects/envoy-ci/instances/default_instance
+build:cache-google --remote_timeout=7200
 build:rbe-google --remote_executor=grpcs://remotebuildexecution.googleapis.com
-build:rbe-google --remote_timeout=7200
-build:rbe-google --remote_instance_name=projects/envoy-ci/instances/default_instance
+build:rbe-google --config=cache-google
 
 build:rbe-google-bes --bes_backend=grpcs://buildeventservice.googleapis.com
 build:rbe-google-bes --bes_results_url=https://source.cloud.google.com/results/invocations/
@@ -526,7 +529,7 @@ build:rbe-envoy-engflow --grpc_keepalive_time=30s
 build:rbe-envoy-engflow --remote_timeout=3600s
 build:rbe-envoy-engflow --bes_timeout=3600s
 build:rbe-envoy-engflow --bes_upload_mode=fully_async
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:fdd65c6270a8507a18d5acd6cf19a18cb695e4fa@sha256:3c8a3ce6f90dcfb5d09dc8f79bb01404d3526d420061f9a176e0a8e91e1e573e
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:7467652575122d8d54e767a68f141598bd855383@sha256:8781bc7e431b754c142edbfc937905fdf343db91f3fe19bbf54c362828db9849
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "7db0b4a299730e9c4dd4872788bd56cc7b11018a"
-ENVOY_SHA = "52f76e1d2e35cbe454f8bff389c5ba74d630830c38e3b619c0207db3bee567a8"
+ENVOY_COMMIT = "05457bb047b87f4cc1a25635400ddcaa7fccc923"
+ENVOY_SHA = "d5439dbf264d5d0b76cba642bd4f65c9a1f75cff948849f96b2c080db6a486cd"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -128,6 +128,7 @@ docker run --rm \
        -e CI_TARGET_BRANCH \
        -e DOCKERHUB_USERNAME \
        -e DOCKERHUB_PASSWORD \
+       -e ENVOY_DOCKER_SAVE_IMAGE \
        -e ENVOY_STDLIB \
        -e BUILD_REASON \
        -e BAZEL_REMOTE_INSTANCE \

--- a/docs/root/updating_envoy_dependency.md
+++ b/docs/root/updating_envoy_dependency.md
@@ -272,10 +272,10 @@ merge_from_envoy "tools/code_format/config.yaml"
 
 ### Step 11
 Perform this step if [tools/base/requirements.in](/tools/base/requirements.in)
-has not been updated in the last 30 days (based on comment at top of file).
+has not been updated in the last 30 days.
 
 ```bash
-head -1 requirements.txt
+ls -l tools/base/requirements.txt
 ```
 
 - If less than 30 days ago, skip to next step.

--- a/docs/root/updating_envoy_dependency.md
+++ b/docs/root/updating_envoy_dependency.md
@@ -272,10 +272,10 @@ merge_from_envoy "tools/code_format/config.yaml"
 
 ### Step 11
 Perform this step if [tools/base/requirements.in](/tools/base/requirements.in)
-has not been updated in the last 30 days.
+has not been updated in the last 30 days (based on comment at top of file).
 
 ```bash
-ls -l tools/base/requirements.txt
+head -1 tools/base/requirements.in
 ```
 
 - If less than 30 days ago, skip to next step.

--- a/source/client/flush_worker_impl.h
+++ b/source/client/flush_worker_impl.h
@@ -35,7 +35,8 @@ public:
   // flushed to.
   FlushWorkerImpl(const std::chrono::milliseconds& stats_flush_interval, Envoy::Api::Api& api,
                   Envoy::ThreadLocal::Instance& tls, Envoy::Stats::Store& store,
-                  std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks);
+                  std::list<std::unique_ptr<Envoy::Stats::Sink>>& stats_sinks,
+                  Envoy::Upstream::ClusterManager& cluster_manager);
 
   void shutdownThread() override;
 
@@ -55,6 +56,7 @@ private:
   std::list<std::unique_ptr<Envoy::Stats::Sink>> stats_sinks_;
   const std::chrono::milliseconds stats_flush_interval_;
   Envoy::Event::TimerPtr stat_flush_timer_;
+  Envoy::Upstream::ClusterManager& cluster_manager_;
 };
 
 } // namespace Client

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -835,8 +835,8 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const UriPtr& tracing_
 
     if (!options_.statsSinks().empty()) {
       // There should be only a single live flush worker instance at any time.
-      flush_worker_ = std::make_unique<FlushWorkerImpl>(stats_flush_interval, *api_, tls_,
-                                                        store_root_, stats_sinks);
+      flush_worker_ = std::make_unique<FlushWorkerImpl>(
+          stats_flush_interval, *api_, tls_, store_root_, stats_sinks, *cluster_manager_);
       flush_worker_->start();
     }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -80,6 +80,7 @@ envoy_cc_test(
         "@envoy//test/mocks/local_info:local_info_mocks",
         "@envoy//test/mocks/protobuf:protobuf_mocks",
         "@envoy//test/mocks/thread_local:thread_local_mocks",
+        "@envoy//test/mocks/upstream:cluster_manager_mocks",
     ],
 )
 

--- a/test/flush_worker_test.cc
+++ b/test/flush_worker_test.cc
@@ -10,6 +10,7 @@
 #include "external/envoy/test/mocks/protobuf/mocks.h"
 #include "external/envoy/test/mocks/stats/mocks.h"
 #include "external/envoy/test/mocks/thread_local/mocks.h"
+#include "external/envoy/test/mocks/upstream/cluster_manager.h"
 
 #include "source/client/flush_worker_impl.h"
 
@@ -113,8 +114,10 @@ public:
 TEST_F(FlushWorkerTest, WorkerFlushStatsPeriodically) {
   std::chrono::milliseconds stats_flush_interval{10};
   setupDispatcherTimerEmulation();
+  NiceMock<Envoy::Upstream::MockClusterManager> mock_cluster_manager;
 
-  FlushWorkerImpl worker(stats_flush_interval, api_, tls_, store_, stats_sinks_);
+  FlushWorkerImpl worker(stats_flush_interval, api_, tls_, store_, stats_sinks_,
+                         mock_cluster_manager);
 
   std::thread thread = std::thread([&worker, this] {
     // Wait for the while loop to run kNumTimerLoops times in simulateTimerLoop().
@@ -139,8 +142,10 @@ TEST_F(FlushWorkerTest, WorkerFlushStatsPeriodically) {
 // even when the dispatcher and timer is not set up (expectDispatcherRun() is not called).
 TEST_F(FlushWorkerTest, FinalFlush) {
   std::chrono::milliseconds stats_flush_interval{10};
+  NiceMock<Envoy::Upstream::MockClusterManager> mock_cluster_manager;
 
-  FlushWorkerImpl worker(stats_flush_interval, api_, tls_, store_, stats_sinks_);
+  FlushWorkerImpl worker(stats_flush_interval, api_, tls_, store_, stats_sinks_,
+                         mock_cluster_manager);
 
   worker.start();
   worker.waitForCompletion();

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -105,7 +105,7 @@ paths:
     - source/common/upstream/upstream_impl.cc
     - source/common/upstream/default_local_address_selector_factory.cc
     - source/common/network/listen_socket_impl.cc
-    - source/common/network/io_socket_handle_impl.cc
+    - source/common/network/io_socket_handle_base_impl.cc
     - source/common/network/address_impl.cc
     - source/common/network/cidr_range.cc
     - source/common/network/utility.cc


### PR DESCRIPTION
- synced `.bazelrc`
- synced `bazel/repositories.bzl`
- synced `ci/run_envoy_docker.sh`
- synced `tools/code_format/config.yaml`
- Adjusted Python procedure in `docs/root/updating_envoy_dependency.md`
- Added `ClusterManager` parameter now expected by `FlushWorkerImpl` constructor
