### PR TITLE
Update Envoy to dc3b061 (Feb 07, 2025)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "695306141ee8ab6168e42ad867be67a8fb85ef29"
-ENVOY_SHA = "eda1625a78429dfa3b6e39f856b06479cdef82ef72f52185e5cf452fecc7e97d"
+ENVOY_COMMIT = "dc3b061ea1136d263cbdae8e0f3e229d1022425e"
+ENVOY_SHA = "a6ae4219843c6b8222fcd44be1f3207f4e16cdaf95d221cbc428492d28ee7f73"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -1,4 +1,4 @@
-# Last updated 2025-01-10
+# Last updated 2025-02-07
 apipkg
 attrs
 certifi

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -8,13 +8,13 @@ apipkg==3.0.2 \
     --hash=sha256:a16984c39de280701f3f6406ed3af658f2a1965011fe7bb5be34fbb48423b411 \
     --hash=sha256:c7aa61a4f82697fdaa667e70af1505acf1f7428b1c27b891d204ba7a8a3c5e0d
     # via -r tools/base/requirements.in
-attrs==24.3.0 \
-    --hash=sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff \
-    --hash=sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308
+attrs==25.1.0 \
+    --hash=sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e \
+    --hash=sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a
     # via -r tools/base/requirements.in
-certifi==2024.12.14 \
-    --hash=sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56 \
-    --hash=sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db
+certifi==2025.1.31 \
+    --hash=sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651 \
+    --hash=sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe
     # via
     #   -r tools/base/requirements.in
     #   requests
@@ -136,9 +136,9 @@ idna==3.10 \
     # via
     #   -r tools/base/requirements.in
     #   requests
-importlib-metadata==8.5.0 \
-    --hash=sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b \
-    --hash=sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7
+importlib-metadata==8.6.1 \
+    --hash=sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e \
+    --hash=sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580
     # via -r tools/base/requirements.in
 iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
@@ -150,9 +150,9 @@ mccabe==0.7.0 \
     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
     # via flake8
-more-itertools==10.5.0 \
-    --hash=sha256:037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef \
-    --hash=sha256:5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6
+more-itertools==10.6.0 \
+    --hash=sha256:2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b \
+    --hash=sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89
     # via -r tools/base/requirements.in
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -66,7 +66,6 @@ paths:
     - bazel/BUILD
     - bazel/external/
     - bazel/toolchains/
-    - tools/clang_tools
 
   # `build_urls`:
   #   We want all URL references to exist in repository_locations.bzl files and have
@@ -105,7 +104,6 @@ paths:
     - source/common/network/io_socket_handle_base_impl.cc
     - source/common/network/address_impl.cc
     - source/common/formatter/http_specific_formatter.cc
-    - source/common/formatter/stream_info_formatter.h
     - source/common/formatter/stream_info_formatter.cc
     - source/common/formatter/substitution_formatter.h
     - source/common/stats/tag_extractor_impl.cc
@@ -114,11 +112,8 @@ paths:
     - source/common/grpc/google_grpc_utils.cc
     - source/common/tcp_proxy/tcp_proxy.cc
     - source/common/listener_manager/lds_api.cc
-    - source/common/upstream/od_cds_api_impl.cc
-    - source/common/upstream/cds_api_impl.cc
     - source/common/rds/common/route_config_provider_manager_impl.h
     - source/common/rds/route_config_provider_manager.h
-    - source/common/filter/config_discovery_impl.cc
     - source/common/json/json_internal.cc
     - source/common/router/scoped_rds.cc
     - source/common/router/config_impl.cc
@@ -145,11 +140,9 @@ paths:
     - source/common/event/file_event_impl.cc
     - source/common/http/async_client_impl.cc
     - source/common/grpc/google_async_client_impl.cc
-    - source/common/formatter/substitution_format_utility.cc
     # Extensions can exempt entire directories but new extensions
     # points should ideally use StatusOr
     - source/extensions/access_loggers
-    - source/extensions/bootstrap/wasm/config.cc
     - source/extensions/clusters/eds/
     - source/extensions/clusters/logical_dns
     - source/extensions/clusters/original_dst
@@ -166,8 +159,6 @@ paths:
     - source/extensions/config_subscription
     - source/extensions/compression/zstd/common/dictionary_manager.h
     - source/extensions/filters/http/adaptive_concurrency/controller
-    - source/extensions/filters/http/admission_control
-    - source/extensions/filters/http/aws_lambda
     - source/extensions/filters/http/basic_auth
     - source/extensions/filters/http/cache
     - source/extensions/filters/http/common
@@ -357,8 +348,6 @@ paths:
     - source/server/admin/stats_request.cc
     - source/server/admin/utils.h
     - source/server/admin/utils.cc
-    - tools/clang_tools/api_booster/main.cc
-    - tools/clang_tools/api_booster/proto_cxx_utils.cc
 
   # These are entire files that are allowed to use std::string_view vs. individual exclusions. Right
   # now this is just WASM which makes use of std::string_view heavily so we need to convert to

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -245,7 +245,6 @@ paths:
   namespace_check:
     exclude:
     - tools/api_boost/testdata/
-    - tools/clang_tools/
 
   # Files that should not raise an error for using memcpy
   memcpy:


### PR DESCRIPTION
- No code changes needed
- Upstream `tools/code_format/config.yaml` removed some entries
- Refreshed Python dependencies