### PR TITLE
Update Envoy to e28e0d6 (Mar 05, 2024)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -73,7 +73,7 @@ common --experimental_allow_tags_propagation
 build:linux --copt=-fdebug-types-section
 build:linux --copt=-fPIC
 build:linux --copt=-Wno-deprecated-declarations
-build:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+build:linux --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
 build:linux --cxxopt=-fsized-deallocation --host_cxxopt=-fsized-deallocation
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
@@ -144,7 +144,7 @@ build:clang-asan --linkopt --rtlib=compiler-rt
 build:clang-asan --linkopt --unwindlib=libgcc
 
 # macOS
-build:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+build:linux --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
 build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --define tcmalloc=disabled
@@ -205,7 +205,7 @@ build:libc++ --define force_libcpp=enabled
 
 build:libc++20 --config=libc++
 # gRPC has a lot of deprecated-enum-enum-conversion warning. Remove once it is addressed
-build:libc++20 --cxxopt=-std=c++20 --copt=-Wno-error=deprecated-enum-enum-conversion
+build:libc++20 --copt=-Wno-error=deprecated-enum-enum-conversion
 
 # Optimize build for binary size reduction.
 build:sizeopt -c opt --copt -Os

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "66ed82767e6d9a8b33d09f481ded689021c2668b"
-ENVOY_SHA = "c09d8ae2eb9e56fa73562cf03325c9c67fa08aa3963fd5e3bd94bef96f507100"
+ENVOY_COMMIT = "e28e0d67fc9f9f677b644f940320c5c01bf057c9"
+ENVOY_SHA = "b37f2e2eee9c7b1dd8f0eac76f0e086675e919d8e298fd3fac5d8d03128900d1"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -21,6 +21,7 @@
 #include "external/envoy/source/common/api/api_impl.h"
 #include "external/envoy/source/common/common/cleanup.h"
 #include "external/envoy/source/common/common/statusor.h"
+#include "external/envoy/source/common/config/stats_utility.h"
 #include "external/envoy/source/common/config/utility.h"
 #include "external/envoy/source/common/event/dispatcher_impl.h"
 #include "external/envoy/source/common/event/real_time_system.h"
@@ -804,7 +805,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const UriPtr& tracing_
     // the objects that require stats.
     if (!options_.statsSinks().empty()) {
       store_root_.setTagProducer(
-          Envoy::Config::Utility::createTagProducer(bootstrap_, envoy_options_.statsTags()));
+          Envoy::Config::StatsUtility::createTagProducer(bootstrap_, envoy_options_.statsTags()));
     }
 
     absl::Status workers_status = createWorkers(number_of_workers_, scheduled_start);

--- a/source/client/stream_decoder.cc
+++ b/source/client/stream_decoder.cc
@@ -10,6 +10,12 @@
 
 #include "fmt/ostream.h"
 
+// NOLINT(namespace-nighthawk)
+namespace fmt {
+// Allow fmtlib to use operator << defined in HeaderMapPtr.
+template <> struct formatter<::Nighthawk::HeaderMapPtr> : ostream_formatter {};
+} // namespace fmt
+
 namespace Nighthawk {
 namespace Client {
 
@@ -200,9 +206,3 @@ void StreamDecoder::setupForTracing() {
 
 } // namespace Client
 } // namespace Nighthawk
-
-// NOLINT(namespace-nighthawk)
-namespace fmt {
-// Allow fmtlib to use operator << defined in HeaderMapPtr.
-template <> struct formatter<::Nighthawk::HeaderMapPtr> : ostream_formatter {};
-} // namespace fmt

--- a/source/sink/sink_impl.cc
+++ b/source/sink/sink_impl.cc
@@ -7,6 +7,14 @@
 #include "external/envoy/source/common/common/logger.h"
 #include "external/envoy/source/common/common/random_generator.h"
 
+#include "fmt/ostream.h"
+
+// NOLINT(namespace-nighthawk)
+namespace fmt {
+// Allow fmtlib to use operator << defined in std::filesystem::path.
+template <> struct formatter<::std::filesystem::path> : ostream_formatter {};
+} // namespace fmt
+
 namespace Nighthawk {
 namespace {
 
@@ -137,9 +145,3 @@ InMemorySinkImpl::LoadExecutionResult(absl::string_view execution_id) const {
 }
 
 } // namespace Nighthawk
-
-// NOLINT(namespace-nighthawk)
-namespace fmt {
-// Allow fmtlib to use operator << defined in std::filesystem::path.
-template <> struct formatter<::std::filesystem::path> : ostream_formatter {};
-} // namespace fmt

--- a/source/user_defined_output/BUILD
+++ b/source/user_defined_output/BUILD
@@ -42,5 +42,6 @@ envoy_cc_library(
         "@envoy//envoy/config:typed_config_interface",
         "@envoy//source/common/common:statusor_lib_with_external_headers",
         "@envoy//source/common/config:utility_lib_with_external_headers",
+        "@envoy//source/common/http:utility_lib",
     ],
 )

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -1,4 +1,4 @@
-# Last updated 2024-02-02
+# Last updated 2024-03-04
 apipkg
 attrs
 certifi

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -186,9 +186,9 @@ pyflakes==3.2.0 \
     --hash=sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f \
     --hash=sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a
     # via flake8
-pytest==8.0.0 \
-    --hash=sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c \
-    --hash=sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6
+pytest==8.0.2 \
+    --hash=sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd \
+    --hash=sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096
     # via
     #   -r tools/base/requirements.in
     #   pytest-dependency
@@ -269,9 +269,9 @@ tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via yapf
-urllib3==2.2.0 \
-    --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20 \
-    --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224
+urllib3==2.2.1 \
+    --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d \
+    --hash=sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19
     # via
     #   -r tools/base/requirements.in
     #   requests
@@ -287,7 +287,7 @@ zipp==3.17.0 \
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==69.0.3 \
-    --hash=sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05 \
-    --hash=sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78
+setuptools==69.1.1 \
+    --hash=sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56 \
+    --hash=sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8
     # via pytest-dependency

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -134,7 +134,6 @@ paths:
     - source/common/tcp_proxy/tcp_proxy.cc
     - source/common/config/subscription_factory_impl.cc
     - source/common/config/xds_resource.cc
-    - source/common/config/datasource.cc
     - source/common/runtime/runtime_impl.cc
     - source/common/filter/config_discovery_impl.cc
     - source/common/json/json_internal.cc
@@ -164,6 +163,7 @@ paths:
     - source/common/upstream/health_discovery_service.cc
     - source/common/secret/sds_api.h
     - source/common/secret/sds_api.cc
+    - source/common/secret/secret_provider_impl.cc
     - source/common/router/router.cc
     - source/common/config/config_provider_impl.h
     - source/common/common/logger_delegates.cc

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -102,8 +102,8 @@ def modify_compile_command(target, args):
         # depend on Envoy targets.
         if not target["file"].startswith("external/") or target["file"].startswith(
                 "external/envoy"):
-            # *.h file is treated as C header by default while our headers files are all C++17.
-            options = "-x c++ -std=c++17 -fexceptions " + options
+            # *.h file is treated as C header by default while our headers files are all C++20.
+            options = "-x c++ -std=c++20 -fexceptions " + options
 
     target["command"] = " ".join([cc, options])
     return target


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update to .bazelrc and tools/gen_compilation_database.py to https://github.com/envoyproxy/envoy/pull/32585
- Update source/client/process_impl.cc to accommodate refactor in https://github.com/envoyproxy/envoy/pull/32587
- Update tools/code_format/config.yaml for changes in https://github.com/envoyproxy/envoy/pull/32625 and https://github.com/envoyproxy/envoy/pull/32252
- Update python dependencies
- Ensure ostream_formatter definitions are before usage to prevent "explicit specialization of X after instantiation" errors
