### PR TITLE
Update Envoy to 10bbd32 (Dec 06, 2024)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "41e0a67edd7ca6d54157b2f00ca404c5619dd6f5"
-ENVOY_SHA = "cea2a0f468671d87b7e9b6778018fc440951515544b287da9d03f56b41b4f334"
+ENVOY_COMMIT = "10bbd32f672ddbdf05eb697c7e3b53d7d1428ea3"
+ENVOY_SHA = "d34a508ac9c0b42e5ff6bbdcb5ee0f91dd693e545958c99e985dfb3ba5d7ce18"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -1,4 +1,4 @@
-# Last updated 2024-10-30
+# Last updated 2024-12-06
 apipkg
 attrs
 certifi

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -272,9 +272,9 @@ requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via -r tools/base/requirements.in
-six==1.16.0 \
-    --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
-    --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+six==1.17.0 \
+    --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
+    --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via -r tools/base/requirements.in
 snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -94,15 +94,12 @@ paths:
     - source/common/matcher/matcher.h
     - source/extensions/common/matcher/trie_matcher.h
     - envoy/common/exception.h
-    - source/common/upstream/upstream_impl.h
-    - source/common/config/context_provider_impl.h
     - source/common/protobuf/utility.h
     # legacy core files which throw exceptions. We can add to this list but strongly prefer
     # StausOr where possible.
     - source/common/watchdog/abort_action_config.cc
     - source/extensions/watchdog/profile_action/config.cc
     - source/common/router/route_config_update_receiver_impl.cc
-    - source/common/upstream/cluster_manager_impl.cc
     - source/common/upstream/upstream_impl.cc
     - source/common/network/listen_socket_impl.cc
     - source/common/network/io_socket_handle_base_impl.cc
@@ -139,14 +136,11 @@ paths:
     - source/server/hot_restart_impl.cc
     - source/common/upstream/health_discovery_service.cc
     - source/common/upstream/prod_cluster_info_factory.cc
-    - source/common/secret/sds_api.h
     - source/common/secret/sds_api.cc
-    - source/common/router/router.cc
     - source/common/config/config_provider_impl.h
     - source/common/grpc/async_client_impl.cc
     - source/common/grpc/google_grpc_creds_impl.cc
     - source/common/local_reply/local_reply.cc
-    - source/common/config/watched_directory.cc
     - source/server/drain_manager_impl.cc
     - source/common/router/rds_impl.cc
     - source/server/hot_restarting_parent.cc
@@ -165,7 +159,12 @@ paths:
     - source/extensions/clusters/redis
     - source/extensions/clusters/static
     - source/extensions/clusters/strict_dns
-    - source/extensions/common
+    - source/extensions/common/async_files
+    - source/extensions/common/aws
+    - source/extensions/common/dubbo
+    - source/extensions/common/matcher
+    - source/extensions/common/tap
+    - source/extensions/common/wasm
     - source/extensions/config/validators/minimum_clusters/minimum_clusters_validator.cc
     - source/extensions/config_subscription
     - source/extensions/compression/zstd/common/dictionary_manager.h


### PR DESCRIPTION
- `clusterManagerFromProto()` started to return `StatusOr<ClusterManagerPtr>` instead of `ClusterManagerPtr`
- Some upstream changes in `tools/code_format/config.yaml` 
- Regenerated Python requirements
