### PR TITLE
Update Envoy to 33679e4 (Oct 05, 2024)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -104,7 +104,7 @@ build:clang-pch --spawn_strategy=local
 build:clang-pch --define=ENVOY_CLANG_PCH=1
 
 # Use gold linker for gcc compiler.
-build:gcc --linkopt=-fuse-ld=gold
+build:gcc --linkopt=-fuse-ld=gold --host_linkopt=-fuse-ld=gold
 build:gcc --test_env=HEAPCHECK=
 build:gcc --action_env=BAZEL_COMPILER=gcc
 build:gcc --action_env=CC=gcc --action_env=CXX=g++

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "39851cddac60be79f58ab33eafa35a1c9dda81a3"
-ENVOY_SHA = "6eb18670119a1ccde1bb05089149188a2b350aefcf8294f0668537201c8cf378"
+ENVOY_COMMIT = "33679e411dbb4698eae07f7926e595fc13e2805d"
+ENVOY_SHA = "774a89c6f194fab6a3ed8e488a194f621ba540860fbb36afbc61a736f937773e"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -160,15 +160,14 @@ docker run --rm \
        -e ENVOY_REPO \
        -e ENVOY_TARBALL_DIR \
        -e ENVOY_GEN_COMPDB_OPTIONS \
-       -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
        -e GCS_ARTIFACT_BUCKET \
+       -e GCS_REDIRECT_PATH \
        -e GITHUB_REF_NAME \
        -e GITHUB_REF_TYPE \
        -e GITHUB_TOKEN \
        -e GITHUB_APP_ID \
        -e GITHUB_INSTALL_ID \
        -e MOBILE_DOCS_CHECKOUT_DIR \
-       -e BUILD_SOURCEBRANCHNAME \
        -e BAZELISK_BASE_URL \
        -e ENVOY_BUILD_ARCH \
        -e SYSTEM_STAGEDISPLAYNAME \

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -222,7 +222,6 @@ paths:
     - source/extensions/http/custom_response
     - source/extensions/http/early_header_mutation
     - source/extensions/http/injected_credentials
-    - source/extensions/http/original_ip_detection
     - source/extensions/http/stateful_session
     - source/extensions/io_socket/user_space
     - source/extensions/key_value


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update .bazelrc to https://github.com/envoyproxy/envoy/pull/36438
- Update ci/run_envoy_docker.sh to https://github.com/envoyproxy/envoy/pull/36423
- Update tools/code_format/config.yaml to https://github.com/envoyproxy/envoy/pull/36311