### PR TITLE
Update Envoy to a93ea37 (Sep 23, 2024)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,6 +34,7 @@ build --copt=-DABSL_MIN_LOG_LEVEL=4
 build --define envoy_mobile_listener=enabled
 build --experimental_repository_downloader_retries=2
 build --enable_platform_specific_config
+build --incompatible_merge_fixed_and_default_shell_env
 
 # Pass CC, CXX and LLVM_CONFIG variables from the environment.
 # We assume they have stable values, so this won't cause action cache misses.
@@ -542,7 +543,7 @@ build:bes-envoy-engflow --bes_upload_mode=fully_async
 build:rbe-envoy-engflow --config=cache-envoy-engflow
 build:rbe-envoy-engflow --config=bes-envoy-engflow
 build:rbe-envoy-engflow --remote_executor=grpcs://morganite.cluster.engflow.com
-build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://docker.io/envoyproxy/envoy-build-ubuntu:f94a38f62220a2b017878b790b6ea98a0f6c5f9c@sha256:2dd96b6f43c08ccabd5f4747fce5854f5f96af509b32e5cf6493f136e9833649
+build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://gcr.io/envoy-ci/envoy-build@sha256:7adc40c09508f957624c4d2e0f5aeecb73a59207ee6ded53b107eac828c091b2
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "8cd214daaf858a5e698494a5a667f31978531c18"
-ENVOY_SHA = "7d17c7aaa675d22abdb1cecb800e7a9a83c61c01d64639a62397570d32db868b"
+ENVOY_COMMIT = "a93ea37c132465703460667a8061b7903fa41775"
+ENVOY_SHA = "4dffa9f61ff9f4d4e0c62dfce73c664ab05571f68df1db5d58c344ecdf86b86d"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"
@@ -46,7 +46,7 @@ cc_library(
         "-Wno-implicit-function-declaration",
         "-Wno-error",
     ],
-    deps = ["//external:zlib"],
+    deps = ["@envoy//bazel/foreign_cc:zlib",],
     visibility = ["//visibility:public"],
 )
   """,

--- a/source/common/uri_impl.cc
+++ b/source/common/uri_impl.cc
@@ -77,7 +77,8 @@ bool UriImpl::performDnsLookup(Envoy::Event::Dispatcher& dispatcher,
        &active_dns_query_](Envoy::Network::DnsResolver::ResolutionStatus status, absl::string_view,
                            std::list<Envoy::Network::DnsResponse>&& response) -> void {
         active_dns_query_ = nullptr;
-        if (!response.empty() && status == Envoy::Network::DnsResolver::ResolutionStatus::Success) {
+        if (!response.empty() &&
+            status == Envoy::Network::DnsResolver::ResolutionStatus::Completed) {
           address_ = Envoy::Network::Utility::getAddressWithPort(
               *response.front().addrInfo().address_, port());
           ENVOY_LOG(debug, "DNS resolution complete for {} ({} entries, using {}).",

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -11,15 +11,13 @@ envoy_package()
 envoy_cc_library(
     name = "adaptive_load_client_entry_lib",
     srcs = ["adaptive_load_client_main_entry.cc"],
-    external_deps = [
-        "abseil_symbolize",
-    ],
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
         "//source/adaptive_load:adaptive_load_client_main",
         "//source/common:nighthawk_service_client_impl",
         "//source/common:version_linkstamp",
+        "@com_google_absl//absl/debugging:symbolize",
         "@envoy//source/exe:platform_header_lib_with_external_headers",
         "@envoy//source/exe:platform_impl_lib",
     ],
@@ -28,28 +26,24 @@ envoy_cc_library(
 envoy_cc_library(
     name = "nighthawk_client_entry_lib",
     srcs = ["client_main_entry.cc"],
-    external_deps = [
-        "abseil_symbolize",
-    ],
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
         "//source/client:nighthawk_client_lib",
         "//source/common:version_linkstamp",
+        "@com_google_absl//absl/debugging:symbolize",
     ],
 )
 
 envoy_cc_library(
     name = "nighthawk_service_entry_lib",
     srcs = ["service_main_entry.cc"],
-    external_deps = [
-        "abseil_symbolize",
-    ],
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
         "//source/client:nighthawk_service_lib",
         "//source/common:version_linkstamp",
+        "@com_google_absl//absl/debugging:symbolize",
     ],
 )
 

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -78,6 +78,7 @@ _TEST_SERVER_WARN_ERROR_IGNORE_LIST = frozenset([
 
             # Logged for normal termination, not really a warning.
             "caught ENVOY_SIGTERM",
+            "internal_address_config is not configured. The existing default behaviour will trust RFC1918 IP addresses, but this will be changed in next release. Please explictily config internal address config as the migration step.",
         ),
     ),
 ])

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -78,6 +78,8 @@ _TEST_SERVER_WARN_ERROR_IGNORE_LIST = frozenset([
 
             # Logged for normal termination, not really a warning.
             "caught ENVOY_SIGTERM",
+
+            # TODO(#1224): Explictily config internal address config in HTTPConnectionManager
             "internal_address_config is not configured. The existing default behaviour will trust RFC1918 IP addresses, but this will be changed in next release. Please explictily config internal address config as the migration step.",
         ),
     ),

--- a/test/process_bootstrap_test.cc
+++ b/test/process_bootstrap_test.cc
@@ -60,7 +60,7 @@ protected:
                                   // change the function declaration here.
                                   // NOLINTNEXTLINE(performance-unnecessary-value-param)
                                   Envoy::Network::DnsResolver::ResolveCb callback) {
-          callback(Envoy::Network::DnsResolver::ResolutionStatus::Success, "",
+          callback(Envoy::Network::DnsResolver::ResolutionStatus::Completed, "",
                    Envoy::TestUtility::makeDnsResponse({"127.0.0.1"}));
           return nullptr;
         }));

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -39,7 +39,7 @@ paths:
   # this exclusion prevents all of our files from being formatted              # unique
   # - .                                                                        # unique
   - bazel/external/http_parser/
-  - bazel/toolchains/configs/
+  - bazel/rbe/toolchains/configs/
   - bazel-
   - build
   - contrib/contrib_build_config.bzl
@@ -111,7 +111,6 @@ paths:
     - source/common/formatter/stream_info_formatter.h
     - source/common/formatter/stream_info_formatter.cc
     - source/common/formatter/substitution_formatter.h
-    - source/common/formatter/substitution_format_string.h
     - source/common/stats/tag_extractor_impl.cc
     - source/common/protobuf/yaml_utility.cc
     - source/common/protobuf/utility.cc
@@ -162,36 +161,86 @@ paths:
     # Extensions can exempt entire directories but new extensions
     # points should ideally use StatusOr
     - source/extensions/access_loggers
-    - source/extensions/bootstrap
-    - source/extensions/clusters
+    - source/extensions/bootstrap/wasm/config.cc
+    - source/extensions/clusters/eds/
+    - source/extensions/clusters/logical_dns
+    - source/extensions/clusters/original_dst
+    - source/extensions/clusters/redis
+    - source/extensions/clusters/static
+    - source/extensions/clusters/strict_dns
     - source/extensions/common
-    - source/extensions/config
+    - source/extensions/config/validators/minimum_clusters/minimum_clusters_validator.cc
     - source/extensions/config_subscription
-    - source/extensions/compression/zstd/common
-    - source/extensions/early_data
-    - source/extensions/filters
+    - source/extensions/compression/zstd/common/dictionary_manager.h
+    - source/extensions/filters/http/adaptive_concurrency/controller
+    - source/extensions/filters/http/admission_control
+    - source/extensions/filters/http/aws_lambda
+    - source/extensions/filters/http/aws_request_signing
+    - source/extensions/filters/http/bandwidth_limit
+    - source/extensions/filters/http/basic_auth
+    - source/extensions/filters/http/cache
+    - source/extensions/filters/http/cdn_loop
+    - source/extensions/filters/http/common
+    - source/extensions/filters/http/composite
+    - source/extensions/filters/http/ext_authz
+    - source/extensions/filters/http/ext_proc
+    - source/extensions/filters/http/file_system_buffer
+    - source/extensions/filters/http/gcp_authn
+    - source/extensions/filters/http/grpc_field_extraction
+    - source/extensions/filters/http/grpc_json_transcoder
+    - source/extensions/filters/http/grpc_stats
+    - source/extensions/filters/http/header_mutation
+    - source/extensions/filters/http/header_to_metadata
+    - source/extensions/filters/http/health_check
+    - source/extensions/filters/http/ip_tagging
+    - source/extensions/filters/http/json_to_metadata
+    - source/extensions/filters/http/jwt_authn
+    - source/extensions/filters/http/local_ratelimit
+    - source/extensions/filters/http/oauth2
+    - source/extensions/filters/http/file_system_buffer
+    - source/extensions/filters/http/header_to_metadata
+    - source/extensions/filters/http/on_demand
+    - source/extensions/filters/http/json_to_metadata
+    - source/extensions/filters/http/json_to_metadata
+    - source/extensions/filters/http/thrift_to_metadata
+    - source/extensions/filters/http/lua
+    - source/extensions/filters/http/proto_message_extraction
+    - source/extensions/filters/http/rate_limit_quota
+    - source/extensions/filters/http/ratelimit
+    - source/extensions/filters/http/oauth2
+    - source/extensions/filters/http/wasm
+    - source/extensions/filters/network
+    - source/extensions/filters/common
+    - source/extensions/filters/udp
+    - source/extensions/filters/listener
     - source/extensions/formatter
-    - source/extensions/geoip_providers
+    - source/extensions/geoip_providers/maxmind/geoip_provider.cc
     - source/extensions/grpc_credentials
-    - source/extensions/health_check
+    - source/extensions/health_check/event_sinks/file/file_sink_impl.h
     - source/extensions/health_checkers
-    - source/extensions/http
-    - source/extensions/io_socket
+    - source/extensions/http/cache/file_system_http_cache/config.cc
+    - source/extensions/http/custom_response
+    - source/extensions/http/early_header_mutation
+    - source/extensions/http/injected_credentials
+    - source/extensions/http/original_ip_detection
+    - source/extensions/http/stateful_session
+    - source/extensions/io_socket/user_space
     - source/extensions/key_value
-    - source/extensions/listener_managers
-    - source/extensions/load_balancing_policies
+    - source/extensions/load_balancing_policies/maglev
+    - source/extensions/load_balancing_policies/ring_hash
+    - source/extensions/load_balancing_policies/subset
     - source/extensions/matching
-    - source/extensions/network
-    - source/extensions/path
+    - source/extensions/network/dns_resolver/cares/
     - source/extensions/quic/server_preferred_address
     - source/extensions/rate_limit_descriptors
     - source/extensions/resource_monitors
-    - source/extensions/retry
-    - source/extensions/router
+    - source/extensions/router/cluster_specifiers/lua/lua_cluster_specifier.cc
     - source/extensions/stat_sinks
-    - source/extensions/string_matcher
+    - source/extensions/string_matcher/lua/match.cc
     - source/extensions/tracers
-    - source/extensions/transport_sockets
+    - source/extensions/transport_sockets/internal_upstream
+    - source/extensions/transport_sockets/tls/cert_validator
+    - source/extensions/transport_sockets/tcp_stats/config.cc
 
   # Only one C++ file should instantiate grpc_init
   grpc_init:


### PR DESCRIPTION
- Updated `.bazelrc` and `tools/code_format/config.yaml`
- no changes in `ci/run_envoy_docker.sh.`, `.bazelversion`,  or `tools/gen_compilation_database.py`
- Changed external dependencies -> dependencies
- Changed `Envoy::Network::DnsResolver::ResolutionStatus::Success` -> `Envoy::Network::DnsResolver::ResolutionStatus::Completed`
- Added ignore to `internal_address_config is not configured` warning for Test Server

Signed-off-by: Sebastian Avila <sebastianavila@google.com>