### PR TITLE
Update Envoy to 8ded2fe (Jan 18, 2025)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "81cd00f08db037e952c6503c8cc0e8851a8c5f42"
-ENVOY_SHA = "13383c404719901c6cef80f753bb814abcd1a943fcab3ea26c1e3c41618b3fed"
+ENVOY_COMMIT = "8ded2fefbc1f051a5bf4e18950db2e4bd543014a"
+ENVOY_SHA = "1f3c57b8d682f2e4c25a4c436dd7181c74e02899267fe3b1688bf6a1ab2d681a"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/benchmark_client_impl.h
+++ b/source/client/benchmark_client_impl.h
@@ -148,7 +148,9 @@ public:
   // Helpers
   absl::optional<::Envoy::Upstream::HttpPoolData> pool() {
     const auto thread_local_cluster = cluster_manager_->getThreadLocalCluster(cluster_name_);
-    Envoy::Upstream::HostConstSharedPtr host = thread_local_cluster->chooseHost(nullptr);
+    Envoy::Upstream::HostConstSharedPtr host =
+        Envoy::Upstream::LoadBalancer::onlyAllowSynchronousHostSelection(
+            thread_local_cluster->chooseHost(nullptr));
     return thread_local_cluster->httpConnPool(host, Envoy::Upstream::ResourcePriority::Default,
                                               protocol_, nullptr);
   }

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -595,7 +595,7 @@ ProcessImpl::ProcessImpl(const Options& options, Envoy::Event::TimeSystem& time_
       typed_dns_resolver_config_(std::move(typed_dns_resolver_config)),
       init_watcher_("Nighthawk", []() {}),
       admin_(Envoy::Network::Address::InstanceConstSharedPtr()),
-      validation_context_(false, false, false), router_context_(store_root_.symbolTable()),
+      validation_context_(false, false, false, false), router_context_(store_root_.symbolTable()),
       envoy_options_(/* args = */ {"process_impl"}, HotRestartDisabled, spdlog::level::info) {
   // Any dispatchers created after the following call will use hr timers.
   setupForHRTimers();

--- a/source/server/README.md
+++ b/source/server/README.md
@@ -196,6 +196,7 @@ bazel-bin/nighthawk_test_server  [--stats-tag <string>] ...
 <string>] [-l <string>]
 [--local-address-ip-version <string>]
 [--admin-address-path <string>]
+[--skip-deprecated-logs]
 [--ignore-unknown-dynamic-fields]
 [--reject-unknown-dynamic-fields]
 [--allow-unknown-static-fields]
@@ -301,6 +302,10 @@ The local IP address version (v4 or v6).
 
 --admin-address-path <string>
 Admin address path
+
+--skip-deprecated-logs
+Skips the logging of deprecated field warnings during Protobuf message
+validation
 
 --ignore-unknown-dynamic-fields
 Ignore unknown fields in dynamic configuration

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -56,6 +56,8 @@ struct ClientSetupParameters {
   const uint64_t amount_of_requests;
   const RequestGenerator& request_generator;
 };
+
+ACTION(ReturnNewHostSelectionResponse) { return Envoy::Upstream::HostSelectionResponse(nullptr); }
 } // namespace
 
 class BenchmarkClientHttpTest : public Test {
@@ -79,7 +81,8 @@ public:
     EXPECT_CALL(cluster_manager(), getThreadLocalCluster(_))
         .WillRepeatedly(Return(&thread_local_cluster_));
     EXPECT_CALL(thread_local_cluster_, info()).WillRepeatedly(Return(cluster_info_));
-    EXPECT_CALL(thread_local_cluster_, chooseHost(_)).WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(thread_local_cluster_, chooseHost(_))
+        .WillRepeatedly(ReturnNewHostSelectionResponse());
     EXPECT_CALL(thread_local_cluster_, httpConnPool(_, _, _, _))
         .WillRepeatedly(Return(Envoy::Upstream::HttpPoolData([]() {}, &pool_)));
 

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -138,7 +138,6 @@ paths:
     - source/common/upstream/prod_cluster_info_factory.cc
     - source/common/secret/sds_api.cc
     - source/common/config/config_provider_impl.h
-    - source/common/grpc/async_client_impl.cc
     - source/common/grpc/google_grpc_creds_impl.cc
     - source/common/local_reply/local_reply.cc
     - source/common/router/rds_impl.cc


### PR DESCRIPTION
- Updated `tools/code_format/config.yaml`
- no changes in `.bazelrc`, `.bazelversion`, `ci/run_envoy_docker.sh.` or `tools/gen_compilation_database.py`
- APIs for Async Host Resolution were introduced to envoy in https://github.com/envoyproxy/envoy/pull/38021, migrated `HostConstSharedPtr` to `HostSelectionResponse` to match these changes

Signed-off-by: Sebastian Avila <sebastianavila@google.com>