### PR TITLE
Update Envoy to 81cd00f (Jan 10, 2025)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "b0d58be31c2d7fe3ea8fd620c7aedb6b09a4bb89"
-ENVOY_SHA = "66e09f6146cb1548bd0cf6b6cfda1a5cc5fdb349f7bcb98e81cc23c9dd6c7d16"
+ENVOY_COMMIT = "81cd00f08db037e952c6503c8cc0e8851a8c5f42"
+ENVOY_SHA = "13383c404719901c6cef80f753bb814abcd1a943fcab3ea26c1e3c41618b3fed"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -1,4 +1,4 @@
-# Last updated 2024-12-06
+# Last updated 2025-01-10
 apipkg
 attrs
 certifi


### PR DESCRIPTION
- Cluster manager `createUncachedRawAsyncClient()` started returning `absl::StatusOr` after https://github.com/envoyproxy/envoy/pull/37765
- Refreshed Python dependencies with `bazel run //tools/base:requirements.update`, but the final `requirements.txt` was identical