### PR TITLE
Update Envoy to 7d047cd (Jan 16, 2024)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -369,7 +369,7 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:fd9ec000fdd72d5c5e4e4ef16db4f9103058779e@sha256:1386a26f687826850ba488d66a6cd5337c5941b3b8793d08cfa6f9df12aa2fcf
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:0ca52447572ee105a4730da5e76fe47c9c5a7c64@sha256:d736c58f06f36848e7966752cc7e01519cc1b5101a178d5c6634807e8ac3deab
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
@@ -530,7 +530,7 @@ build:rbe-envoy-engflow --grpc_keepalive_time=30s
 build:rbe-envoy-engflow --remote_timeout=3600s
 build:rbe-envoy-engflow --bes_timeout=3600s
 build:rbe-envoy-engflow --bes_upload_mode=fully_async
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:fd9ec000fdd72d5c5e4e4ef16db4f9103058779e@sha256:1386a26f687826850ba488d66a6cd5337c5941b3b8793d08cfa6f9df12aa2fcf
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:0ca52447572ee105a4730da5e76fe47c9c5a7c64@sha256:d736c58f06f36848e7966752cc7e01519cc1b5101a178d5c6634807e8ac3deab
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "bb126b88bdae5fd422dd53d3e4f8639980de3827"
-ENVOY_SHA = "f7b56936e9f36a40811bfbecf7329adaa9feea276b52244afe7fd1bf260bd370"
+ENVOY_COMMIT = "7d047cd1d09afb4211e7e6cc68a2c0e9ae63b8da"
+ENVOY_SHA = "1f950734840298ebddd921a54ee4de84afeb5609cc51210928c022e80a47c55c"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -110,7 +110,6 @@ paths:
     - source/common/network/address_impl.cc
     - source/common/network/utility.cc
     - source/common/network/dns_resolver/dns_factory_util.cc
-    - source/common/network/resolver_impl.cc
     - source/common/network/socket_impl.cc
     - source/common/ssl/tls_certificate_config_impl.cc
     - source/common/formatter/http_specific_formatter.cc
@@ -140,7 +139,6 @@ paths:
     - source/common/config/datasource.cc
     - source/common/config/utility.cc
     - source/common/runtime/runtime_impl.cc
-    - source/common/quic/quic_transport_socket_factory.cc
     - source/common/filter/config_discovery_impl.cc
     - source/common/json/json_internal.cc
     - source/common/router/scoped_rds.cc
@@ -148,7 +146,6 @@ paths:
     - source/common/router/scoped_config_impl.cc
     - source/common/router/router_ratelimit.cc
     - source/common/router/vhds.cc
-    - source/common/router/config_utility.cc
     - source/common/router/header_parser.cc
     - source/common/filesystem/inotify/watcher_impl.cc
     - source/common/filesystem/posix/directory_iterator_impl.cc


### PR DESCRIPTION
- Upstream removed some files from `tools/code_format/config.yaml`
- Trivial `.bazelrc` hash updates
- Trivial `bazel/repositories.bzl` Docker hash updates