### PR TITLE
bisect at bb28dda

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -13,7 +13,7 @@ def nighthawk_dependencies():
         strip_prefix = "envoy-%s" % ENVOY_COMMIT,
         # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
         url = "https://github.com/envoyproxy/envoy/archive/%s.tar.gz" % ENVOY_COMMIT,
-        # // clang-format on
+        # // clang-format on ##
     )
     http_archive(
         name = "dep_hdrhistogram_c",


### PR DESCRIPTION
bisect for CI failure at test only runs remotely.
https://dev.azure.com/cncf/envoy/_build/results?buildId=181241&view=logs&j=ba32a847-52a6-5a74-7953-2233bd8760fe&t=0972c501-e6b4-53e1-3f22-d475a50c3c53&l=9836