### PR TITLE
Update Envoy to 3feff04 (Jun 28, 2024)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "0b9f67e7f71bcba3ff49575dc61676478cb68614"
-ENVOY_SHA = "e67c43ddfe49baa5d49c17859ba6c32977632676030bb7f9b6637eff1f7432b5"
+ENVOY_COMMIT = "3feff04eeb2356cf16f799bc9fb812e5b765315f"
+ENVOY_SHA = "dd6519f74567f43da6123803be14e480d8b7b474f31127a3bd3cb4d5859c85df"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -153,7 +153,6 @@ paths:
     - source/common/grpc/google_grpc_creds_impl.cc
     - source/common/local_reply/local_reply.cc
     - source/common/tls/server_context_impl.cc
-    - source/common/tls/context_config_impl.cc
     - source/common/config/watched_directory.cc
     - source/server/drain_manager_impl.cc
     - source/common/router/rds_impl.cc


### PR DESCRIPTION
- update envoy commit and SHA.
- sync `tools/code_format/config.yaml` from Envoy's version.