### PR TITLE
Update Envoy to 5c821fe (Jan 29, 2024)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "dcba1835367931bb4ba663cda6adcb754535c229"
-ENVOY_SHA = "d59a9629129c907055c4ed8b6ef27e21f9cbcbd44453ac5391b045e8422d448e"
+ENVOY_COMMIT = "5c821febbbba530315295a3c3dd3481364f89890"
+ENVOY_SHA = "6b86be668942d1f0a98757fba7b0e4e0e0b06b2741db0e8cba9ae2ecd3a7fd07"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -110,7 +110,6 @@ paths:
     - source/common/network/address_impl.cc
     - source/common/network/utility.cc
     - source/common/network/dns_resolver/dns_factory_util.cc
-    - source/common/network/socket_impl.cc
     - source/common/ssl/tls_certificate_config_impl.cc
     - source/common/formatter/http_specific_formatter.cc
     - source/common/formatter/stream_info_formatter.h
@@ -129,6 +128,7 @@ paths:
     - source/common/protobuf/visitor.cc
     - source/common/protobuf/utility.cc
     - source/common/protobuf/message_validator_impl.cc
+    - source/common/quic/quic_server_transport_socket_factory.cc
     - source/common/access_log/access_log_manager_impl.cc
     - source/common/secret/secret_manager_impl.cc
     - source/common/grpc/async_client_manager_impl.cc
@@ -137,7 +137,6 @@ paths:
     - source/common/config/subscription_factory_impl.cc
     - source/common/config/xds_resource.cc
     - source/common/config/datasource.cc
-    - source/common/config/utility.cc
     - source/common/runtime/runtime_impl.cc
     - source/common/filter/config_discovery_impl.cc
     - source/common/json/json_internal.cc
@@ -145,7 +144,6 @@ paths:
     - source/common/router/config_impl.cc
     - source/common/router/scoped_config_impl.cc
     - source/common/router/router_ratelimit.cc
-    - source/common/router/vhds.cc
     - source/common/router/header_parser.cc
     - source/common/filesystem/inotify/watcher_impl.cc
     - source/common/filesystem/posix/directory_iterator_impl.cc
@@ -164,7 +162,12 @@ paths:
     - source/server/hot_restarting_base.cc
     - source/server/hot_restart_impl.cc
     - source/server/ssl_context_manager.cc
-    - source/server/configuration_impl.cc
+    - source/server/config_validation/cluster_manager.cc
+    - source/common/upstream/health_discovery_service.cc
+    - source/common/secret/sds_api.h
+    - source/common/secret/sds_api.cc
+    - source/common/router/router.cc
+    - source/common/config/config_provider_impl.h
 
   # Only one C++ file should instantiate grpc_init
   grpc_init:


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update to tools/code_format/config.yaml to https://github.com/envoyproxy/envoy/pull/32022