### PR TITLE
Adopt Envoy::Protobuf::DynamicCastToGenerated

### DIFF
--- a/source/adaptive_load/input_variable_setter_impl.cc
+++ b/source/adaptive_load/input_variable_setter_impl.cc
@@ -31,9 +31,9 @@ RequestsPerSecondInputVariableSetterConfigFactory::createEmptyConfigProto() {
 
 InputVariableSetterPtr RequestsPerSecondInputVariableSetterConfigFactory::createInputVariableSetter(
     const Envoy::Protobuf::Message& message) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::RequestsPerSecondInputVariableSetterConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<RequestsPerSecondInputVariableSetter>(config);
 }
 

--- a/source/adaptive_load/input_variable_setter_impl.cc
+++ b/source/adaptive_load/input_variable_setter_impl.cc
@@ -31,7 +31,8 @@ RequestsPerSecondInputVariableSetterConfigFactory::createEmptyConfigProto() {
 
 InputVariableSetterPtr RequestsPerSecondInputVariableSetterConfigFactory::createInputVariableSetter(
     const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::RequestsPerSecondInputVariableSetterConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<RequestsPerSecondInputVariableSetter>(config);

--- a/source/adaptive_load/input_variable_setter_impl.cc
+++ b/source/adaptive_load/input_variable_setter_impl.cc
@@ -31,7 +31,7 @@ RequestsPerSecondInputVariableSetterConfigFactory::createEmptyConfigProto() {
 
 InputVariableSetterPtr RequestsPerSecondInputVariableSetterConfigFactory::createInputVariableSetter(
     const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::RequestsPerSecondInputVariableSetterConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<RequestsPerSecondInputVariableSetter>(config);

--- a/source/adaptive_load/scoring_function_impl.cc
+++ b/source/adaptive_load/scoring_function_impl.cc
@@ -16,7 +16,8 @@ Envoy::ProtobufTypes::MessagePtr BinaryScoringFunctionConfigFactory::createEmpty
 
 ScoringFunctionPtr
 BinaryScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::BinaryScoringFunctionConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<BinaryScoringFunction>(config);
@@ -48,7 +49,8 @@ Envoy::ProtobufTypes::MessagePtr LinearScoringFunctionConfigFactory::createEmpty
 
 ScoringFunctionPtr
 LinearScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<LinearScoringFunction>(config);

--- a/source/adaptive_load/scoring_function_impl.cc
+++ b/source/adaptive_load/scoring_function_impl.cc
@@ -16,7 +16,7 @@ Envoy::ProtobufTypes::MessagePtr BinaryScoringFunctionConfigFactory::createEmpty
 
 ScoringFunctionPtr
 BinaryScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::BinaryScoringFunctionConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<BinaryScoringFunction>(config);
@@ -48,7 +48,7 @@ Envoy::ProtobufTypes::MessagePtr LinearScoringFunctionConfigFactory::createEmpty
 
 ScoringFunctionPtr
 LinearScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<LinearScoringFunction>(config);

--- a/source/adaptive_load/scoring_function_impl.cc
+++ b/source/adaptive_load/scoring_function_impl.cc
@@ -16,9 +16,9 @@ Envoy::ProtobufTypes::MessagePtr BinaryScoringFunctionConfigFactory::createEmpty
 
 ScoringFunctionPtr
 BinaryScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf::Message& message) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::BinaryScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<BinaryScoringFunction>(config);
 }
 
@@ -48,9 +48,9 @@ Envoy::ProtobufTypes::MessagePtr LinearScoringFunctionConfigFactory::createEmpty
 
 ScoringFunctionPtr
 LinearScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf::Message& message) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<LinearScoringFunction>(config);
 }
 

--- a/source/adaptive_load/step_controller_impl.cc
+++ b/source/adaptive_load/step_controller_impl.cc
@@ -50,7 +50,8 @@ std::string ExponentialSearchStepControllerConfigFactory::name() const {
 
 absl::Status ExponentialSearchStepControllerConfigFactory::ValidateConfig(
     const Envoy::Protobuf::Message& message) const {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   if (config.has_input_variable_setter()) {
@@ -62,7 +63,8 @@ absl::Status ExponentialSearchStepControllerConfigFactory::ValidateConfig(
 StepControllerPtr ExponentialSearchStepControllerConfigFactory::createStepController(
     const Envoy::Protobuf::Message& message,
     const nighthawk::client::CommandLineOptions& command_line_options_template) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<ExponentialSearchStepController>(config, command_line_options_template);

--- a/source/adaptive_load/step_controller_impl.cc
+++ b/source/adaptive_load/step_controller_impl.cc
@@ -50,7 +50,7 @@ std::string ExponentialSearchStepControllerConfigFactory::name() const {
 
 absl::Status ExponentialSearchStepControllerConfigFactory::ValidateConfig(
     const Envoy::Protobuf::Message& message) const {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   if (config.has_input_variable_setter()) {
@@ -62,7 +62,7 @@ absl::Status ExponentialSearchStepControllerConfigFactory::ValidateConfig(
 StepControllerPtr ExponentialSearchStepControllerConfigFactory::createStepController(
     const Envoy::Protobuf::Message& message,
     const nighthawk::client::CommandLineOptions& command_line_options_template) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<ExponentialSearchStepController>(config, command_line_options_template);

--- a/source/adaptive_load/step_controller_impl.cc
+++ b/source/adaptive_load/step_controller_impl.cc
@@ -50,9 +50,9 @@ std::string ExponentialSearchStepControllerConfigFactory::name() const {
 
 absl::Status ExponentialSearchStepControllerConfigFactory::ValidateConfig(
     const Envoy::Protobuf::Message& message) const {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   if (config.has_input_variable_setter()) {
     return LoadInputVariableSetterPlugin(config.input_variable_setter()).status();
   }
@@ -62,9 +62,9 @@ absl::Status ExponentialSearchStepControllerConfigFactory::ValidateConfig(
 StepControllerPtr ExponentialSearchStepControllerConfigFactory::createStepController(
     const Envoy::Protobuf::Message& message,
     const nighthawk::client::CommandLineOptions& command_line_options_template) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<ExponentialSearchStepController>(config, command_line_options_template);
 }
 

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -754,7 +754,7 @@ void ProcessImpl::maybeCreateTracingDriver(const envoy::config::trace::v3::Traci
     Envoy::ProtobufTypes::MessagePtr message = Envoy::Config::Utility::translateToFactoryConfig(
         configuration.http(), Envoy::ProtobufMessage::getStrictValidationVisitor(), factory);
     auto* zipkin_config =
-        Envoy::Protobuf::DynamicCastToGenerated<envoy::config::trace::v3::ZipkinConfig>(
+        Envoy::Protobuf::DynamicCastToGenerated<const envoy::config::trace::v3::ZipkinConfig>(
             message.get());
     Envoy::Tracing::DriverPtr zipkin_driver =
         std::make_unique<Envoy::Extensions::Tracers::Zipkin::Driver>(

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -753,7 +753,7 @@ void ProcessImpl::maybeCreateTracingDriver(const envoy::config::trace::v3::Traci
             configuration.http());
     Envoy::ProtobufTypes::MessagePtr message = Envoy::Config::Utility::translateToFactoryConfig(
         configuration.http(), Envoy::ProtobufMessage::getStrictValidationVisitor(), factory);
-    auto* zipkin_config =
+    const auto* zipkin_config =
         Envoy::Protobuf::DynamicCastToGenerated<const envoy::config::trace::v3::ZipkinConfig>(
             message.get());
     Envoy::Tracing::DriverPtr zipkin_driver =

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -28,6 +28,7 @@
 #include "external/envoy/source/common/local_info/local_info_impl.h"
 #include "external/envoy/source/common/network/dns_resolver/dns_factory_util.h"
 #include "external/envoy/source/common/network/utility.h"
+#include "external/envoy/source/common/protobuf/protobuf.h"
 #include "external/envoy/source/common/runtime/runtime_impl.h"
 #include "external/envoy/source/common/singleton/manager_impl.h"
 #include "external/envoy/source/common/thread_local/thread_local_impl.h"
@@ -752,10 +753,12 @@ void ProcessImpl::maybeCreateTracingDriver(const envoy::config::trace::v3::Traci
             configuration.http());
     Envoy::ProtobufTypes::MessagePtr message = Envoy::Config::Utility::translateToFactoryConfig(
         configuration.http(), Envoy::ProtobufMessage::getStrictValidationVisitor(), factory);
-    auto zipkin_config = dynamic_cast<const envoy::config::trace::v3::ZipkinConfig&>(*message);
+    auto* zipkin_config =
+        Envoy::Protobuf::DynamicCastToGenerated<envoy::config::trace::v3::ZipkinConfig>(
+            message.get());
     Envoy::Tracing::DriverPtr zipkin_driver =
         std::make_unique<Envoy::Extensions::Tracers::Zipkin::Driver>(
-            zipkin_config, *cluster_manager_, scope_root_, tls_, *runtime_loader_.get(),
+            *zipkin_config, *cluster_manager_, scope_root_, tls_, *runtime_loader_.get(),
             *local_info_, generator_, time_system_);
     tracer_ = std::make_unique<Envoy::Tracing::TracerImpl>(std::move(zipkin_driver), *local_info_);
 #else

--- a/source/request_source/request_options_list_plugin_impl.cc
+++ b/source/request_source/request_options_list_plugin_impl.cc
@@ -23,7 +23,7 @@ FileBasedOptionsListRequestSourceFactory::createEmptyConfigProto() {
 RequestSourcePtr FileBasedOptionsListRequestSourceFactory::createRequestSourcePlugin(
     const Envoy::Protobuf::Message& message, Envoy::Api::Api& api,
     Envoy::Http::RequestHeaderMapPtr header) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::FileBasedOptionsListRequestSourceConfig config;
   Envoy::MessageUtil util;
   util.unpackTo(*any, config);
@@ -56,7 +56,7 @@ Envoy::ProtobufTypes::MessagePtr InLineOptionsListRequestSourceFactory::createEm
 RequestSourcePtr InLineOptionsListRequestSourceFactory::createRequestSourcePlugin(
     const Envoy::Protobuf::Message& message, Envoy::Api::Api&,
     Envoy::Http::RequestHeaderMapPtr header) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::InLineOptionsListRequestSourceConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   auto loaded_list_ptr =

--- a/source/request_source/request_options_list_plugin_impl.cc
+++ b/source/request_source/request_options_list_plugin_impl.cc
@@ -23,7 +23,8 @@ FileBasedOptionsListRequestSourceFactory::createEmptyConfigProto() {
 RequestSourcePtr FileBasedOptionsListRequestSourceFactory::createRequestSourcePlugin(
     const Envoy::Protobuf::Message& message, Envoy::Api::Api& api,
     Envoy::Http::RequestHeaderMapPtr header) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::FileBasedOptionsListRequestSourceConfig config;
   Envoy::MessageUtil util;
   util.unpackTo(*any, config);
@@ -56,7 +57,8 @@ Envoy::ProtobufTypes::MessagePtr InLineOptionsListRequestSourceFactory::createEm
 RequestSourcePtr InLineOptionsListRequestSourceFactory::createRequestSourcePlugin(
     const Envoy::Protobuf::Message& message, Envoy::Api::Api&,
     Envoy::Http::RequestHeaderMapPtr header) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::InLineOptionsListRequestSourceConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   auto loaded_list_ptr =

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
@@ -1,5 +1,7 @@
 #include "test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.h"
 
+#include "external/envoy/source/common/protobuf/protobuf.h"
+
 namespace Nighthawk {
 
 namespace {
@@ -35,18 +37,18 @@ Envoy::ProtobufTypes::MessagePtr FakeInputVariableSetterConfigFactory::createEmp
 
 InputVariableSetterPtr FakeInputVariableSetterConfigFactory::createInputVariableSetter(
     const Envoy::Protobuf::Message& message) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeInputVariableSetter>(config);
 }
 
 absl::Status FakeInputVariableSetterConfigFactory::ValidateConfig(
     const Envoy::Protobuf::Message& message) const {
   try {
-    const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
-    Envoy::MessageUtil::unpackTo(any, config);
+    Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {
       return StatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
@@ -37,7 +37,8 @@ Envoy::ProtobufTypes::MessagePtr FakeInputVariableSetterConfigFactory::createEmp
 
 InputVariableSetterPtr FakeInputVariableSetterConfigFactory::createInputVariableSetter(
     const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeInputVariableSetter>(config);
@@ -46,7 +47,8 @@ InputVariableSetterPtr FakeInputVariableSetterConfigFactory::createInputVariable
 absl::Status FakeInputVariableSetterConfigFactory::ValidateConfig(
     const Envoy::Protobuf::Message& message) const {
   try {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+    const auto* any =
+        Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
@@ -37,7 +37,7 @@ Envoy::ProtobufTypes::MessagePtr FakeInputVariableSetterConfigFactory::createEmp
 
 InputVariableSetterPtr FakeInputVariableSetterConfigFactory::createInputVariableSetter(
     const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeInputVariableSetter>(config);
@@ -46,7 +46,7 @@ InputVariableSetterPtr FakeInputVariableSetterConfigFactory::createInputVariable
 absl::Status FakeInputVariableSetterConfigFactory::ValidateConfig(
     const Envoy::Protobuf::Message& message) const {
   try {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
@@ -2,6 +2,8 @@
 
 #include "envoy/common/exception.h"
 
+#include "external/envoy/source/common/protobuf/protobuf.h"
+
 #include "api/adaptive_load/benchmark_result.pb.h"
 
 #include "test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.pb.h"
@@ -57,18 +59,18 @@ Envoy::ProtobufTypes::MessagePtr FakeMetricsPluginConfigFactory::createEmptyConf
 
 MetricsPluginPtr
 FakeMetricsPluginConfigFactory::createMetricsPlugin(const Envoy::Protobuf::Message& message) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeMetricsPluginConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeMetricsPlugin>(config);
 }
 
 absl::Status
 FakeMetricsPluginConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& message) const {
   try {
-    const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeMetricsPluginConfig config;
-    Envoy::MessageUtil::unpackTo(any, config);
+    Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {
       return GetStatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
@@ -59,7 +59,7 @@ Envoy::ProtobufTypes::MessagePtr FakeMetricsPluginConfigFactory::createEmptyConf
 
 MetricsPluginPtr
 FakeMetricsPluginConfigFactory::createMetricsPlugin(const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeMetricsPluginConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeMetricsPlugin>(config);
@@ -68,7 +68,7 @@ FakeMetricsPluginConfigFactory::createMetricsPlugin(const Envoy::Protobuf::Messa
 absl::Status
 FakeMetricsPluginConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& message) const {
   try {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeMetricsPluginConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
@@ -59,7 +59,8 @@ Envoy::ProtobufTypes::MessagePtr FakeMetricsPluginConfigFactory::createEmptyConf
 
 MetricsPluginPtr
 FakeMetricsPluginConfigFactory::createMetricsPlugin(const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeMetricsPluginConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeMetricsPlugin>(config);
@@ -68,7 +69,8 @@ FakeMetricsPluginConfigFactory::createMetricsPlugin(const Envoy::Protobuf::Messa
 absl::Status
 FakeMetricsPluginConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& message) const {
   try {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+    const auto* any =
+        Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeMetricsPluginConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {

--- a/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
@@ -75,7 +75,8 @@ Envoy::ProtobufTypes::MessagePtr FakeStepControllerConfigFactory::createEmptyCon
 StepControllerPtr FakeStepControllerConfigFactory::createStepController(
     const Envoy::Protobuf::Message& message,
     const nighthawk::client::CommandLineOptions& command_line_options_template) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeStepControllerConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeStepController>(config, command_line_options_template);
@@ -84,7 +85,8 @@ StepControllerPtr FakeStepControllerConfigFactory::createStepController(
 absl::Status
 FakeStepControllerConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& message) const {
   try {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+    const auto* any =
+        Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeStepControllerConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {

--- a/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
@@ -1,5 +1,7 @@
 #include "test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.h"
 
+#include "external/envoy/source/common/protobuf/protobuf.h"
+
 #include "api/adaptive_load/benchmark_result.pb.h"
 
 #include "test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.pb.h"
@@ -73,18 +75,18 @@ Envoy::ProtobufTypes::MessagePtr FakeStepControllerConfigFactory::createEmptyCon
 StepControllerPtr FakeStepControllerConfigFactory::createStepController(
     const Envoy::Protobuf::Message& message,
     const nighthawk::client::CommandLineOptions& command_line_options_template) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeStepControllerConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeStepController>(config, command_line_options_template);
 }
 
 absl::Status
 FakeStepControllerConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& message) const {
   try {
-    const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeStepControllerConfig config;
-    Envoy::MessageUtil::unpackTo(any, config);
+    Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {
       return StatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
@@ -75,7 +75,7 @@ Envoy::ProtobufTypes::MessagePtr FakeStepControllerConfigFactory::createEmptyCon
 StepControllerPtr FakeStepControllerConfigFactory::createStepController(
     const Envoy::Protobuf::Message& message,
     const nighthawk::client::CommandLineOptions& command_line_options_template) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeStepControllerConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<FakeStepController>(config, command_line_options_template);
@@ -84,7 +84,7 @@ StepControllerPtr FakeStepControllerConfigFactory::createStepController(
 absl::Status
 FakeStepControllerConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& message) const {
   try {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeStepControllerConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     if (config.has_artificial_validation_failure()) {

--- a/test/adaptive_load/plugin_loader_test.cc
+++ b/test/adaptive_load/plugin_loader_test.cc
@@ -38,7 +38,8 @@ const double kBadConfigThreshold = 98765.0;
  * @return Status InvalidArgument if threshold is kBadConfigThreshold, OK otherwise.
  */
 absl::Status DoValidateConfig(const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return config.threshold() == kBadConfigThreshold
@@ -82,7 +83,8 @@ public:
 
   InputVariableSetterPtr
   createInputVariableSetter(const Envoy::Protobuf::Message& message) override {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+    const auto* any =
+        Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestInputVariableSetter>(config);
@@ -120,7 +122,8 @@ public:
     return DoValidateConfig(message);
   }
   ScoringFunctionPtr createScoringFunction(const Envoy::Protobuf::Message& message) override {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+    const auto* any =
+        Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestScoringFunction>(config);
@@ -159,7 +162,8 @@ public:
     return DoValidateConfig(message);
   }
   MetricsPluginPtr createMetricsPlugin(const Envoy::Protobuf::Message& message) override {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+    const auto* any =
+        Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestMetricsPlugin>(config);
@@ -209,7 +213,8 @@ public:
   StepControllerPtr createStepController(
       const Envoy::Protobuf::Message& message,
       const nighthawk::client::CommandLineOptions& command_line_options_template) override {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+    const auto* any =
+        Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestStepController>(config, command_line_options_template);

--- a/test/adaptive_load/plugin_loader_test.cc
+++ b/test/adaptive_load/plugin_loader_test.cc
@@ -7,6 +7,7 @@
 #include "nighthawk/adaptive_load/step_controller.h"
 
 #include "external/envoy/source/common/config/utility.h"
+#include "external/envoy/source/common/protobuf/protobuf.h"
 
 #include "api/adaptive_load/benchmark_result.pb.h"
 #include "api/adaptive_load/scoring_function_impl.pb.h"
@@ -37,9 +38,9 @@ const double kBadConfigThreshold = 98765.0;
  * @return Status InvalidArgument if threshold is kBadConfigThreshold, OK otherwise.
  */
 absl::Status DoValidateConfig(const Envoy::Protobuf::Message& message) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return config.threshold() == kBadConfigThreshold
              ? absl::InvalidArgumentError("input validation failed")
              : absl::OkStatus();
@@ -81,9 +82,9 @@ public:
 
   InputVariableSetterPtr
   createInputVariableSetter(const Envoy::Protobuf::Message& message) override {
-    const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackTo(any, config);
+    Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestInputVariableSetter>(config);
   }
 };
@@ -119,9 +120,9 @@ public:
     return DoValidateConfig(message);
   }
   ScoringFunctionPtr createScoringFunction(const Envoy::Protobuf::Message& message) override {
-    const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackTo(any, config);
+    Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestScoringFunction>(config);
   }
 };
@@ -158,9 +159,9 @@ public:
     return DoValidateConfig(message);
   }
   MetricsPluginPtr createMetricsPlugin(const Envoy::Protobuf::Message& message) override {
-    const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackTo(any, config);
+    Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestMetricsPlugin>(config);
   }
 };
@@ -208,9 +209,9 @@ public:
   StepControllerPtr createStepController(
       const Envoy::Protobuf::Message& message,
       const nighthawk::client::CommandLineOptions& command_line_options_template) override {
-    const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackTo(any, config);
+    Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestStepController>(config, command_line_options_template);
   }
 };

--- a/test/adaptive_load/plugin_loader_test.cc
+++ b/test/adaptive_load/plugin_loader_test.cc
@@ -38,7 +38,7 @@ const double kBadConfigThreshold = 98765.0;
  * @return Status InvalidArgument if threshold is kBadConfigThreshold, OK otherwise.
  */
 absl::Status DoValidateConfig(const Envoy::Protobuf::Message& message) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return config.threshold() == kBadConfigThreshold
@@ -82,7 +82,7 @@ public:
 
   InputVariableSetterPtr
   createInputVariableSetter(const Envoy::Protobuf::Message& message) override {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestInputVariableSetter>(config);
@@ -120,7 +120,7 @@ public:
     return DoValidateConfig(message);
   }
   ScoringFunctionPtr createScoringFunction(const Envoy::Protobuf::Message& message) override {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestScoringFunction>(config);
@@ -159,7 +159,7 @@ public:
     return DoValidateConfig(message);
   }
   MetricsPluginPtr createMetricsPlugin(const Envoy::Protobuf::Message& message) override {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestMetricsPlugin>(config);
@@ -209,7 +209,7 @@ public:
   StepControllerPtr createStepController(
       const Envoy::Protobuf::Message& message,
       const nighthawk::client::CommandLineOptions& command_line_options_template) override {
-    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+    const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
     Envoy::MessageUtil::unpackTo(*any, config);
     return std::make_unique<TestStepController>(config, command_line_options_template);

--- a/test/request_source/stub_plugin_impl.cc
+++ b/test/request_source/stub_plugin_impl.cc
@@ -1,6 +1,7 @@
 #include "test/request_source/stub_plugin_impl.h"
 
 #include "external/envoy/source/common/protobuf/message_validator_impl.h"
+#include "external/envoy/source/common/protobuf/protobuf.h"
 #include "external/envoy/source/common/protobuf/utility.h"
 #include "external/envoy/source/exe/platform_impl.h"
 
@@ -21,9 +22,9 @@ Envoy::ProtobufTypes::MessagePtr StubRequestSourcePluginConfigFactory::createEmp
 
 RequestSourcePtr StubRequestSourcePluginConfigFactory::createRequestSourcePlugin(
     const Envoy::Protobuf::Message& message, Envoy::Api::Api&, Envoy::Http::RequestHeaderMapPtr) {
-  const auto& any = dynamic_cast<const Envoy::ProtobufWkt::Any&>(message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::StubPluginConfig config;
-  Envoy::MessageUtil::unpackTo(any, config);
+  Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<StubRequestSource>(config);
 }
 

--- a/test/request_source/stub_plugin_impl.cc
+++ b/test/request_source/stub_plugin_impl.cc
@@ -22,7 +22,7 @@ Envoy::ProtobufTypes::MessagePtr StubRequestSourcePluginConfigFactory::createEmp
 
 RequestSourcePtr StubRequestSourcePluginConfigFactory::createRequestSourcePlugin(
     const Envoy::Protobuf::Message& message, Envoy::Api::Api&, Envoy::Http::RequestHeaderMapPtr) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<Envoy::ProtobufWkt::Any>(&message);
+  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::StubPluginConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<StubRequestSource>(config);

--- a/test/request_source/stub_plugin_impl.cc
+++ b/test/request_source/stub_plugin_impl.cc
@@ -22,7 +22,8 @@ Envoy::ProtobufTypes::MessagePtr StubRequestSourcePluginConfigFactory::createEmp
 
 RequestSourcePtr StubRequestSourcePluginConfigFactory::createRequestSourcePlugin(
     const Envoy::Protobuf::Message& message, Envoy::Api::Api&, Envoy::Http::RequestHeaderMapPtr) {
-  const auto* any = Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
+  const auto* any =
+      Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::StubPluginConfig config;
   Envoy::MessageUtil::unpackTo(*any, config);
   return std::make_unique<StubRequestSource>(config);


### PR DESCRIPTION
Nighthawk can use `Envoy::Protobuf::DynamicCastToGenerated` to track Envoy's preferred approach to casting proto `Message`.

See https://github.com/envoyproxy/envoy/blob/e61e461736a28e26b6fcf0ca25d34c47ed29b0fc/source/common/protobuf/protobuf.h#L96