### PR TITLE
Update Envoy to acc54c5 (Nov 24th 2023).

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "294324a8cb3e94dade9e8b9762cbadab94101c77"
-ENVOY_SHA = "dd4c8cbc269421f317093ff35ad79be49bafdd6a92f18f758fb916ae0576131f"
+ENVOY_COMMIT = "acc54c548214504a17704e75bf7e6a141c02ae8f"
+ENVOY_SHA = "857f72e947222ab2ebab495cb51fa5275354e8a2b770c77f0d70e3b19363330d"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/docs/root/updating_envoy_dependency.md
+++ b/docs/root/updating_envoy_dependency.md
@@ -333,6 +333,8 @@ may see new failures due to these updates. Re-introduce dependency pins as neces
 command Step 11 again. Repeat this until the tests pass and document the need for any
 pins in [tools/base/requirements.in](/tools/base/requirements.in).
 
+If you updated the Python dependencies, update the date at the top of the
+[tools/base/requirements.in](/tools/base/requirements.in) file.
 
 ### Step 13
 

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -1,4 +1,4 @@
-# Last updated 2023-10-27
+# Last updated 2023-11-26
 apipkg
 attrs
 certifi


### PR DESCRIPTION
- no changes to `.bazelrc`, `.bazelversion`, `ci/run_envoy_docker.sh`, `tools/gen_compilation_database.py`, `tools/code_format/config.yaml`.
- updated Python requirements in `tools/base/requirements.in`.
- modified Python dependency update instructions - explicitly listing that the date at the top of `tools/base/requirements.in` should be updated.