### PR TITLE
Update Envoy to 1ae6fb2 (Apr 8th, 2024)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "01ed2a75d539ac227c938738c22ee2affeea8236"
-ENVOY_SHA = "c760f701573e554c7de3af250b5d0f7ce336b16fa94a3a79acbfcf66694dc0e0"
+ENVOY_COMMIT = "1ae6fb29cab8043cc23e070b118fa25c79f7f7d8"
+ENVOY_SHA = "15d19b258d3f0f2c0b13e0aca307d127c326a891d3183ecc0a711b7e9c01dee6"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -125,6 +125,7 @@ envoy_cc_library(
         "@envoy//source/common/singleton:manager_impl_lib_with_external_headers",
         "@envoy//source/common/stats:allocator_lib_with_external_headers",
         "@envoy//source/common/stats:symbol_table_lib_with_external_headers",
+        "@envoy//source/common/stats:tag_producer_lib_with_external_headers",
         "@envoy//source/common/stats:thread_local_store_lib_with_external_headers",
         "@envoy//source/common/stream_info:stream_info_lib_with_external_headers",
         "@envoy//source/common/thread_local:thread_local_lib_with_external_headers",

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -848,8 +848,9 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const UriPtr& tracing_
     // Needs to happen as early as possible (before createWorkers()) in the instantiation to preempt
     // the objects that require stats.
     if (!options_.statsSinks().empty()) {
-      auto producer_or_error = Envoy::Stats::TagProducerImpl::createTagProducer(
-          bootstrap_.stats_config(), envoy_options_.statsTags());
+      absl::StatusOr<Envoy::Stats::TagProducerPtr> producer_or_error =
+          Envoy::Stats::TagProducerImpl::createTagProducer(bootstrap_.stats_config(),
+                                                           envoy_options_.statsTags());
       if (!producer_or_error.ok()) {
         ENVOY_LOG(error, "createTagProducer failed. Received bad status: {}",
                   producer_or_error.status());


### PR DESCRIPTION
- Adjust code to changes in the createTagProducer return value.