### PR TITLE
Update Dockerfile-nighthawk

### DIFF
--- a/ci/docker/Dockerfile-nighthawk
+++ b/ci/docker/Dockerfile-nighthawk
@@ -4,6 +4,7 @@ ADD nighthawk_client /usr/local/bin/nighthawk_client
 ADD nighthawk_test_server /usr/local/bin/nighthawk_test_server
 ADD nighthawk_output_transform /usr/local/bin/nighthawk_output_transform
 ADD nighthawk_service /usr/local/bin/nighthawk_service
+ADD nighthawk_adaptive_load_client /usr/local/bin/nighthawk_adaptive_load_client
 ADD default-config.yaml /etc/envoy/envoy.yaml
 
 # Ports for nighthawk_test_server, see default-config.yaml


### PR DESCRIPTION
This is an addendum to https://github.com/envoyproxy/nighthawk/pull/1089

This actually makes sure that the docker image that gets pushed from CI will contain the binary which is now available.
Sorry, this should have gone into the PR mentioned above. 