### PR TITLE
Increase hard shutdown timeout to 30 seconds

### DIFF
--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -127,7 +127,7 @@ void BenchmarkClientHttpImpl::terminate() {
       ENVOY_LOG(info, "Wait for the connection pool drain timed out, proceeding to hard shutdown.");
       dispatcher_.exit();
     });
-    drain_timer_->enableTimer(5s);
+    drain_timer_->enableTimer(30s);
     dispatcher_.run(Envoy::Event::Dispatcher::RunType::RunUntilExit);
   }
 }


### PR DESCRIPTION
This is inline with the default connection connect timeout period in 30 seconds. For well behaved clients with short response latencies, this should be a no-op as we will end prematurely once the pool is idle. This does allow for clients with high latencies a long enough time to resolve gracefully.