### PR TITLE
Update Envoy to 4d154dd(Dec 1st 2023)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "acc54c548214504a17704e75bf7e6a141c02ae8f"
-ENVOY_SHA = "857f72e947222ab2ebab495cb51fa5275354e8a2b770c77f0d70e3b19363330d"
+ENVOY_COMMIT = "4d154dd245690cfcf24fa21ad395f86800724d71"
+ENVOY_SHA = "dea3a07c9633b9a066161154dcd5ee47edf75e0becd4c6db11159391b5f2c3ec"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -160,7 +160,7 @@ envoy_cc_library(
         "@envoy//source/common/protobuf:utility_lib_with_external_headers",
         "@envoy//source/common/stats:histogram_lib_with_external_headers",
         "@envoy//source/common/version:version_includes_with_external_headers",
-        "@envoy//source/exe:envoy_common_lib_with_external_headers",
+        "@envoy//source/exe:main_common_lib_with_external_headers",
         "@envoy//source/server/config_validation:server_lib_with_external_headers",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],


### PR DESCRIPTION
- updated envoy commit number to 
- updated nighthawk common lib dependency: replace `envoy_common_lib_with_external_headers` with `main_common_lib_with_external_headers`  due to change https://github.com/envoyproxy/envoy/pull/30924/