### PR TITLE
Update Envoy to 72b7507 (Nov 1, 2024).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -545,9 +545,9 @@ build:rbe-envoy-engflow --remote_executor=grpcs://mordenite.cluster.engflow.com
 build:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://gcr.io/envoy-ci/envoy-build@sha256:7adc40c09508f957624c4d2e0f5aeecb73a59207ee6ded53b107eac828c091b2
 build:rbe-envoy-engflow --jobs=200
 build:rbe-envoy-engflow --define=engflow_rbe=true
+
 build:remote-envoy-engflow --config=common-envoy-engflow
 build:remote-envoy-engflow --config=cache-envoy-engflow
-build:remote-envoy-engflow --config=bes-envoy-engflow
 build:remote-envoy-engflow --config=rbe-envoy-engflow
 
 #############################################################################
@@ -572,6 +572,7 @@ common:debug --config=debug-sandbox
 common:debug --config=debug-coverage
 common:debug --config=debug-tests
 
+try-import %workspace%/repo.bazelrc
 try-import %workspace%/clang.bazelrc
 try-import %workspace%/user.bazelrc
 try-import %workspace%/local_tsan.bazelrc

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "8ffdf9857801e53428c6e13757ef113648fcbd2a"
-ENVOY_SHA = "ceffb7d7ee75a7891993c2d3115080c24fd99c0fc59bc4ab2e399f702b0c11bb"
+ENVOY_COMMIT = "72b75074a0ee089ad81f68ae011e31f14c2936fe"
+ENVOY_SHA = "37bb27bf250d394872c2a8366223789c3a59fcfa20adbe5fe97ead1064da194f"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/adaptive_load/input_variable_setter_impl.cc
+++ b/source/adaptive_load/input_variable_setter_impl.cc
@@ -34,7 +34,7 @@ InputVariableSetterPtr RequestsPerSecondInputVariableSetterConfigFactory::create
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::RequestsPerSecondInputVariableSetterConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return std::make_unique<RequestsPerSecondInputVariableSetter>(config);
 }
 

--- a/source/adaptive_load/scoring_function_impl.cc
+++ b/source/adaptive_load/scoring_function_impl.cc
@@ -19,7 +19,7 @@ BinaryScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf:
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::BinaryScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return std::make_unique<BinaryScoringFunction>(config);
 }
 
@@ -52,7 +52,7 @@ LinearScoringFunctionConfigFactory::createScoringFunction(const Envoy::Protobuf:
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return std::make_unique<LinearScoringFunction>(config);
 }
 

--- a/source/adaptive_load/step_controller_impl.cc
+++ b/source/adaptive_load/step_controller_impl.cc
@@ -53,7 +53,7 @@ absl::Status ExponentialSearchStepControllerConfigFactory::ValidateConfig(
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   if (config.has_input_variable_setter()) {
     return LoadInputVariableSetterPlugin(config.input_variable_setter()).status();
   }
@@ -66,7 +66,7 @@ StepControllerPtr ExponentialSearchStepControllerConfigFactory::createStepContro
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   ExponentialSearchStepControllerConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return std::make_unique<ExponentialSearchStepController>(config, command_line_options_template);
 }
 

--- a/source/request_source/request_options_list_plugin_impl.cc
+++ b/source/request_source/request_options_list_plugin_impl.cc
@@ -27,7 +27,7 @@ RequestSourcePtr FileBasedOptionsListRequestSourceFactory::createRequestSourcePl
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::FileBasedOptionsListRequestSourceConfig config;
   Envoy::MessageUtil util;
-  util.unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(util.unpackTo(*any, config));
   uint32_t max_file_size = config.has_max_file_size() ? config.max_file_size().value() : 1000000;
   if (api.fileSystem().fileSize(config.file_path()) > max_file_size) {
     throw NighthawkException("file size must be less than max_file_size");
@@ -60,7 +60,7 @@ RequestSourcePtr InLineOptionsListRequestSourceFactory::createRequestSourcePlugi
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::InLineOptionsListRequestSourceConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   auto loaded_list_ptr =
       std::make_unique<const nighthawk::client::RequestOptionsList>(config.options_list());
   return std::make_unique<OptionsListRequestSource>(config.num_requests(), std::move(header),

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter.cc
@@ -40,7 +40,7 @@ InputVariableSetterPtr FakeInputVariableSetterConfigFactory::createInputVariable
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return std::make_unique<FakeInputVariableSetter>(config);
 }
 
@@ -50,7 +50,7 @@ absl::Status FakeInputVariableSetterConfigFactory::ValidateConfig(
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeInputVariableSetterConfig config;
-    Envoy::MessageUtil::unpackToOrThrow(*any, config);
+    RETURN_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
     if (config.has_artificial_validation_failure()) {
       return StatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter_test.cc
+++ b/test/adaptive_load/fake_plugins/fake_input_variable_setter/fake_input_variable_setter_test.cc
@@ -55,7 +55,7 @@ TEST(FakeInputVariableSetterConfigFactory, ValidateConfigWithBadConfigProtoRetur
       Envoy::Config::Utility::getAndCheckFactoryByName<InputVariableSetterConfigFactory>(
           "nighthawk.fake_input_variable_setter");
   absl::Status status = config_factory.ValidateConfig(empty_any);
-  EXPECT_THAT(status.message(), HasSubstr("Failed to parse"));
+  EXPECT_THAT(status.message(), HasSubstr("Unable to unpack"));
 }
 
 TEST(FakeInputVariableSetterConfigFactory,

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin.cc
@@ -62,7 +62,7 @@ FakeMetricsPluginConfigFactory::createMetricsPlugin(const Envoy::Protobuf::Messa
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeMetricsPluginConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return std::make_unique<FakeMetricsPlugin>(config);
 }
 
@@ -72,7 +72,7 @@ FakeMetricsPluginConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& m
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeMetricsPluginConfig config;
-    Envoy::MessageUtil::unpackToOrThrow(*any, config);
+    RETURN_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
     if (config.has_artificial_validation_failure()) {
       return GetStatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin_test.cc
+++ b/test/adaptive_load/fake_plugins/fake_metrics_plugin/fake_metrics_plugin_test.cc
@@ -57,7 +57,7 @@ TEST(FakeMetricsPluginConfigFactory, ValidateConfigWithBadConfigProtoReturnsErro
       Envoy::Config::Utility::getAndCheckFactoryByName<MetricsPluginConfigFactory>(
           "nighthawk.fake_metrics_plugin");
   absl::Status status = config_factory.ValidateConfig(empty_any);
-  EXPECT_THAT(status.message(), HasSubstr("Failed to parse"));
+  EXPECT_THAT(status.message(), HasSubstr("Unable to unpack"));
 }
 
 TEST(FakeMetricsPluginConfigFactory, ValidateConfigWithWellFormedIllegalConfigReturnsError) {
@@ -129,7 +129,7 @@ TEST(MakeFakeMetricsPluginTypedExtensionConfig, PacksGivenConfigProto) {
   envoy::config::core::v3::TypedExtensionConfig activator =
       MakeFakeMetricsPluginTypedExtensionConfig(expected_config);
   nighthawk::adaptive_load::FakeMetricsPluginConfig actual_config;
-  Envoy::MessageUtil::unpackToOrThrow(activator.typed_config(), actual_config);
+  ASSERT_TRUE(Envoy::MessageUtil::unpackTo(activator.typed_config(), actual_config).ok());
   EXPECT_THAT(expected_config, EqualsProto(actual_config));
 }
 

--- a/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller.cc
@@ -78,7 +78,7 @@ StepControllerPtr FakeStepControllerConfigFactory::createStepController(
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::FakeStepControllerConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return std::make_unique<FakeStepController>(config, command_line_options_template);
 }
 
@@ -88,7 +88,7 @@ FakeStepControllerConfigFactory::ValidateConfig(const Envoy::Protobuf::Message& 
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::FakeStepControllerConfig config;
-    Envoy::MessageUtil::unpackToOrThrow(*any, config);
+    RETURN_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
     if (config.has_artificial_validation_failure()) {
       return StatusFromProtoRpcStatus(config.artificial_validation_failure());
     }

--- a/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller_test.cc
+++ b/test/adaptive_load/fake_plugins/fake_step_controller/fake_step_controller_test.cc
@@ -61,7 +61,7 @@ TEST(FakeStepControllerConfigFactory, ValidateConfigWithBadConfigProtoReturnsErr
       Envoy::Config::Utility::getAndCheckFactoryByName<StepControllerConfigFactory>(
           "nighthawk.fake_step_controller");
   absl::Status status = config_factory.ValidateConfig(empty_any);
-  EXPECT_THAT(status.message(), HasSubstr("Failed to parse"));
+  EXPECT_THAT(status.message(), HasSubstr("Unable to unpack"));
 }
 
 TEST(FakeStepControllerConfigFactory, ValidateConfigWithAritificialValidationErrorReturnsError) {

--- a/test/adaptive_load/plugin_loader_test.cc
+++ b/test/adaptive_load/plugin_loader_test.cc
@@ -41,7 +41,7 @@ absl::Status DoValidateConfig(const Envoy::Protobuf::Message& message) {
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  RETURN_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return config.threshold() == kBadConfigThreshold
              ? absl::InvalidArgumentError("input validation failed")
              : absl::OkStatus();
@@ -86,7 +86,7 @@ public:
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackToOrThrow(*any, config);
+    THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
     return std::make_unique<TestInputVariableSetter>(config);
   }
 };
@@ -125,7 +125,7 @@ public:
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackToOrThrow(*any, config);
+    THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
     return std::make_unique<TestScoringFunction>(config);
   }
 };
@@ -165,7 +165,7 @@ public:
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackToOrThrow(*any, config);
+    THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
     return std::make_unique<TestMetricsPlugin>(config);
   }
 };
@@ -216,7 +216,7 @@ public:
     const auto* any =
         Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
     nighthawk::adaptive_load::LinearScoringFunctionConfig config;
-    Envoy::MessageUtil::unpackToOrThrow(*any, config);
+    THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
     return std::make_unique<TestStepController>(config, command_line_options_template);
   }
 };

--- a/test/request_source/stub_plugin_impl.cc
+++ b/test/request_source/stub_plugin_impl.cc
@@ -25,7 +25,7 @@ RequestSourcePtr StubRequestSourcePluginConfigFactory::createRequestSourcePlugin
   const auto* any =
       Envoy::Protobuf::DynamicCastToGenerated<const Envoy::ProtobufWkt::Any>(&message);
   nighthawk::request_source::StubPluginConfig config;
-  Envoy::MessageUtil::unpackToOrThrow(*any, config);
+  THROW_IF_NOT_OK(Envoy::MessageUtil::unpackTo(*any, config));
   return std::make_unique<StubRequestSource>(config);
 }
 

--- a/test/sink/sink_service_test.cc
+++ b/test/sink/sink_service_test.cc
@@ -160,8 +160,9 @@ TEST_P(SinkServiceTest, LoadTwoResultsWithExecutionResponseWhereOneHasErrorDetai
   ASSERT_EQ(response_.execution_response().error_detail().details_size(), 1);
   ASSERT_TRUE(response_.execution_response().error_detail().details(0).Is<::google::rpc::Status>());
   ::google::rpc::Status status;
-  Envoy::MessageUtil::unpackToOrThrow(response_.execution_response().error_detail().details(0),
-                                      status);
+  ASSERT_TRUE(
+      Envoy::MessageUtil::unpackTo(response_.execution_response().error_detail().details(0), status)
+          .ok());
   // TODO(XXX): proper equivalence test.
   EXPECT_THAT(status, EqualsProto(*error_detail));
   EXPECT_TRUE(reader_writer->Finish().ok());

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -97,8 +97,10 @@ paths:
     - envoy/common/exception.h
     - source/common/upstream/upstream_impl.h
     - source/common/config/context_provider_impl.h
+    - source/common/protobuf/utility.h
     # legacy core files which throw exceptions. We can add to this list but strongly prefer
     # StausOr where possible.
+    - source/common/config/utility.cc
     - source/common/router/route_config_update_receiver_impl.cc
     - source/common/upstream/cluster_manager_impl.cc
     - source/common/upstream/upstream_impl.cc


### PR DESCRIPTION
- synced changes to `.bazelrc` and `tools/code_format/config.yaml` from Envoy's versions.
- no changes to `.bazelversion`, `ci/run_envoy_docker.sh`, `tools/gen_compilation_database.py`.
- changing calls from `MessageUtil::unpackToOrThrow` to `MessageUtil::unpackTo` as per https://github.com/envoyproxy/envoy/pull/36821.