### PR TITLE
Update Envoy to dcbfb85

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,9 +70,9 @@ test --experimental_ui_max_stdouterr_bytes=11712829 #default 1048576
 # Allow tags to influence execution requirements
 common --experimental_allow_tags_propagation
 
+build:linux --copt=-fdebug-types-section
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
-build:linux --copt=-fdebug-types-section
 build:linux --copt=-fPIC
 build:linux --copt=-Wno-deprecated-declarations
 build:linux --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
@@ -108,6 +108,21 @@ build:gcc --linkopt=-fuse-ld=gold --host_linkopt=-fuse-ld=gold
 build:gcc --test_env=HEAPCHECK=
 build:gcc --action_env=BAZEL_COMPILER=gcc
 build:gcc --action_env=CC=gcc --action_env=CXX=g++
+# This is to work around a bug in GCC that makes debug-types-section
+# option not play well with fission:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110885
+build:gcc --copt=-fno-debug-types-section
+# These trigger errors in multiple places both in Envoy dependecies
+# and in Envoy code itself when using GCC.
+# And in all cases the reports appear to be clear false positives.
+build:gcc --copt=-Wno-error=restrict
+build:gcc --copt=-Wno-error=uninitialized
+build:gcc --cxxopt=-Wno-missing-requires
+# We need this because -Wno-missing-requires options is rather new
+# in GCC, so flags -Wno-missing-requires exists in GCC 12, but does
+# not in GCC 11 and GCC 11 is what is used in docker-gcc
+# configuration currently
+build:gcc --cxxopt=-Wno-unknown-warning
 
 # Clang-tidy
 # TODO(phlax): enable this, its throwing some errors as well as finding more issues
@@ -391,6 +406,7 @@ build:docker-clang-libc++ --config=docker-sandbox
 build:docker-clang-libc++ --config=rbe-toolchain-clang-libc++
 
 build:docker-gcc --config=docker-sandbox
+build:docker-gcc --config=gcc
 build:docker-gcc --config=rbe-toolchain-gcc
 
 build:docker-asan --config=docker-sandbox
@@ -550,6 +566,9 @@ common:rbe-envoy-engflow --define=engflow_rbe=true
 common:remote-envoy-engflow --config=common-envoy-engflow
 common:remote-envoy-engflow --config=cache-envoy-engflow
 common:remote-envoy-engflow --config=rbe-envoy-engflow
+
+# Specifies the rustfmt.toml for all rustfmt_test targets.
+build --@rules_rust//rust/settings:rustfmt.toml=//:rustfmt.toml
 
 #############################################################################
 # debug: Various Bazel debugging flags

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "665995079c8eb9e1cd008812e85d939a8210a34c"
-ENVOY_SHA = "c8e6df9a015e3135275879e27cc8722afbb2d7b216ae00f8f7587134f65fdbe1"
+ENVOY_COMMIT = "dcbfb852d560a7ccdf14bbda4166b2fa4d52ccac"
+ENVOY_SHA = "c783028e704c36f0d10ef42252bb8c178bf82010cc1ba8a1fdce2e5229c369fc"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -99,7 +99,8 @@ paths:
     - source/common/protobuf/utility.h
     # legacy core files which throw exceptions. We can add to this list but strongly prefer
     # StausOr where possible.
-    - source/common/config/utility.cc
+    - source/common/watchdog/abort_action_config.cc
+    - source/extensions/watchdog/profile_action/config.cc
     - source/common/router/route_config_update_receiver_impl.cc
     - source/common/upstream/cluster_manager_impl.cc
     - source/common/upstream/upstream_impl.cc
@@ -126,8 +127,9 @@ paths:
     - source/common/router/config_impl.cc
     - source/common/router/scoped_config_impl.cc
     - source/common/common/utility.cc
-    - source/common/common/regex.h
     - source/exe/stripped_main_base.cc
+    - source/common/http/header_utility.cc
+    - source/common/common/matchers.h
     - source/server/options_impl.cc
     - source/server/config_validation/server.cc
     - source/server/admin/html/active_stats.js
@@ -136,16 +138,12 @@ paths:
     - source/server/hot_restarting_base.cc
     - source/server/hot_restart_impl.cc
     - source/common/upstream/health_discovery_service.cc
+    - source/common/upstream/prod_cluster_info_factory.cc
     - source/common/secret/sds_api.h
     - source/common/secret/sds_api.cc
-    - source/common/secret/secret_provider_impl.cc
     - source/common/router/router.cc
     - source/common/config/config_provider_impl.h
-    - source/common/common/logger_delegates.cc
-    - source/common/upstream/health_checker_event_logger.h
-    - source/common/upstream/outlier_detection_impl.h
     - source/common/grpc/async_client_impl.cc
-    - source/common/ssl/certificate_validation_context_config_impl.cc
     - source/common/grpc/google_grpc_creds_impl.cc
     - source/common/local_reply/local_reply.cc
     - source/common/config/watched_directory.cc
@@ -332,6 +330,7 @@ paths:
     - test/common/grpc/codec_fuzz_test.cc
     - test/common/grpc/codec_test.cc
     - test/common/protobuf/utility_test.cc
+    - source/extensions/common/tap/tap_config_base.cc
     - test/extensions/bootstrap/wasm/test_data/speed_cpp.cc
     - test/extensions/filters/common/expr/context_test.cc
     - test/extensions/filters/http/common/fuzz/uber_filter.h


### PR DESCRIPTION
1. Update commit number in `bazel/repositories.bzl`.
2. synced changes to `.bazelrc` and `tools/code_format/config.yaml` from Envoy's versions.