### PR TITLE
Update Envoy to cd13b60 (Dec 21, 2023)

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -44,23 +44,22 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
 
-# TODO(tomjzzhang): Re-enable test_gcc
-# - stage: test_gcc
-#   dependsOn: ["check"]
-#   pool: "envoy-x64-large"
-#   jobs:
-#   - job: test_gcc
-#     displayName: "do_ci.sh"
-#     strategy:
-#       maxParallel: 1
-#       matrix:
-#         test_gcc:
-#           CI_TARGET: "test_gcc"
-#     timeoutInMinutes: 120
-#     steps:
-#     - template: bazel.yml
-#       parameters:
-#         ciTarget: $(CI_TARGET)
+- stage: test_gcc
+  dependsOn: ["check"]
+  pool: "envoy-x64-large"
+  jobs:
+  - job: test_gcc
+    displayName: "do_ci.sh"
+    strategy:
+      maxParallel: 1
+      matrix:
+        test_gcc:
+          CI_TARGET: "test_gcc"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
 
 - stage: sanitizers
   dependsOn: ["test"]
@@ -108,8 +107,7 @@ stages:
 # reported by https://github.com/envoyproxy/nighthawk/issues/1006
 - stage: release
   dependsOn:
-  # TODO(tomjzzhang): Re-enable test_gcc
-  # - "test_gcc"
+  - "test_gcc"
   - "sanitizers"
   - "coverage_unit"
   condition: eq(variables['PostSubmit'], true)

--- a/.bazelrc
+++ b/.bazelrc
@@ -368,7 +368,7 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:6eba113ee1a0ef8e4f71830e90b6aedbbeb7360c@sha256:d117d6139f3af1eede6bb1606ad05ffccb766eef3262b336dd31bcf02a81a669
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:7467652575122d8d54e767a68f141598bd855383@sha256:8781bc7e431b754c142edbfc937905fdf343db91f3fe19bbf54c362828db9849
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
@@ -529,7 +529,7 @@ build:rbe-envoy-engflow --grpc_keepalive_time=30s
 build:rbe-envoy-engflow --remote_timeout=3600s
 build:rbe-envoy-engflow --bes_timeout=3600s
 build:rbe-envoy-engflow --bes_upload_mode=fully_async
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:6eba113ee1a0ef8e4f71830e90b6aedbbeb7360c@sha256:d117d6139f3af1eede6bb1606ad05ffccb766eef3262b336dd31bcf02a81a669
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:7467652575122d8d54e767a68f141598bd855383@sha256:8781bc7e431b754c142edbfc937905fdf343db91f3fe19bbf54c362828db9849
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "b18ea4488a540aaab4979aea7ebeb252b77d4fe7"
-ENVOY_SHA = "d229fc9007aaef4057e0525a21b38841dfda24e17c690cefccfd537dd888b42e"
+ENVOY_COMMIT = "cd13b6045ea0fa9926173501d1cd27f93d19ade5"
+ENVOY_SHA = "edb9438482a7051630e764a77607c58997f8551f00baf292d465291a6254cf97"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -340,12 +340,6 @@ public:
     PANIC("NighthawkServerFactoryContext::overloadManager not implemented");
   }
 
-  Envoy::Server::Configuration::DownstreamHTTPFilterConfigProviderManagerSharedPtr
-  downstreamHttpFilterConfigProviderManager() override {
-    PANIC(
-        "NighthawkServerFactoryContext::downstreamHttpFilterConfigProviderManager not implemented");
-  }
-
   bool healthCheckFailed() const override {
     PANIC("NighthawkServerFactoryContext::healthCheckFailed not implemented");
   }

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -187,8 +187,9 @@ void StreamDecoder::setupForTracing() {
                                                                       random_generator_);
   uuid_generator.set(*headers_copy, true);
   uuid_generator.setTraceReason(*headers_copy, Envoy::Tracing::Reason::ClientForced);
-  active_span_ = tracer_->startSpan(config_, *headers_copy, stream_info_, tracing_decision);
-  active_span_->injectContext(*headers_copy, /*upstream=*/nullptr);
+  Envoy::Tracing::HttpTraceContext trace_context(*headers_copy);
+  active_span_ = tracer_->startSpan(config_, trace_context, stream_info_, tracing_decision);
+  active_span_->injectContext(trace_context, /*upstream=*/nullptr);
   request_headers_.reset(headers_copy.release());
   // We pass in a fake remote address; recently trace finalization mandates setting this, and will
   // segfault without it.


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update stream_decoder to support https://github.com/envoyproxy/envoy/pull/31141
- Update source/client/process_impl.cc to support https://github.com/envoyproxy/envoy/pull/31458
- Re-enable test_gcc target to resolve https://github.com/envoyproxy/nighthawk/issues/1049 since we've included https://github.com/envoyproxy/envoy/pull/31470

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>