### PR TITLE
Update Envoy to d69544e (May 27, 2024)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -164,12 +164,6 @@ build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/u
 build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --define tcmalloc=disabled
 
-# Workaround issue with pkgconfig, see https://github.com/envoyproxy/envoy/issues/33225
-build:macos --host_action_env=CXXFLAGS=-Wno-int-conversion
-build:macos --action_env=CXXFLAGS=-Wno-int-conversion
-build:macos --host_action_env=CFLAGS=-Wno-int-conversion
-build:macos --action_env=CFLAGS=-Wno-int-conversion
-
 # macOS ASAN/UBSAN
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "ecbd64de59315f990ed7b1861a19aa96061de39d"
-ENVOY_SHA = "764f8036b14baf190af26a9ed3510a7305e9c2b76cf9c96c736eeddf82aa4d91"
+ENVOY_COMMIT = "d69544eec9f285b9fe05548ea18b5f3dc75fb087"
+ENVOY_SHA = "b6dbb0d486d479f827740d231651d5081b754be22eec5e612e9024c59cf82a5c"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -163,6 +163,7 @@ paths:
     - source/common/router/rds_impl.cc
     - source/common/io/io_uring_worker_impl.cc
     - source/common/event/file_event_impl.cc
+    - source/common/http/async_client_impl.cc
 
   # Only one C++ file should instantiate grpc_init
   grpc_init:


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update to .bazelrc to https://github.com/envoyproxy/envoy/pull/32022
- Update to tools/code_format/config.yaml to https://github.com/envoyproxy/envoy/pull/33728