### PR TITLE
Fix procedure for python dependency updates

### DIFF
--- a/docs/root/updating_envoy_dependency.md
+++ b/docs/root/updating_envoy_dependency.md
@@ -293,7 +293,8 @@ These should always be accompanied with a comment explaining them. Avoid using
 First attempt to remove all existing pins in
 [tools/base/requirements.in](/tools/base/requirements.in) to see if they are
 still necessary. Once done editing
-[tools/base/requirements.in](/tools/base/requirements.in), update the
+[tools/base/requirements.in](/tools/base/requirements.in), delete the contents
+of [tools/base/requirements.txt](/tools/base/requirements.txt) and update the
 dependencies by running:
 
 ```bash

--- a/docs/root/updating_envoy_dependency.md
+++ b/docs/root/updating_envoy_dependency.md
@@ -298,6 +298,7 @@ of [tools/base/requirements.txt](/tools/base/requirements.txt) and update the
 dependencies by running:
 
 ```bash
+echo > tools/base/requirements.txt
 bazel run //tools/base:requirements.update
 ```
 


### PR DESCRIPTION
Our current python dependency update command doesn't update the requirements.txt file when the file has contents.
Removing the contents allows for the it to be written with updated dependencies. 