### PR TITLE
Update Envoy to 1f52a8e (Mar 29, 2024)

### DIFF
--- a/bazel/python_dependencies.bzl
+++ b/bazel/python_dependencies.bzl
@@ -1,5 +1,5 @@
-load("@rules_python//python:pip.bzl", "pip_parse")
 load("@python3_11//:defs.bzl", "interpreter")
+load("@rules_python//python:pip.bzl", "pip_parse")
 
 def nighthawk_python_dependencies():
     pip_parse(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "38c5c867ab92c60bb0fc32bde0f6565516ba0ff4"
-ENVOY_SHA = "f6fb93e9c11c13bbee2234ffc43c6f525f3dd1294516885559bc930211f9b336"
+ENVOY_COMMIT = "1f52a8e3c7fe1719ea83e1d79755e2de0f9689b4"
+ENVOY_SHA = "abfdbc199535c340eb1f9ab894ecd56f8aabc0db2019d04870241189b06c9e08"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/dynamic_config/BUILD
+++ b/dynamic_config/BUILD
@@ -1,5 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@nh_pip3//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/source/adaptive_load/input_variable_setter_impl.cc
+++ b/source/adaptive_load/input_variable_setter_impl.cc
@@ -34,7 +34,7 @@ InputVariableSetterPtr RequestsPerSecondInputVariableSetterConfigFactory::create
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::RequestsPerSecondInputVariableSetterConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return std::make_unique<RequestsPerSecondInputVariableSetter>(config);
 }
 

--- a/source/adaptive_load/scoring_function_impl.cc
+++ b/source/adaptive_load/scoring_function_impl.cc
@@ -19,7 +19,7 @@ BinaryScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf:
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::BinaryScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return std::make_unique<BinaryScoringFunction>(config);
 }
 
@@ -52,7 +52,7 @@ LinearScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf:
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return std::make_unique<LinearScoringFunction>(config);
 }
 

--- a/source/adaptive_load/step_controller_impl.cc
+++ b/source/adaptive_load/step_controller_impl.cc
@@ -53,7 +53,7 @@ absl::Status ExponentialSearchStepControllerConfigFactory::ValidateConfig(
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   if (config.has_input_variable_setter()) {
     return LoadInputVariableSetterPlugin(config.input_variable_setter()).status();
   }
@@ -66,7 +66,7 @@ StepControllerPtr ExponentialSearchStepControllerConfigFactory::createStepContro
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return std::make_unique<ExponentialSearchStepController>(config, command_line_options_template);
 }
 

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -129,10 +129,16 @@ private:
 
 // A fake ServerLifecycleNotifier. Because it does nothing, it's safe to just create
 // multiple instances of it, rather than manage the lifetime of a single one.
-class LifecycleNotifierImpl : public Envoy::Server::ServerLifecycleNotifier {
+class NighthawkLifecycleNotifierImpl : public Envoy::Server::ServerLifecycleNotifier {
 public:
-  HandlePtr registerCallback(Stage, StageCallback) override { return nullptr; }
-  HandlePtr registerCallback(Stage, StageCallbackWithCompletion) override { return nullptr; }
+  HandlePtr registerCallback(Stage, StageCallback) override {
+    PANIC(
+        "NighthawkLifecycleNotifierImpl::registerCallbacki(Stage, StageCallback) not implemented");
+  }
+  HandlePtr registerCallback(Stage, StageCallbackWithCompletion) override {
+    PANIC("NighthawkLifecycleNotifierImpl::registerCallback(Stage, StageCallbackWithCompletion) "
+          "not implemented");
+  }
 };
 
 // Implementation of Envoy::Server::Instance. Only methods used by Envoy's code
@@ -272,7 +278,7 @@ private:
   Envoy::Grpc::Context& grpc_context_;
   Envoy::Router::Context& router_context_;
   Envoy::Server::Configuration::ServerFactoryContext& server_factory_context_;
-  LifecycleNotifierImpl lifecycle_notifier_; // A no-op object that lives here.
+  NighthawkLifecycleNotifierImpl lifecycle_notifier_; // A no-op object that lives here.
 };
 
 // Implementation of Envoy::Server::Configuration::ServerFactoryContext.
@@ -385,8 +391,8 @@ private:
   Envoy::Router::Context& router_context_;
   StatsConfigImpl stats_config_; // Using the object created here.
   Envoy::Stats::Scope& server_scope_;
-  LifecycleNotifierImpl lifecycle_notifier_;  // A no-op object that lives here.
-  Envoy::Regex::GoogleReEngine regex_engine_; // Using the object created here.
+  NighthawkLifecycleNotifierImpl lifecycle_notifier_; // A no-op object that lives here.
+  Envoy::Regex::GoogleReEngine regex_engine_;         // Using the object created here.
 };
 
 /**

--- a/source/request_source/request_options_list_plugin_impl.cc
+++ b/source/request_source/request_options_list_plugin_impl.cc
@@ -27,7 +27,7 @@ RequestSourcePtr FileBasedOptionsListRequestSourceFactory::createRequestSourcePl
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::FileBasedOptionsListRequestSourceConfig config;
   Envoy::MessageUtil util;
-  util.unpackTo(*any, config);
+  util.unpackToOrThrow(*any, config);
   uint32_t max_file_size = config.has_max_file_size() ? config.max_file_size().value() : 1000000;
   if (api.fileSystem().fileSize(config.file_path()) > max_file_size) {
     throw NighthawkException("file size must be less than max_file_size");
@@ -60,7 +60,7 @@ RequestSourcePtr InLineOptionsListRequestSourceFactory::createRequestSourcePlugi
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::InLineOptionsListRequestSourceConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   auto loaded_list_ptr =
       std::make_unique<const nighthawk::client::RequestOptionsList>(config.options_list());
   return std::make_unique<OptionsListRequestSource>(config.num_requests(), std::move(header),

--- a/source/user_defined_output/log_response_headers_plugin.cc
+++ b/source/user_defined_output/log_response_headers_plugin.cc
@@ -126,7 +126,7 @@ absl::StatusOr<UserDefinedOutputPluginPtr>
 LogResponseHeadersPluginFactory::createUserDefinedOutputPlugin(
     const Envoy::ProtobufWkt::Any& config_any, const WorkerMetadata& worker_metadata) {
   LogResponseHeadersConfig config;
-  absl::Status unpack_status = Envoy::MessageUtil::unpackToNoThrow(config_any, config);
+  absl::Status unpack_status = Envoy::MessageUtil::unpackTo(config_any, config);
   if (!unpack_status.ok()) {
     return unpack_status;
   }

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/BUILD
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/BUILD
@@ -1,10 +1,10 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
 )
+load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
@@ -40,7 +40,7 @@ InputVariableSetterPtr FakeInputVariableSetterConfigFactory::createInputVariable
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return std::make_unique<FakeInputVariableSetter>(config);
 }
 
@@ -50,7 +50,7 @@ absl::Status FakeInputVariableSetterConfigFactory::ValidateConfig(
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
-    Envoy::MessageUtil::unpackTo(*any, config);
+    Envoy::MessageUtil::unpackToOrThrow(*any, config);
     if (config.has_artificial_validation_failure()) {
       return StatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/BUILD
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/BUILD
@@ -1,10 +1,10 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
 )
+load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
@@ -62,7 +62,7 @@ FakeMetricsPluginConfigFactory::createMetricsPlugin(const Envoy::Protobuf::Messa
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeMetricsPluginConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return std::make_unique<FakeMetricsPlugin>(config);
 }
 
@@ -72,7 +72,7 @@ FakeMetricsPluginConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& m
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeMetricsPluginConfig config;
-    Envoy::MessageUtil::unpackTo(*any, config);
+    Envoy::MessageUtil::unpackToOrThrow(*any, config);
     if (config.has_artificial_validation_failure()) {
       return GetStatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin_test.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin_test.cc
@@ -129,7 +129,7 @@ TEST(MakeFakeMetricsPluginTypedExtensionConfig, PacksGivenConfigProto) {
   envoy::config::core::v3::TypedExtensionConfig activator =
       MakeFakeMetricsPluginTypedExtensionConfig(expected_config);
   nighthawk::adaptive_load::FakeMetricsPluginConfig actual_config;
-  Envoy::MessageUtil::unpackTo(activator.typed_config(), actual_config);
+  Envoy::MessageUtil::unpackToOrThrow(activator.typed_config(), actual_config);
   EXPECT_THAT(expected_config, EqualsProto(actual_config));
 }
 

--- a/test/adaptive_load/fake_plugins/fake_step_controller/BUILD
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/BUILD
@@ -1,10 +1,10 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
 )
+load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
@@ -78,7 +78,7 @@ StepControllerPtr FakeStepControllerConfigFactory::createStepController(
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeStepControllerConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return std::make_unique<FakeStepController>(config, command_line_options_template);
 }
 
@@ -88,7 +88,7 @@ FakeStepControllerConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& 
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeStepControllerConfig config;
-    Envoy::MessageUtil::unpackTo(*any, config);
+    Envoy::MessageUtil::unpackToOrThrow(*any, config);
     if (config.has_artificial_validation_failure()) {
       return StatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/plugin_loader_test.cc
+++ b/test/adaptive_load/plugin_loader_test.cc
@@ -41,7 +41,7 @@ absl::Status DoValidateConfig(const Envoy::Protobuf::Message& message) {
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return config.threshold() == kBadConfigThreshold
              ? absl::InvalidArgumentError("input validation failed")
              : absl::OkStatus();
@@ -86,7 +86,7 @@ public:
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackTo(*any, config);
+    Envoy::MessageUtil::unpackToOrThrow(*any, config);
     return std::make_unique<TestInputVariableSetter>(config);
   }
 };
@@ -125,7 +125,7 @@ public:
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackTo(*any, config);
+    Envoy::MessageUtil::unpackToOrThrow(*any, config);
     return std::make_unique<TestScoringFunction>(config);
   }
 };
@@ -165,7 +165,7 @@ public:
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackTo(*any, config);
+    Envoy::MessageUtil::unpackToOrThrow(*any, config);
     return std::make_unique<TestMetricsPlugin>(config);
   }
 };
@@ -216,7 +216,7 @@ public:
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackTo(*any, config);
+    Envoy::MessageUtil::unpackToOrThrow(*any, config);
     return std::make_unique<TestStepController>(config, command_line_options_template);
   }
 };

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -493,7 +493,7 @@ TEST_F(BenchmarkClientHttpTest, CallsUserDefinedPluginHandleHeaders) {
   absl::StatusOr<Envoy::ProtobufWkt::Any> output_any = plugin_ptr->getPerWorkerOutput();
   ASSERT_TRUE(output_any.ok());
   nighthawk::FakeUserDefinedOutput output;
-  ASSERT_TRUE(Envoy::MessageUtil::unpackToNoThrow(*output_any, output).ok());
+  ASSERT_TRUE(Envoy::MessageUtil::unpackTo(*output_any, output).ok());
   EXPECT_EQ(output.headers_called(), 2);
   EXPECT_EQ(getCounter("user_defined_plugin_handle_headers_failure"), 0);
 }
@@ -524,7 +524,7 @@ TEST_F(BenchmarkClientHttpTest, IncrementsCounterWhenUserDefinedPluginHandleHead
   absl::StatusOr<Envoy::ProtobufWkt::Any> output_any = plugin_ptr->getPerWorkerOutput();
   ASSERT_TRUE(output_any.ok());
   nighthawk::FakeUserDefinedOutput output;
-  ASSERT_TRUE(Envoy::MessageUtil::unpackToNoThrow(*output_any, output).ok());
+  ASSERT_TRUE(Envoy::MessageUtil::unpackTo(*output_any, output).ok());
   EXPECT_EQ(output.headers_called(), 2);
   EXPECT_EQ(getCounter("user_defined_plugin_handle_headers_failure"), 2);
 }
@@ -551,7 +551,7 @@ TEST_F(BenchmarkClientHttpTest, CallsUserDefinedPluginHandleData) {
   absl::StatusOr<Envoy::ProtobufWkt::Any> output_any = plugin_ptr->getPerWorkerOutput();
   ASSERT_TRUE(output_any.ok());
   nighthawk::FakeUserDefinedOutput output;
-  ASSERT_TRUE(Envoy::MessageUtil::unpackToNoThrow(*output_any, output).ok());
+  ASSERT_TRUE(Envoy::MessageUtil::unpackTo(*output_any, output).ok());
   EXPECT_EQ(output.data_called(), 2);
   EXPECT_EQ(getCounter("user_defined_plugin_handle_data_failure"), 0);
 }
@@ -580,7 +580,7 @@ TEST_F(BenchmarkClientHttpTest, IncrementsCounterWhenUserDefinedPluginHandleData
   absl::StatusOr<Envoy::ProtobufWkt::Any> output_any = plugin_ptr->getPerWorkerOutput();
   ASSERT_TRUE(output_any.ok());
   nighthawk::FakeUserDefinedOutput output;
-  ASSERT_TRUE(Envoy::MessageUtil::unpackToNoThrow(*output_any, output).ok());
+  ASSERT_TRUE(Envoy::MessageUtil::unpackTo(*output_any, output).ok());
   EXPECT_EQ(output.data_called(), 2);
   EXPECT_EQ(getCounter("user_defined_plugin_handle_data_failure"), 2);
 }

--- a/test/dynamic_config/BUILD
+++ b/test/dynamic_config/BUILD
@@ -1,5 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_test")
 load("@nh_pip3//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_test")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1,9 +1,9 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_package",
 )
 load("@nh_pip3//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/integration/unit_tests/BUILD
+++ b/test/integration/unit_tests/BUILD
@@ -1,5 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_test")
 load("@nh_pip3//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_test")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -298,8 +298,8 @@ TEST_F(OptionsImplTest, AlmostAll) {
   EXPECT_EQ(options->userDefinedOutputPluginConfigs().size(), 1);
   envoy::config::core::v3::TypedExtensionConfig extension_config =
       options->userDefinedOutputPluginConfigs()[0];
-  EXPECT_TRUE(Envoy::MessageUtil::unpackToNoThrow(extension_config.typed_config(),
-                                                  actual_user_defined_output_config)
+  EXPECT_TRUE(Envoy::MessageUtil::unpackTo(extension_config.typed_config(),
+                                           actual_user_defined_output_config)
                   .ok());
   EXPECT_THAT(actual_user_defined_output_config, EqualsProto(expected_user_defined_output_config));
 

--- a/test/request_source/stub_plugin_impl.cc
+++ b/test/request_source/stub_plugin_impl.cc
@@ -25,7 +25,7 @@ RequestSourcePtr StubRequestSourcePluginConfigFactory::createRequestSourcePlugin
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::StubPluginConfig config;
-  Envoy::MessageUtil::unpackTo(*any, config);
+  Envoy::MessageUtil::unpackToOrThrow(*any, config);
   return std::make_unique<StubRequestSource>(config);
 }
 

--- a/test/sink/sink_service_test.cc
+++ b/test/sink/sink_service_test.cc
@@ -160,7 +160,8 @@ TEST_P(SinkServiceTest, LoadTwoResultsWithExecutionResponseWhereOneHasErrorDetai
   ASSERT_EQ(response_.execution_response().error_detail().details_size(), 1);
   ASSERT_TRUE(response_.execution_response().error_detail().details(0).Is<::google::rpc::Status>());
   ::google::rpc::Status status;
-  Envoy::MessageUtil::unpackTo(response_.execution_response().error_detail().details(0), status);
+  Envoy::MessageUtil::unpackToOrThrow(response_.execution_response().error_detail().details(0),
+                                      status);
   // TODO(XXX): proper equivalence test.
   EXPECT_THAT(status, EqualsProto(*error_detail));
   EXPECT_TRUE(reader_writer->Finish().ok());

--- a/test/user_defined_output/fake_plugin/BUILD
+++ b/test/user_defined_output/fake_plugin/BUILD
@@ -1,10 +1,10 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_package",
 )
+load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/user_defined_output/fake_plugin/fake_user_defined_output.cc
+++ b/test/user_defined_output/fake_plugin/fake_user_defined_output.cc
@@ -68,7 +68,7 @@ FakeUserDefinedOutputPluginFactory::createUserDefinedOutputPlugin(
     const Envoy::ProtobufWkt::Any& config_any, const WorkerMetadata& worker_metadata) {
   plugin_count_++;
   FakeUserDefinedOutputConfig config;
-  absl::Status status = Envoy::MessageUtil::unpackToNoThrow(config_any, config);
+  absl::Status status = Envoy::MessageUtil::unpackTo(config_any, config);
   if (!status.ok()) {
     return status;
   }
@@ -85,7 +85,7 @@ absl::StatusOr<Envoy::ProtobufWkt::Any> FakeUserDefinedOutputPluginFactory::Aggr
     if (user_defined_output.has_typed_output()) {
       Envoy::ProtobufWkt::Any any = user_defined_output.typed_output();
       FakeUserDefinedOutput output;
-      absl::Status status = Envoy::MessageUtil::unpackToNoThrow(any, output);
+      absl::Status status = Envoy::MessageUtil::unpackTo(any, output);
       if (status.ok()) {
         data_called += output.data_called();
         headers_called += output.headers_called();

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,4 +1,3 @@
-load("@nh_pip3//:requirements.bzl", "entry_point")
 load("@nh_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 

--- a/tools/base/BUILD
+++ b/tools/base/BUILD
@@ -1,5 +1,5 @@
-load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 licenses(["notice"])  # Apache 2
 


### PR DESCRIPTION
- No changes to .bazelrc etc.
- Implemented `lifecycleNotifier()` on `NighthawkServerInstance` and `NighthawkServerFactoryContext` (H/T @eziskind for the advance warning and known-good fix)
- Implemented `regexEngine()` on `NighthawkServerFactoryContext`
- Reacted to https://github.com/envoyproxy/envoy/pull/32775
  - Renamed `unpackTo` to `unpackToOrThrow`
  - Renamed `unpackToNoThrow` to `unpackTo` (the version that returns `Status`)
- `fix_format` reordered some bzl imports and removed unused ones