### PR TITLE
Update Envoy to 41e0a67 (Dec 2nd 2024).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -164,7 +164,6 @@ build:clang-asan-common --linkopt --rtlib=compiler-rt
 build:clang-asan-common --linkopt --unwindlib=libgcc
 
 build:clang-asan --config=clang-asan-common
-build:clang-asan --linkopt='-L/opt/llvm/lib/clang/14.0.0/lib/x86_64-unknown-linux-gnu'      # unique
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone.a
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone_cxx.a
 build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1
@@ -566,6 +565,9 @@ common:rbe-envoy-engflow --define=engflow_rbe=true
 common:remote-envoy-engflow --config=common-envoy-engflow
 common:remote-envoy-engflow --config=cache-envoy-engflow
 common:remote-envoy-engflow --config=rbe-envoy-engflow
+
+common:remote-cache-envoy-engflow --config=common-envoy-engflow
+common:remote-cache-envoy-engflow --config=cache-envoy-engflow
 
 # Specifies the rustfmt.toml for all rustfmt_test targets.
 build --@rules_rust//rust/settings:rustfmt.toml=//:rustfmt.toml

--- a/.bazelrc
+++ b/.bazelrc
@@ -164,6 +164,7 @@ build:clang-asan-common --linkopt --rtlib=compiler-rt
 build:clang-asan-common --linkopt --unwindlib=libgcc
 
 build:clang-asan --config=clang-asan-common
+build:clang-asan --linkopt='-L/opt/llvm/lib/clang/14.0.0/lib/x86_64-unknown-linux-gnu' # unique
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone.a
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone_cxx.a
 build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -164,7 +164,7 @@ build:clang-asan-common --linkopt --rtlib=compiler-rt
 build:clang-asan-common --linkopt --unwindlib=libgcc
 
 build:clang-asan --config=clang-asan-common
-build:clang-asan --linkopt='-L/opt/llvm/lib/clang/14.0.0/lib/x86_64-unknown-linux-gnu' # unique
+build:clang-asan --linkopt='-L/opt/llvm/lib/clang/14.0.0/lib/x86_64-unknown-linux-gnu'      # unique
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone.a
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone_cxx.a
 build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "dcbfb852d560a7ccdf14bbda4166b2fa4d52ccac"
-ENVOY_SHA = "c783028e704c36f0d10ef42252bb8c178bf82010cc1ba8a1fdce2e5229c369fc"
+ENVOY_COMMIT = "41e0a67edd7ca6d54157b2f00ca404c5619dd6f5"
+ENVOY_SHA = "cea2a0f468671d87b7e9b6778018fc440951515544b287da9d03f56b41b4f334"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -126,7 +126,7 @@ function do_clang_tidy() {
 function do_unit_test_coverage() {
     export TEST_TARGETS="//test/... -//test:python_test"
     # TODO(https://github.com/envoyproxy/nighthawk/issues/747): Increase back to 93.2 when coverage flakiness address
-    export COVERAGE_THRESHOLD=91.9
+    export COVERAGE_THRESHOLD=91.8
     echo "bazel coverage build with tests ${TEST_TARGETS}"
     test/run_nighthawk_bazel_coverage.sh ${TEST_TARGETS}
     exit 0

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -152,9 +152,7 @@ idna==3.10 \
 importlib-metadata==8.5.0 \
     --hash=sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b \
     --hash=sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7
-    # via
-    #   -r tools/base/requirements.in
-    #   yapf
+    # via -r tools/base/requirements.in
 iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
@@ -169,9 +167,9 @@ more-itertools==10.5.0 \
     --hash=sha256:037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef \
     --hash=sha256:5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6
     # via -r tools/base/requirements.in
-packaging==24.1 \
-    --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
-    --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
+packaging==24.2 \
+    --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
+    --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
     # via
     #   -r tools/base/requirements.in
     #   pytest
@@ -201,9 +199,9 @@ pyflakes==3.2.0 \
     --hash=sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f \
     --hash=sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a
     # via flake8
-pytest==8.3.3 \
-    --hash=sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181 \
-    --hash=sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2
+pytest==8.3.4 \
+    --hash=sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6 \
+    --hash=sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761
     # via
     #   -r tools/base/requirements.in
     #   pytest-dependency
@@ -282,23 +280,19 @@ snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
     # via pydocstyle
-tomli==2.0.2 \
-    --hash=sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38 \
-    --hash=sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed
-    # via yapf
 urllib3==2.2.3 \
     --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \
     --hash=sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9
     # via
     #   -r tools/base/requirements.in
     #   requests
-yapf==0.40.2 \
-    --hash=sha256:4dab8a5ed7134e26d57c1647c7483afb3f136878b579062b786c9ba16b94637b \
-    --hash=sha256:adc8b5dd02c0143108878c499284205adb258aad6db6634e5b869e7ee2bd548b
+yapf==0.43.0 \
+    --hash=sha256:00d3aa24bfedff9420b2e0d5d9f5ab6d9d4268e72afbf59bb3fa542781d5218e \
+    --hash=sha256:224faffbc39c428cb095818cf6ef5511fdab6f7430a10783fdfb292ccf2852ca
     # via -r tools/base/requirements.in
-zipp==3.20.2 \
-    --hash=sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350 \
-    --hash=sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29
+zipp==3.21.0 \
+    --hash=sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4 \
+    --hash=sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931
     # via
     #   -r tools/base/requirements.in
     #   importlib-metadata


### PR DESCRIPTION
- synced `.bazelrc` from Envoy's version.
- no changes to `.bazelversion`, `ci/run_envoy_docker.sh`, `tools/gen_compilation_database.py`, `tools/code_format/config.yaml`.
- updated Python requirements in `tools/base/requirements.in`.
- lowered coverage threshold from `91.9` to `91.8` due to external changes (no changes to code coverage in this PR).