### PR TITLE
Update Envoy to fbc6ee2 (Sep 08, 2024)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -276,14 +276,14 @@ build:rbe-toolchain-clang --platforms=@envoy_build_tools//toolchains:rbe_linux_c
 build:rbe-toolchain-clang --host_platform=@envoy_build_tools//toolchains:rbe_linux_clang_platform
 build:rbe-toolchain-clang --crosstool_top=@envoy_build_tools//toolchains/configs/linux/clang/cc:toolchain
 build:rbe-toolchain-clang --extra_toolchains=@envoy_build_tools//toolchains/configs/linux/clang/config:cc-toolchain
-build:rbe-toolchain-clang --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/opt/llvm/bin
+build:rbe-toolchain-clang --action_env=CC=clang --action_env=CXX=clang++
 
 build:rbe-toolchain-clang-libc++ --config=rbe-toolchain
 build:rbe-toolchain-clang-libc++ --platforms=@envoy_build_tools//toolchains:rbe_linux_clang_libcxx_platform
 build:rbe-toolchain-clang-libc++ --host_platform=@envoy_build_tools//toolchains:rbe_linux_clang_libcxx_platform
 build:rbe-toolchain-clang-libc++ --crosstool_top=@envoy_build_tools//toolchains/configs/linux/clang_libcxx/cc:toolchain
 build:rbe-toolchain-clang-libc++ --extra_toolchains=@envoy_build_tools//toolchains/configs/linux/clang_libcxx/config:cc-toolchain
-build:rbe-toolchain-clang-libc++ --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/opt/llvm/bin
+build:rbe-toolchain-clang-libc++ --action_env=CC=clang --action_env=CXX=clang++
 build:rbe-toolchain-clang-libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --action_env=LDFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --define force_libcpp=enabled

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "b661f52c82218f1d1159ed1c5bd4c6436649d350"
-ENVOY_SHA = "08c88e49d00d46380419a3d81901d14927a6fc126abf3945392dda9afacd55f9"
+ENVOY_COMMIT = "fbc6ee2ed5b858c842999c688504fd133008868a"
+ENVOY_SHA = "5afbcfb875d41f7ecf7851b04ba43d1e1810bc1bc5a0da813cd82a0ee579ad2f"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -94,6 +94,11 @@ VOLUMES=(
     -v "${ENVOY_DOCKER_BUILD_DIR}":"${BUILD_DIR_MOUNT_DEST}"
     -v "${SOURCE_DIR}":"${SOURCE_DIR_MOUNT_DEST}")
 
+if [[ -n "$MOUNT_GPG_HOME" ]]; then
+    VOLUMES+=(
+        -v "${HOME}/.gnupg:${BUILD_DIR_MOUNT_DEST}/.gnupg")
+fi
+
 if ! is_windows; then
     export BUILD_DIR="${BUILD_DIR_MOUNT_DEST}"
 fi
@@ -155,6 +160,7 @@ docker run --rm \
        -e ENVOY_PUBLISH_DRY_RUN \
        -e ENVOY_REPO \
        -e ENVOY_TARBALL_DIR \
+       -e ENVOY_GEN_COMPDB_OPTIONS \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
        -e GCS_ARTIFACT_BUCKET \
        -e GITHUB_REF_NAME \

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -515,7 +515,9 @@ public:
       const Envoy::Network::ConnectionSocket::OptionsSharedPtr& options,
       const Envoy::Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
       Envoy::TimeSource& time_source, Envoy::Upstream::ClusterConnectivityState& state,
-      Envoy::Http::PersistentQuicInfoPtr& quic_info) override {
+      Envoy::Http::PersistentQuicInfoPtr& quic_info,
+      Envoy::OptRef<Envoy::Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry)
+      override {
     // This changed in
     // https://github.com/envoyproxy/envoy/commit/93ee668a690d297ab5e8bd2cbf03771d852ebbda ALPN may
     // be set up to negotiate a protocol, in which case we'd need a HttpConnPoolImplMixed. However,
@@ -545,7 +547,7 @@ public:
     }
     return Envoy::Upstream::ProdClusterManagerFactory::allocateConnPool(
         dispatcher, host, priority, protocols, alternate_protocol_options, options,
-        transport_socket_options, time_source, state, quic_info);
+        transport_socket_options, time_source, state, quic_info, network_observer_registry);
   }
 
   void setConnectionReuseStrategy(

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -24,14 +24,14 @@ def generate_compilation_database(args):
     if args.exclude_contrib:
         source_dir_targets.remove("//contrib/...")
 
-    subprocess.check_call([args.bazel, *bazel_startup_options, "build"] + bazel_options + [
+    subprocess.check_call(["bazel", *bazel_startup_options, "build"] + bazel_options + [
         "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
         "--output_groups=compdb_files,header_files"
     ] + source_dir_targets)
 
-    execroot = subprocess.check_output([
-        args.bazel, *bazel_startup_options, "info", *bazel_options, "execution_root", *bazel_options
-    ]).decode().strip()
+    execroot = subprocess.check_output(
+        ["bazel", *bazel_startup_options, "info", *bazel_options,
+         "execution_root"]).decode().strip()
 
     db_entries = []
     for db in Path(execroot).glob('**/*.compile_commands.json'):


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update .bazelrc to https://github.com/envoyproxy/envoy/pull/35978
- Update ci/run_envoy_docker.sh to https://github.com/envoyproxy/envoy/pull/35926 and https://github.com/envoyproxy/envoy/pull/35660
- Update tools/gen_compilation_database.py to https://github.com/envoyproxy/envoy/pull/36018 and https://github.com/envoyproxy/envoy/pull/35811
- Update source/client/process_impl.cc to match interface change in https://github.com/envoyproxy/envoy/pull/35912