### PR TITLE
Update Envoy to 01ed2a7 (Apr 5th 20214).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,12 +44,10 @@ build --action_env=LLVM_CONFIG --host_action_env=LLVM_CONFIG
 # It tends to have machine-specific values, such as dynamically created temp folders.
 # This would make it impossible to share remote action cache hits among machines.
 # build --action_env=PATH --host_action_env=PATH
-
 # Explicitly set the --host_action_env for clang build since we are not building             # unique
 # rbe-toolchain-clang that Envoy builds.                                                     # unique
 # This value is the same for different VMs, thus cache hits can be shared among machines.    # unique
 build --host_action_env=PATH=/usr/sbin:/usr/bin:/opt/llvm/bin                                # unique
-
 # To make our own CI green, we do need that flag on Windows though.
 build:windows --action_env=PATH --host_action_env=PATH
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "690d3aa8fdce342234e5205b01a84519bd457e81"
-ENVOY_SHA = "9ff9b6a1e2eebbf0ffbe9c23077f968d806b324006a8381fa84915b8010471ab"
+ENVOY_COMMIT = "01ed2a75d539ac227c938738c22ee2affeea8236"
+ENVOY_SHA = "c760f701573e554c7de3af250b5d0f7ce336b16fa94a3a79acbfcf66694dc0e0"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -1,4 +1,4 @@
-# Last updated 2024-03-04
+# Last updated 2024-04-05
 apipkg
 attrs
 certifi

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -134,9 +134,9 @@ idna==3.6 \
     # via
     #   -r tools/base/requirements.in
     #   requests
-importlib-metadata==7.0.1 \
-    --hash=sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e \
-    --hash=sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc
+importlib-metadata==7.1.0 \
+    --hash=sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570 \
+    --hash=sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2
     # via
     #   -r tools/base/requirements.in
     #   yapf
@@ -154,9 +154,9 @@ more-itertools==10.2.0 \
     --hash=sha256:686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684 \
     --hash=sha256:8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1
     # via -r tools/base/requirements.in
-packaging==23.2 \
-    --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
-    --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
+packaging==24.0 \
+    --hash=sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5 \
+    --hash=sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9
     # via
     #   -r tools/base/requirements.in
     #   pytest
@@ -186,9 +186,9 @@ pyflakes==3.2.0 \
     --hash=sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f \
     --hash=sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a
     # via flake8
-pytest==8.0.2 \
-    --hash=sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd \
-    --hash=sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096
+pytest==8.1.1 \
+    --hash=sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7 \
+    --hash=sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044
     # via
     #   -r tools/base/requirements.in
     #   pytest-dependency
@@ -279,15 +279,15 @@ yapf==0.40.2 \
     --hash=sha256:4dab8a5ed7134e26d57c1647c7483afb3f136878b579062b786c9ba16b94637b \
     --hash=sha256:adc8b5dd02c0143108878c499284205adb258aad6db6634e5b869e7ee2bd548b
     # via -r tools/base/requirements.in
-zipp==3.17.0 \
-    --hash=sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31 \
-    --hash=sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0
+zipp==3.18.1 \
+    --hash=sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b \
+    --hash=sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715
     # via
     #   -r tools/base/requirements.in
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==69.1.1 \
-    --hash=sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56 \
-    --hash=sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8
+setuptools==69.2.0 \
+    --hash=sha256:0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e \
+    --hash=sha256:c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c
     # via pytest-dependency

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -428,3 +428,4 @@ visibility_excludes:
 - source/extensions/load_balancing_policies/least_request/
 - source/extensions/load_balancing_policies/random/
 - source/extensions/load_balancing_policies/cluster_provided/
+- source/extensions/filters/http/match_delegate/


### PR DESCRIPTION
- whitespace-only changes in `.bazelrc`.
- no changes in `.bazelversion`, `ci/run_envoy_docker.sh`, `tools/gen_compilation_database.py`.
- synced changes from Envoy's `tools/code_format/config.yaml`.
- updated Python requirements.