### PR TITLE
Update Envoy to 66ed827 (Feb 23, 2024)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -521,16 +521,18 @@ build:rbe-engflow --remote_timeout=3600s
 build:rbe-engflow --bes_timeout=3600s
 build:rbe-engflow --bes_upload_mode=fully_async
 
-build:rbe-envoy-engflow --google_default_credentials=false
-build:rbe-envoy-engflow --remote_cache=grpcs://morganite.cluster.engflow.com
+build:cache-envoy-engflow --google_default_credentials=false
+build:cache-envoy-engflow --remote_cache=grpcs://morganite.cluster.engflow.com
+build:cache-envoy-engflow --remote_timeout=3600s
+build:cache-envoy-engflow --credential_helper=*.engflow.com=%workspace%/bazel/engflow-bazel-credential-helper.sh
+build:cache-envoy-engflow --grpc_keepalive_time=30s
+build:bes-envoy-engflow --bes_backend=grpcs://morganite.cluster.engflow.com/
+build:bes-envoy-engflow --bes_results_url=https://morganite.cluster.engflow.com/invocation/
+build:bes-envoy-engflow --bes_timeout=3600s
+build:bes-envoy-engflow --bes_upload_mode=fully_async
+build:rbe-envoy-engflow --config=cache-envoy-engflow
+build:rbe-envoy-engflow --config=bes-envoy-engflow
 build:rbe-envoy-engflow --remote_executor=grpcs://morganite.cluster.engflow.com
-build:rbe-envoy-engflow --bes_backend=grpcs://morganite.cluster.engflow.com/
-build:rbe-envoy-engflow --bes_results_url=https://morganite.cluster.engflow.com/invocation/
-build:rbe-envoy-engflow --credential_helper=*.engflow.com=%workspace%/bazel/engflow-bazel-credential-helper.sh
-build:rbe-envoy-engflow --grpc_keepalive_time=30s
-build:rbe-envoy-engflow --remote_timeout=3600s
-build:rbe-envoy-engflow --bes_timeout=3600s
-build:rbe-envoy-engflow --bes_upload_mode=fully_async
 build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:0ca52447572ee105a4730da5e76fe47c9c5a7c64@sha256:d736c58f06f36848e7966752cc7e01519cc1b5101a178d5c6634807e8ac3deab
 
 #############################################################################

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "7c410102b1a97b439c8b86bc10c0c5059a408ca3"
-ENVOY_SHA = "ffb0018c01c13978dc2571fa26dfc49687cea9dad3a9bbb45cdcba2025d988bf"
+ENVOY_COMMIT = "66ed82767e6d9a8b33d09f481ded689021c2668b"
+ENVOY_SHA = "c09d8ae2eb9e56fa73562cf03325c9c67fa08aa3963fd5e3bd94bef96f507100"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
- Updated `.bazelrc`
- no changes in `.bazelversion`, `ci/run_envoy_docker.sh.`, `tools/gen_compilation_database.py` or `tools/gen_compilation_database.py`

Signed-off-by: Sebastian Avila <sebastianavila@google.com>
