### PR TITLE
Set content length if json_body is provided

### DIFF
--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -191,7 +191,8 @@ bool BenchmarkClientHttpImpl::tryStartRequest(CompletionCallback caller_completi
       dispatcher_, api_.timeSource(), *this, std::move(caller_completion_callback),
       *statistic_.connect_statistic, *statistic_.response_statistic,
       *statistic_.response_header_size_statistic, *statistic_.response_body_size_statistic,
-      *statistic_.origin_latency_statistic, request->header(), shouldMeasureLatencies(),
+      *statistic_.origin_latency_statistic, request->header(), request->body(),
+      shouldMeasureLatencies(),
       content_length, generator_, tracer_, latency_response_header_name_);
   requests_initiated_++;
   pool_data.value().newStream(*stream_decoder, *stream_decoder,

--- a/source/client/stream_decoder.h
+++ b/source/client/stream_decoder.h
@@ -45,7 +45,8 @@ public:
                 OperationCallback caller_completion_callback, Statistic& connect_statistic,
                 Statistic& latency_statistic, Statistic& response_header_sizes_statistic,
                 Statistic& response_body_sizes_statistic, Statistic& origin_latency_statistic,
-                HeaderMapPtr request_headers, bool measure_latencies, uint32_t request_body_size,
+                HeaderMapPtr request_headers, std::string request_body,
+		bool measure_latencies, uint32_t request_body_size,
                 Envoy::Random::RandomGenerator& random_generator,
                 Envoy::Tracing::TracerSharedPtr& tracer,
                 absl::string_view latency_response_header_name)
@@ -56,7 +57,8 @@ public:
         response_header_sizes_statistic_(response_header_sizes_statistic),
         response_body_sizes_statistic_(response_body_sizes_statistic),
         origin_latency_statistic_(origin_latency_statistic),
-        request_headers_(std::move(request_headers)), connect_start_(time_source_.monotonicTime()),
+        request_headers_(std::move(request_headers)), request_body_(request_body),
+	connect_start_(time_source_.monotonicTime()),
         measure_latencies_(measure_latencies), request_body_size_(request_body_size),
         downstream_address_setter_(std::make_shared<Envoy::Network::ConnectionInfoSetterImpl>(
             // The two addresses aren't used in an execution of Nighthawk.
@@ -116,6 +118,7 @@ private:
   Statistic& response_body_sizes_statistic_;
   Statistic& origin_latency_statistic_;
   HeaderMapPtr request_headers_;
+  const std::string request_body_;
   Envoy::Http::ResponseHeaderMapPtr response_headers_;
   Envoy::Http::ResponseTrailerMapPtr trailer_headers_;
   const Envoy::MonotonicTime connect_start_;

--- a/source/request_source/request_options_list_plugin_impl.cc
+++ b/source/request_source/request_options_list_plugin_impl.cc
@@ -101,7 +101,13 @@ RequestGenerator OptionsListRequestSource::get() {
 
     // Override the default values with the values from the request_option
     header->setMethod(envoy::config::core::v3::RequestMethod_Name(request_option.request_method()));
-    const uint32_t content_length = request_option.request_body_size().value();
+    uint32_t request_body_length = 0;
+    if (!request_option.json_body().empty()) {
+      request_body_length = request_option.json_body().size();
+    } else {
+      request_body_length = request_option.request_body_size().value();
+    }
+    const uint32_t content_length = request_body_length;
     if (content_length > 0) {
       header->setContentLength(
           content_length); // Content length is used later in stream_decoder to populate the body

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -27,6 +27,7 @@ public:
         request_headers_(std::make_shared<Envoy::Http::TestRequestHeaderMapImpl>(
             std::initializer_list<std::pair<std::string, std::string>>(
                 {{":method", "GET"}, {":path", "/foo"}}))),
+	request_body_(""),
         tracer_(std::make_unique<Envoy::Tracing::NullTracer>()),
         test_header_(std::make_unique<Envoy::Http::TestResponseHeaderMapImpl>(
             std::initializer_list<std::pair<std::string, std::string>>({{":status", "200"}}))),
@@ -52,6 +53,7 @@ public:
   StreamingStatistic response_body_size_statistic_;
   StreamingStatistic origin_latency_statistic_;
   HeaderMapPtr request_headers_;
+  std::string request_body_;
   uint64_t stream_decoder_completion_callbacks_{0};
   uint64_t pool_failures_{0};
   uint64_t stream_decoder_export_latency_callbacks_{0};
@@ -67,8 +69,8 @@ TEST_F(StreamDecoderTest, HeaderOnlyTest) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [&is_complete](bool, bool) { is_complete = true; },
       connect_statistic_, latency_statistic_, response_header_size_statistic_,
-      response_body_size_statistic_, origin_latency_statistic_, request_headers_, false, 0,
-      random_generator_, tracer_, "");
+      response_body_size_statistic_, origin_latency_statistic_, request_headers_,
+      request_body_, false, 0, random_generator_, tracer_, "");
   decoder->decodeHeaders(std::move(test_header_), true);
   EXPECT_TRUE(is_complete);
   EXPECT_EQ(1, stream_decoder_completion_callbacks_);
@@ -81,8 +83,8 @@ TEST_F(StreamDecoderTest, HeaderWithBodyTest) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [&is_complete](bool, bool) { is_complete = true; },
       connect_statistic_, latency_statistic_, response_header_size_statistic_,
-      response_body_size_statistic_, origin_latency_statistic_, request_headers_, false, 0,
-      random_generator_, tracer_, "");
+      response_body_size_statistic_, origin_latency_statistic_, request_headers_,
+      request_body_, false, 0, random_generator_, tracer_, "");
   decoder->decodeHeaders(std::move(test_header_), false);
   EXPECT_FALSE(is_complete);
   Envoy::Buffer::OwnedImpl buf(std::string(1, 'a'));
@@ -99,7 +101,8 @@ TEST_F(StreamDecoderTest, TrailerTest) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [&is_complete](bool, bool) { is_complete = true; },
       connect_statistic_, latency_statistic_, response_header_size_statistic_,
-      response_body_size_statistic_, origin_latency_statistic_, request_headers_, false, 0,
+      response_body_size_statistic_, origin_latency_statistic_, request_headers_,
+      request_body_, false, 0,
       random_generator_, tracer_, "");
   Envoy::Http::ResponseHeaderMapPtr headers{
       new Envoy::Http::TestResponseHeaderMapImpl{{":status", "200"}}};
@@ -114,7 +117,7 @@ TEST_F(StreamDecoderTest, LatencyIsNotMeasured) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [](bool, bool) {}, connect_statistic_, latency_statistic_,
       response_header_size_statistic_, response_body_size_statistic_, origin_latency_statistic_,
-      request_headers_, false, 0, random_generator_, tracer_, "");
+      request_headers_, request_body_, false, 0, random_generator_, tracer_, "");
   Envoy::Http::MockRequestEncoder stream_encoder;
   EXPECT_CALL(stream_encoder, getStream());
   Envoy::Upstream::HostDescriptionConstSharedPtr ptr;
@@ -150,7 +153,7 @@ TEST_F(StreamDecoderTest, LatencyIsMeasured) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [](bool, bool) {}, connect_statistic_, latency_statistic_,
       response_header_size_statistic_, response_body_size_statistic_, origin_latency_statistic_,
-      request_header, true, 0, random_generator_, tracer_, "");
+      request_header, request_body_, true, 0, random_generator_, tracer_, "");
   Envoy::Http::MockRequestEncoder stream_encoder;
   EXPECT_CALL(stream_encoder, getStream());
   Envoy::Upstream::HostDescriptionConstSharedPtr ptr;
@@ -172,7 +175,8 @@ TEST_F(StreamDecoderTest, StreamResetTest) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [&is_complete](bool, bool) { is_complete = true; },
       connect_statistic_, latency_statistic_, response_header_size_statistic_,
-      response_body_size_statistic_, origin_latency_statistic_, request_headers_, false, 0,
+      response_body_size_statistic_, origin_latency_statistic_, request_headers_,
+      request_body_, false, 0,
       random_generator_, tracer_, "");
   decoder->decodeHeaders(std::move(test_header_), false);
   decoder->onResetStream(Envoy::Http::StreamResetReason::LocalReset, "fooreason");
@@ -186,7 +190,8 @@ TEST_F(StreamDecoderTest, PoolFailureTest) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [&is_complete](bool, bool) { is_complete = true; },
       connect_statistic_, latency_statistic_, response_header_size_statistic_,
-      response_body_size_statistic_, origin_latency_statistic_, request_headers_, false, 0,
+      response_body_size_statistic_, origin_latency_statistic_, request_headers_,
+      request_body_, false, 0,
       random_generator_, tracer_, "");
   Envoy::Upstream::HostDescriptionConstSharedPtr ptr;
   decoder->onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason::Overflow, "fooreason",
@@ -250,7 +255,7 @@ TEST_P(LatencyTrackingViaResponseHeaderTest, LatencyTrackingViaResponseHeader) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [](bool, bool) {}, connect_statistic_, latency_statistic_,
       response_header_size_statistic_, response_body_size_statistic_, origin_latency_statistic_,
-      request_headers_, false, 0, random_generator_, tracer_, kLatencyTrackingResponseHeader);
+      request_headers_, request_body_, false, 0, random_generator_, tracer_, kLatencyTrackingResponseHeader);
   const LatencyTrackingViaResponseHeaderTestParam param = GetParam();
   Envoy::Http::ResponseHeaderMapPtr headers{new Envoy::Http::TestResponseHeaderMapImpl{
       {":status", "200"}, {kLatencyTrackingResponseHeader, std::get<0>(param)}}};
@@ -267,7 +272,7 @@ TEST_F(StreamDecoderTest, LatencyTrackingWithMultipleResponseHeadersFails) {
   auto decoder = new StreamDecoder(
       *dispatcher_, time_system_, *this, [](bool, bool) {}, connect_statistic_, latency_statistic_,
       response_header_size_statistic_, response_body_size_statistic_, origin_latency_statistic_,
-      request_headers_, false, 0, random_generator_, tracer_, kLatencyTrackingResponseHeader);
+      request_headers_, request_body_, false, 0, random_generator_, tracer_, kLatencyTrackingResponseHeader);
   Envoy::Http::ResponseHeaderMapPtr headers{
       new Envoy::Http::TestResponseHeaderMapImpl{{":status", "200"},
                                                  {kLatencyTrackingResponseHeader, "1"},


### PR DESCRIPTION
If json_body is provided by the user in the request source, we should ignore the provided request_body_size and set the content length as the size of the json_body.