### PR TITLE
Update Envoy to 9feddc1 (Aug 01, 2024)

### DIFF
--- a/bazel/python_dependencies.bzl
+++ b/bazel/python_dependencies.bzl
@@ -1,4 +1,4 @@
-load("@python3_11//:defs.bzl", "interpreter")
+load("@python3_12//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 def nighthawk_python_dependencies():

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "3ab83eebb2b41c75d7702af3d8bf79162dc050df"
-ENVOY_SHA = "40c32ed204b6b9b4e38074347efa83fe24f7c36402a9106c653ab6ef16cc6ab2"
+ENVOY_COMMIT = "9feddc11baec8ee31c957e0b6b8f8988a0ef9d59"
+ENVOY_SHA = "13c646959412526e5c46fa0aa72860b474089bd32de108de1cfa58307a7938fe"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -9,6 +9,7 @@
 #include <random>
 
 #include "envoy/common/optref.h"
+#include "envoy/http/http_server_properties_cache.h"
 #include "envoy/network/address.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/sink.h"
@@ -166,6 +167,9 @@ public:
   Envoy::Upstream::ClusterManager& clusterManager() override {
     PANIC("NighthawkServerInstance::clusterManager not implemented");
   }
+  Envoy::Http::HttpServerPropertiesCacheManager& httpServerPropertiesCacheManager() override {
+    PANIC("NighthawkServerInstance::httpServerPropertiesCacheManager not implemented");
+  }
   const Envoy::Upstream::ClusterManager& clusterManager() const override {
     PANIC("NighthawkServerInstance::clusterManager not implemented");
   }
@@ -299,7 +303,9 @@ public:
       : admin_(admin), api_(api), dispatcher_(dispatcher), log_manager_(log_manager),
         options_(options), runtime_(runtime), singleton_manager_(singleton_manager), tls_(tls),
         local_info_(local_info), validation_context_(validation_context),
-        grpc_context_(grpc_context), router_context_(router_context), server_scope_(server_scope) {}
+        grpc_context_(grpc_context), router_context_(router_context), server_scope_(server_scope),
+        http_server_properties_cache_manager_(
+            *this, Envoy::ProtobufMessage::getStrictValidationVisitor(), tls) {}
 
   const Envoy::Server::Options& options() override { return options_; };
 
@@ -330,6 +336,9 @@ public:
   Envoy::Upstream::ClusterManager& clusterManager() override {
     PANIC("NighthawkServerFactoryContext::clusterManager not implemented");
   };
+  Envoy::Http::HttpServerPropertiesCacheManager& httpServerPropertiesCacheManager() override {
+    return http_server_properties_cache_manager_;
+  }
 
   Envoy::ProtobufMessage::ValidationContext& messageValidationContext() override {
     return validation_context_;
@@ -400,6 +409,7 @@ private:
   Envoy::Stats::Scope& server_scope_;
   NighthawkLifecycleNotifierImpl lifecycle_notifier_; // A no-op object that lives here.
   Envoy::Regex::GoogleReEngine regex_engine_;         // Using the object created here.
+  Envoy::Http::HttpServerPropertiesCacheManagerImpl http_server_properties_cache_manager_;
 };
 
 /**

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -26,6 +26,7 @@
 #include "external/envoy/source/common/config/utility.h"
 #include "external/envoy/source/common/event/dispatcher_impl.h"
 #include "external/envoy/source/common/event/real_time_system.h"
+#include "external/envoy/source/common/http/http_server_properties_cache_manager_impl.h"
 #include "external/envoy/source/common/init/manager_impl.h"
 #include "external/envoy/source/common/local_info/local_info_impl.h"
 #include "external/envoy/source/common/network/dns_resolver/dns_factory_util.h"


### PR DESCRIPTION
- Update `@python3_11` to `@python3_12`
- Add `httpServerPropertiesCacheManager()` to `NighthawkServerInstance` (panic only) and `NighthawkServerFactoryContext` (real instance) after https://github.com/envoyproxy/envoy/commit/7b8132ac125d9bd64089d65e3c5396e7aab2fde9
