### PR TITLE
Update Envoy to 38c5c86 (Mar 25, 2024)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -370,7 +370,7 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:0ca52447572ee105a4730da5e76fe47c9c5a7c64@sha256:d736c58f06f36848e7966752cc7e01519cc1b5101a178d5c6634807e8ac3deab
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:f94a38f62220a2b017878b790b6ea98a0f6c5f9c@sha256:2dd96b6f43c08ccabd5f4747fce5854f5f96af509b32e5cf6493f136e9833649
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
@@ -534,7 +534,7 @@ build:bes-envoy-engflow --bes_upload_mode=fully_async
 build:rbe-envoy-engflow --config=cache-envoy-engflow
 build:rbe-envoy-engflow --config=bes-envoy-engflow
 build:rbe-envoy-engflow --remote_executor=grpcs://morganite.cluster.engflow.com
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:0ca52447572ee105a4730da5e76fe47c9c5a7c64@sha256:d736c58f06f36848e7966752cc7e01519cc1b5101a178d5c6634807e8ac3deab
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:f94a38f62220a2b017878b790b6ea98a0f6c5f9c@sha256:2dd96b6f43c08ccabd5f4747fce5854f5f96af509b32e5cf6493f136e9833649
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "efd9bef80764663be31b115301812a5bb647fad5"
-ENVOY_SHA = "424017e3dd804d3e0ec46aa84e009c413fb6a51ade43ac8339b5a73e1a5d3107"
+ENVOY_COMMIT = "38c5c867ab92c60bb0fc32bde0f6565516ba0ff4"
+ENVOY_SHA = "f6fb93e9c11c13bbee2234ffc43c6f525f3dd1294516885559bc930211f9b336"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -375,7 +375,7 @@ private:
   Envoy::ProtobufMessage::ProdValidationContextImpl& validation_context_;
   Envoy::Grpc::Context& grpc_context_;
   Envoy::Router::Context& router_context_;
-  StatsConfigImpl stats_config_;  // Using the default value.
+  StatsConfigImpl stats_config_; // Using the default value.
   Envoy::Stats::Scope& server_scope_;
 };
 

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -223,7 +223,9 @@ public:
   Envoy::ProtobufMessage::ValidationContext& messageValidationContext() override {
     return validation_context_;
   }
-  Envoy::Server::Configuration::StatsConfig& statsConfig() override { return stats_config_; }
+  Envoy::Server::Configuration::StatsConfig& statsConfig() override {
+    PANIC("NighthawkServerInstance::statsConfig not implemented");
+  }
   envoy::config::bootstrap::v3::Bootstrap& bootstrap() override {
     PANIC("NighthawkServerInstance::bootstrap not implemented");
   }
@@ -260,7 +262,6 @@ private:
   Envoy::ProtobufMessage::ProdValidationContextImpl& validation_context_;
   Envoy::Grpc::Context& grpc_context_;
   Envoy::Router::Context& router_context_;
-  StatsConfigImpl stats_config_;
   Envoy::Server::Configuration::ServerFactoryContext& server_factory_context_;
 };
 
@@ -374,7 +375,7 @@ private:
   Envoy::ProtobufMessage::ProdValidationContextImpl& validation_context_;
   Envoy::Grpc::Context& grpc_context_;
   Envoy::Router::Context& router_context_;
-  StatsConfigImpl stats_config_;
+  StatsConfigImpl stats_config_;  // Using the default value.
   Envoy::Stats::Scope& server_scope_;
 };
 

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -229,6 +229,9 @@ public:
   }
   void setServerFactoryContext(
       Envoy::Server::Configuration::ServerFactoryContext& server_factory_context) {
+    RELEASE_ASSERT(server_factory_context_ != nullptr,
+                   "Mutual pointers between NighthawkServerInstance and "
+                   "NighthawkServerFactoryContext were not correctly set");
     server_factory_context_ = &server_factory_context;
   }
   Envoy::Server::Configuration::ServerFactoryContext& serverFactoryContext() override {
@@ -266,7 +269,7 @@ private:
   Envoy::Router::Context& router_context_;
   StatsConfigImpl stats_config_;
   // Lifetime managed by ProcessImpl
-  Envoy::Server::Configuration::ServerFactoryContext* server_factory_context_;
+  Envoy::Server::Configuration::ServerFactoryContext* server_factory_context_ = nullptr;
 };
 
 // Implementation of Envoy::Server::Configuration::ServerFactoryContext.

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -229,12 +229,12 @@ public:
   }
   void setServerFactoryContext(
       Envoy::Server::Configuration::ServerFactoryContext& server_factory_context) {
-    RELEASE_ASSERT(server_factory_context_ != nullptr,
-                   "Mutual pointers between NighthawkServerInstance and "
-                   "NighthawkServerFactoryContext were not correctly set");
     server_factory_context_ = &server_factory_context;
   }
   Envoy::Server::Configuration::ServerFactoryContext& serverFactoryContext() override {
+    RELEASE_ASSERT(server_factory_context_ != nullptr,
+                   "Mutual pointers between NighthawkServerInstance and "
+                   "NighthawkServerFactoryContext were not correctly set");
     return *server_factory_context_;
   }
   Envoy::Server::Configuration::TransportSocketFactoryContext&

--- a/source/server/http_dynamic_delay_filter.cc
+++ b/source/server/http_dynamic_delay_filter.cc
@@ -74,10 +74,10 @@ computeEffectiveConfiguration(std::shared_ptr<const DynamicDelayConfiguration> b
 HttpDynamicDelayDecoderFilterConfig::HttpDynamicDelayDecoderFilterConfig(
     const DynamicDelayConfiguration& proto_config, Envoy::Runtime::Loader& runtime,
     const std::string& stats_prefix, Envoy::Stats::Scope& scope,
-    Envoy::Server::Configuration::ServerFactoryContext& server_factory_context)
+    Envoy::Server::Configuration::CommonFactoryContext& common_factory_context)
     : FilterConfigurationBase("dynamic-delay"), runtime_(runtime),
       stats_prefix_(absl::StrCat(stats_prefix, fmt::format("{}.", filter_name()))), scope_(scope),
-      server_factory_context_(server_factory_context),
+      common_factory_context_(common_factory_context),
       server_config_(std::make_shared<DynamicDelayConfiguration>(proto_config)) {}
 
 std::shared_ptr<const DynamicDelayConfiguration>
@@ -166,7 +166,7 @@ HttpDynamicDelayDecoderFilter::translateOurConfigIntoFaultFilterConfig(
   fault_config.mutable_delay()->mutable_percentage()->set_numerator(100);
   fault_config.mutable_delay()->mutable_header_delay();
   return std::make_shared<Envoy::Extensions::HttpFilters::Fault::FaultFilterConfig>(
-      fault_config, config.stats_prefix(), config.scope(), config.server_factory_context());
+      fault_config, config.stats_prefix(), config.scope(), config.common_factory_context());
 }
 
 void HttpDynamicDelayDecoderFilter::setDecoderFilterCallbacks(

--- a/source/server/http_dynamic_delay_filter.cc
+++ b/source/server/http_dynamic_delay_filter.cc
@@ -73,10 +73,11 @@ computeEffectiveConfiguration(std::shared_ptr<const DynamicDelayConfiguration> b
 
 HttpDynamicDelayDecoderFilterConfig::HttpDynamicDelayDecoderFilterConfig(
     const DynamicDelayConfiguration& proto_config, Envoy::Runtime::Loader& runtime,
-    const std::string& stats_prefix, Envoy::Stats::Scope& scope, Envoy::TimeSource& time_source)
+    const std::string& stats_prefix, Envoy::Stats::Scope& scope,
+    Envoy::Server::Configuration::ServerFactoryContext& server_factory_context)
     : FilterConfigurationBase("dynamic-delay"), runtime_(runtime),
       stats_prefix_(absl::StrCat(stats_prefix, fmt::format("{}.", filter_name()))), scope_(scope),
-      time_source_(time_source),
+      server_factory_context_(server_factory_context),
       server_config_(std::make_shared<DynamicDelayConfiguration>(proto_config)) {}
 
 std::shared_ptr<const DynamicDelayConfiguration>
@@ -165,7 +166,7 @@ HttpDynamicDelayDecoderFilter::translateOurConfigIntoFaultFilterConfig(
   fault_config.mutable_delay()->mutable_percentage()->set_numerator(100);
   fault_config.mutable_delay()->mutable_header_delay();
   return std::make_shared<Envoy::Extensions::HttpFilters::Fault::FaultFilterConfig>(
-      fault_config, config.runtime(), config.stats_prefix(), config.scope(), config.time_source());
+      fault_config, config.stats_prefix(), config.scope(), config.server_factory_context());
 }
 
 void HttpDynamicDelayDecoderFilter::setDecoderFilterCallbacks(

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -67,7 +67,7 @@ public:
   Envoy::Stats::Scope& scope() { return scope_; }
 
   /**
-   * @return Envoy::Server::Configuration::ServerFactoryContext& to be used by filter
+   * @return Envoy::Server::Configuration::CommonFactoryContext& to be used by filter
    * instantiations associated to this.
    */
   Envoy::Server::Configuration::CommonFactoryContext& common_factory_context() {

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -34,12 +34,12 @@ public:
    * @param stats_prefix Prefix to use by the filter when it names statistics. E.g.
    * dynamic-delay.fault.delays_injected: 1
    * @param scope Statistics scope to be used by the filter.
-   * @param time_source Time source to be used by the filter.
+   * @param server_factory_context ServerFactoryContext to be used by the filter.
    */
   HttpDynamicDelayDecoderFilterConfig(
       const nighthawk::server::DynamicDelayConfiguration& proto_config,
       Envoy::Runtime::Loader& runtime, const std::string& stats_prefix, Envoy::Stats::Scope& scope,
-      Envoy::TimeSource& time_source);
+      Envoy::Server::Configuration::ServerFactoryContext& server_factory_context);
   /**
    * Increments the number of globally active filter instances.
    */
@@ -67,9 +67,17 @@ public:
   Envoy::Stats::Scope& scope() { return scope_; }
 
   /**
+   * @return Envoy::Server::Configuration::ServerFactoryContext& to be used by filter
+   * instantiations associated to this.
+   */
+  Envoy::Server::Configuration::ServerFactoryContext& server_factory_context() {
+    return server_factory_context_;
+  }
+
+  /**
    * @return Envoy::TimeSource& to be used by filter instantiations associated to this.
    */
-  Envoy::TimeSource& time_source() { return time_source_; }
+  // Envoy::TimeSource& time_source() { return server_factory_context_.timeSource(); }
 
   /**
    * @return std::string to be used by filter instantiations associated to this.
@@ -92,7 +100,7 @@ private:
   Envoy::Runtime::Loader& runtime_;
   const std::string stats_prefix_;
   Envoy::Stats::Scope& scope_;
-  Envoy::TimeSource& time_source_;
+  Envoy::Server::Configuration::ServerFactoryContext& server_factory_context_;
   std::shared_ptr<const nighthawk::server::DynamicDelayConfiguration> server_config_;
 };
 

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -34,7 +34,7 @@ public:
    * @param stats_prefix Prefix to use by the filter when it names statistics. E.g.
    * dynamic-delay.fault.delays_injected: 1
    * @param scope Statistics scope to be used by the filter.
-   * @param server_factory_context ServerFactoryContext to be used by the filter.
+   * @param common_factory_context CommonFactoryContext to be used by the filter.
    */
   HttpDynamicDelayDecoderFilterConfig(
       const nighthawk::server::DynamicDelayConfiguration& proto_config,

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -39,7 +39,7 @@ public:
   HttpDynamicDelayDecoderFilterConfig(
       const nighthawk::server::DynamicDelayConfiguration& proto_config,
       Envoy::Runtime::Loader& runtime, const std::string& stats_prefix, Envoy::Stats::Scope& scope,
-      Envoy::Server::Configuration::ServerFactoryContext& server_factory_context);
+      Envoy::Server::Configuration::CommonFactoryContext& common_factory_context);
   /**
    * Increments the number of globally active filter instances.
    */
@@ -70,8 +70,8 @@ public:
    * @return Envoy::Server::Configuration::ServerFactoryContext& to be used by filter
    * instantiations associated to this.
    */
-  Envoy::Server::Configuration::ServerFactoryContext& server_factory_context() {
-    return server_factory_context_;
+  Envoy::Server::Configuration::CommonFactoryContext& common_factory_context() {
+    return common_factory_context_;
   }
 
   /**
@@ -95,7 +95,7 @@ private:
   Envoy::Runtime::Loader& runtime_;
   const std::string stats_prefix_;
   Envoy::Stats::Scope& scope_;
-  Envoy::Server::Configuration::ServerFactoryContext& server_factory_context_;
+  Envoy::Server::Configuration::CommonFactoryContext& common_factory_context_;
   std::shared_ptr<const nighthawk::server::DynamicDelayConfiguration> server_config_;
 };
 

--- a/source/server/http_dynamic_delay_filter.h
+++ b/source/server/http_dynamic_delay_filter.h
@@ -75,11 +75,6 @@ public:
   }
 
   /**
-   * @return Envoy::TimeSource& to be used by filter instantiations associated to this.
-   */
-  // Envoy::TimeSource& time_source() { return server_factory_context_.timeSource(); }
-
-  /**
    * @return std::string to be used by filter instantiations associated to this.
    */
   std::string stats_prefix() { return stats_prefix_; }

--- a/source/server/http_dynamic_delay_filter_config.cc
+++ b/source/server/http_dynamic_delay_filter_config.cc
@@ -43,7 +43,7 @@ private:
         std::make_shared<Nighthawk::Server::HttpDynamicDelayDecoderFilterConfig>(
             Nighthawk::Server::HttpDynamicDelayDecoderFilterConfig(
                 proto_config, context.serverFactoryContext().runtime(), "" /*stats_prefix*/,
-                context.scope(), context.serverFactoryContext().timeSource()));
+                context.scope(), context.serverFactoryContext()));
 
     return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
       auto* filter = new Nighthawk::Server::HttpDynamicDelayDecoderFilter(config);

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -133,19 +133,16 @@ paths:
     - source/common/tcp_proxy/tcp_proxy.cc
     - source/common/config/subscription_factory_impl.cc
     - source/common/config/xds_resource.cc
-    - source/common/runtime/runtime_impl.cc
     - source/common/filter/config_discovery_impl.cc
     - source/common/json/json_internal.cc
     - source/common/router/scoped_rds.cc
     - source/common/router/config_impl.cc
     - source/common/router/scoped_config_impl.cc
-    - source/common/router/router_ratelimit.cc
     - source/common/router/header_parser.cc
-    - source/common/filesystem/inotify/watcher_impl.cc
     - source/common/filesystem/posix/directory_iterator_impl.cc
+    - source/common/filesystem/inotify/watcher_impl.cc
     - source/common/filesystem/kqueue/watcher_impl.cc
     - source/common/filesystem/win32/directory_iterator_impl.cc
-    - source/common/filesystem/win32/watcher_impl.cc
     - source/common/common/utility.cc
     - source/common/common/regex.cc
     - source/common/common/matchers.cc
@@ -154,6 +151,7 @@ paths:
     - source/server/overload_manager_impl.cc
     - source/server/config_validation/server.cc
     - source/server/admin/html/active_stats.js
+    - source/server/admin/runtime_handler.cc
     - source/server/server.cc
     - source/server/hot_restarting_base.cc
     - source/server/hot_restart_impl.cc
@@ -173,6 +171,7 @@ paths:
     - source/common/local_reply/local_reply.cc
     - source/common/tls/context_impl.cc
     - source/common/tls/context_config_impl.cc
+    - source/common/config/watched_directory.cc
 
   # Only one C++ file should instantiate grpc_init
   grpc_init:


### PR DESCRIPTION
- `.bazelrc` updated from upstream
- `tools/code_format/config.yaml` updated from upstream
- In an incredibly confusing refactor:
  - Envoy's `FaultFilterConfig` started taking a `CommonFactoryContext` instead of a `Runtime` and `TimeSource`. 
      - Updated `HttpDynamicDelayDecoderFilterConfig` to store a `CommonFactoryContext&` instead of a `TimeSource&`, so that it has a `CommonFactoryContext&` to use when constructing a `FaultFilterConfig`.
        - How to get a `CommonFactoryContext` when creating the `HttpDynamicDelayDecoderFilterConfig`? `HttpDynamicDelayDecoderFilterConfigFactory` has access to a `Envoy::Server::Configuration::FactoryContext`, which has a `serverFactoryContext()` method. `ServerFactoryContext` is a subclass of `CommonFactoryContext`.
  - Envoy has started calling `serverFactoryContext()` on the `NighthawkServerInstance`, which had a `PANIC` placeholder there. This was discovered in the integration tests.
    - Gave `NighthawkServerInstance` a reference to a `NighthawkServerFactoryContext` to return in  `serverFactoryContext()`, replacing the `PANIC` placeholder.
    - In order to remove a circular dependency, took away `NighthawkServerFactoryContext`'s reference to a  `NighthawkServerInstance`, to which it delegated many calls. Now `NighthawkServerFactoryContext` stores its own references to the underlying objects formerly wrapped in the `NighthawkServerInstance`.
  - I originally assumed the above two things were related, but it appears that both arose here by coincidence. 
