### PR TITLE
Update Envoy to 9fc5535 (Apr 26, 2024)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "0f3e4aa373db6bbb7643b1bb60b0cb60d5b39df8"
-ENVOY_SHA = "7e520cd81b1676b8dea08403832d12993c082a3bcee315a224792240dfc19f50"
+ENVOY_COMMIT = "9fc5535619e8873e37ec7dc88d584ff0f04b87b5"
+ENVOY_SHA = "9fb1f7729c3fa40eb395d0fc709ddec23ac092e53eabe6ffc2d4467bb49a8c92"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/stream_decoder.h
+++ b/source/client/stream_decoder.h
@@ -61,8 +61,10 @@ public:
         downstream_address_setter_(std::make_shared<Envoy::Network::ConnectionInfoSetterImpl>(
             // The two addresses aren't used in an execution of Nighthawk.
             /* downstream_local_address = */ nullptr, /* downstream_remote_address = */ nullptr)),
-        stream_info_(time_source_, downstream_address_setter_), random_generator_(random_generator),
-        tracer_(tracer), latency_response_header_name_(latency_response_header_name) {
+        stream_info_(time_source_, downstream_address_setter_,
+                     Envoy::StreamInfo::FilterState::LifeSpan::FilterChain),
+        random_generator_(random_generator), tracer_(tracer),
+        latency_response_header_name_(latency_response_header_name) {
     if (measure_latencies_ && tracer_ != nullptr) {
       setupForTracing();
     }

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -91,7 +91,7 @@ paths:
     - source/common/filter/config_discovery_impl.h
     - source/common/config/utility.h
     - source/common/matcher/map_matcher.h
-    - source/common/matcher/field_matcher.h
+    - source/common/matcher/matcher.h
     - source/extensions/common/matcher/trie_matcher.h
     - envoy/common/exception.h
     # legacy core files which throw exceptions. We can add to this list but strongly prefer
@@ -164,6 +164,7 @@ paths:
     - source/common/local_reply/local_reply.cc
     - source/common/tls/context_impl.cc
     - source/common/tls/context_config_impl.cc
+    - source/common/tls/ocsp/ocsp.cc
     - source/common/config/watched_directory.cc
 
   # Only one C++ file should instantiate grpc_init


### PR DESCRIPTION
- Forced to set `StreamInfoImpl` lifespan explicitly after https://github.com/envoyproxy/envoy/commit/953690a26f20137607ac331fd0232da86f41fcea
  -   `FilterState::LifeSpan life_span = FilterState::LifeSpan::FilterChain` was the default we had been using: https://github.com/envoyproxy/envoy/pull/33651/files#diff-621e35bff59bda73d45b8171cab02f360f77bb948d2797936090e5afaee73020 
