### PR TITLE
Explicitly config internal address config in HTTPConnectionManager (Sep 24, 2024)

### DIFF
--- a/benchmarks/configurations/dynamic_resources_eds.yaml
+++ b/benchmarks/configurations/dynamic_resources_eds.yaml
@@ -21,6 +21,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $proxy_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:

--- a/benchmarks/configurations/envoy_proxy.yaml
+++ b/benchmarks/configurations/envoy_proxy.yaml
@@ -17,6 +17,10 @@ static_resources:
                 generate_request_id: false
                 codec_type: AUTO
                 stat_prefix: ingress_http
+                internal_address_config:
+                  cidr_ranges:
+                  - address_prefix: $proxy_ip
+                    prefix_len: 32
                 route_config:
                   name: local_route
                   virtual_hosts:

--- a/benchmarks/configurations/lds.yaml
+++ b/benchmarks/configurations/lds.yaml
@@ -13,6 +13,10 @@ resources:
         "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         codec_type: AUTO
         stat_prefix: ingress_http
+        internal_address_config:
+          cidr_ranges:
+          - address_prefix: $proxy_ip
+            prefix_len: 32
         http_filters:
         - name: envoy.router
           typed_config:

--- a/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_15_listeners_http_origin.yaml
@@ -21,6 +21,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -56,6 +60,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -91,6 +99,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -126,6 +138,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -161,182 +177,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: service
-              domains:
-              - "*"
-          http_filters:
-          - name: time-tracking
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
-          - name: dynamic-delay
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
-          - name: test-server
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
-              response_body_size: 10
-              v3_response_headers:
-              - { header: { key: "x-nh", value: "1"}}
-          - name: envoy.filters.http.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              dynamic_stats: false
-  listeners:
-  - address:
-      socket_address:
-        address: $server_ip
-        port_value: 0
-    filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          generate_request_id: false
-          codec_type: AUTO
-          stat_prefix: ingress_http
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: service
-              domains:
-              - "*"
-          http_filters:
-          - name: time-tracking
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
-          - name: dynamic-delay
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
-          - name: test-server
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
-              response_body_size: 10
-              v3_response_headers:
-              - { header: { key: "x-nh", value: "1"}}
-          - name: envoy.filters.http.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              dynamic_stats: false
-  - address:
-      socket_address:
-        address: $server_ip
-        port_value: 0
-    filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          generate_request_id: false
-          codec_type: AUTO
-          stat_prefix: ingress_http
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: service
-              domains:
-              - "*"
-          http_filters:
-          - name: time-tracking
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
-          - name: dynamic-delay
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
-          - name: test-server
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
-              response_body_size: 10
-              v3_response_headers:
-              - { header: { key: "x-nh", value: "1"}}
-          - name: envoy.filters.http.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              dynamic_stats: false
-  - address:
-      socket_address:
-        address: $server_ip
-        port_value: 0
-    filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          generate_request_id: false
-          codec_type: AUTO
-          stat_prefix: ingress_http
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: service
-              domains:
-              - "*"
-          http_filters:
-          - name: time-tracking
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
-          - name: dynamic-delay
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
-          - name: test-server
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
-              response_body_size: 10
-              v3_response_headers:
-              - { header: { key: "x-nh", value: "1"}}
-          - name: envoy.filters.http.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              dynamic_stats: false
-  - address:
-      socket_address:
-        address: $server_ip
-        port_value: 0
-    filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          generate_request_id: false
-          codec_type: AUTO
-          stat_prefix: ingress_http
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: service
-              domains:
-              - "*"
-          http_filters:
-          - name: time-tracking
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
-          - name: dynamic-delay
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
-          - name: test-server
-            typed_config:
-              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
-              response_body_size: 10
-              v3_response_headers:
-              - { header: { key: "x-nh", value: "1"}}
-          - name: envoy.filters.http.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              dynamic_stats: false
-  - address:
-      socket_address:
-        address: $server_ip
-        port_value: 0
-    filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          generate_request_id: false
-          codec_type: AUTO
-          stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -373,6 +217,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -408,6 +256,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -443,6 +295,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -478,6 +334,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -513,6 +373,206 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  listeners:
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+          http_filters:
+          - name: time-tracking
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.TimeTrackingConfiguration
+          - name: dynamic-delay
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.DynamicDelayConfiguration
+          - name: test-server
+            typed_config:
+              "@type": type.googleapis.com/nighthawk.server.ResponseOptions
+              response_body_size: 10
+              v3_response_headers:
+              - { header: { key: "x-nh", value: "1"}}
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              dynamic_stats: false
+  - address:
+      socket_address:
+        address: $server_ip
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          generate_request_id: false
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:

--- a/test/integration/configurations/nighthawk_5_listeners_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_5_listeners_http_origin.yaml
@@ -21,6 +21,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -56,6 +60,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -91,6 +99,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -126,6 +138,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -161,6 +177,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:

--- a/test/integration/configurations/nighthawk_http_origin.yaml
+++ b/test/integration/configurations/nighthawk_http_origin.yaml
@@ -21,6 +21,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:

--- a/test/integration/configurations/nighthawk_https_origin.yaml
+++ b/test/integration/configurations/nighthawk_https_origin.yaml
@@ -21,6 +21,10 @@ static_resources:
                 generate_request_id: false
                 codec_type: AUTO
                 stat_prefix: ingress_http
+                internal_address_config:
+                  cidr_ranges:
+                  - address_prefix: $server_ip
+                    prefix_len: 32
                 route_config:
                   name: local_route
                   virtual_hosts:

--- a/test/integration/configurations/nighthawk_https_origin_dsa.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_dsa.yaml
@@ -21,6 +21,10 @@ static_resources:
                 generate_request_id: false
                 codec_type: AUTO
                 stat_prefix: ingress_http
+                internal_address_config:
+                  cidr_ranges:
+                  - address_prefix: $server_ip
+                    prefix_len: 32
                 route_config:
                   name: local_route
                   virtual_hosts:

--- a/test/integration/configurations/nighthawk_https_origin_quic.yaml
+++ b/test/integration/configurations/nighthawk_https_origin_quic.yaml
@@ -25,6 +25,10 @@ static_resources:
                 generate_request_id: false
                 codec_type: HTTP3
                 stat_prefix: ingress_http
+                internal_address_config:
+                  cidr_ranges:
+                  - address_prefix: $server_ip
+                    prefix_len: 32
                 route_config:
                   name: local_route
                   virtual_hosts:

--- a/test/integration/configurations/nighthawk_track_timings.yaml
+++ b/test/integration/configurations/nighthawk_track_timings.yaml
@@ -24,6 +24,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:

--- a/test/integration/configurations/sni_origin.yaml
+++ b/test/integration/configurations/sni_origin.yaml
@@ -58,6 +58,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:
@@ -82,6 +86,10 @@ static_resources:
           generate_request_id: false
           codec_type: AUTO
           stat_prefix: ingress_http
+          internal_address_config:
+            cidr_ranges:
+            - address_prefix: $server_ip
+              prefix_len: 32
           route_config:
             name: local_route
             virtual_hosts:

--- a/test/integration/nighthawk_test_server.py
+++ b/test/integration/nighthawk_test_server.py
@@ -78,9 +78,6 @@ _TEST_SERVER_WARN_ERROR_IGNORE_LIST = frozenset([
 
             # Logged for normal termination, not really a warning.
             "caught ENVOY_SIGTERM",
-
-            # TODO(#1224): Explictily config internal address config in HTTPConnectionManager
-            "internal_address_config is not configured. The existing default behaviour will trust RFC1918 IP addresses, but this will be changed in next release. Please explictily config internal address config as the migration step.",
         ),
     ),
 ])


### PR DESCRIPTION
Explicitly config internal address config in HTTPConnectionManager

In the next Envoy release, no IP addresses will be considered trusted. 

Therefore, we specify internal address config for each HTTPConnectionManager used in the Nighthawk test servers.

Signed-off-by: Sebastian Avila <sebastianavila@google.com>