### PR TITLE
address content type and content length for json payload

### DIFF
--- a/source/request_source/request_options_list_plugin_impl.cc
+++ b/source/request_source/request_options_list_plugin_impl.cc
@@ -101,10 +101,21 @@ RequestGenerator OptionsListRequestSource::get() {
 
     // Override the default values with the values from the request_option
     header->setMethod(envoy::config::core::v3::RequestMethod_Name(request_option.request_method()));
-    const uint32_t content_length = request_option.request_body_size().value();
+    uint32_t request_body_length = 0;
+    if (!request_option.json_body().empty()) {
+      request_body_length = request_option.json_body().size();
+    } else {
+      request_body_length = request_option.request_body_size().value();
+    }
+    const uint32_t content_length = request_body_length;
+
     if (content_length > 0) {
       header->setContentLength(
           content_length); // Content length is used later in stream_decoder to populate the body
+    }
+    // If json_body is provided, we should set the ContentType as application/json.
+    if (!request_option.json_body().empty()) {
+      header->setContentType("application/json");
     }
     for (const envoy::config::core::v3::HeaderValueOption& option_header :
          request_option.request_headers()) {

--- a/test/request_source/request_source_plugin_test.cc
+++ b/test/request_source/request_source_plugin_test.cc
@@ -220,8 +220,7 @@ TEST_F(FileBasedRequestSourcePluginTest,
   EXPECT_EQ(request3, nullptr);
 }
 
-TEST_F(FileBasedRequestSourcePluginTest,
-       CreateRequestSourcePluginWithJsonBodySetsRequestSize) {
+TEST_F(FileBasedRequestSourcePluginTest, CreateRequestSourcePluginWithJsonBodySetsRequestSize) {
   nighthawk::request_source::FileBasedOptionsListRequestSourceConfig config =
       MakeFileBasedPluginConfigWithTestYaml(Nighthawk::TestEnvironment::runfilesPath(
           "test/request_source/test_data/test-jsonconfig-ab.yaml"));
@@ -492,8 +491,7 @@ TEST_F(InLineRequestSourcePluginTest,
   EXPECT_EQ(request3, nullptr);
 }
 
-TEST_F(InLineRequestSourcePluginTest,
-       CreateRequestSourcePluginWithJsonBodyGetsRequestSize) {
+TEST_F(InLineRequestSourcePluginTest, CreateRequestSourcePluginWithJsonBodyGetsRequestSize) {
   Envoy::MessageUtil util;
   nighthawk::client::RequestOptionsList options_list;
   THROW_IF_NOT_OK(
@@ -524,8 +522,7 @@ TEST_F(InLineRequestSourcePluginTest,
   EXPECT_EQ(header2->getContentLengthValue(), "26");
 }
 
-TEST_F(InLineRequestSourcePluginTest,
-       CreateRequestSourcePluginWithJsonBodyGetsContentType) {
+TEST_F(InLineRequestSourcePluginTest, CreateRequestSourcePluginWithJsonBodyGetsContentType) {
   Envoy::MessageUtil util;
   nighthawk::client::RequestOptionsList options_list;
   THROW_IF_NOT_OK(

--- a/test/request_source/request_source_plugin_test.cc
+++ b/test/request_source/request_source_plugin_test.cc
@@ -216,8 +216,60 @@ TEST_F(FileBasedRequestSourcePluginTest,
   std::string body1 = request1->body();
   std::string body2 = request2->body();
   EXPECT_EQ(body1, R"({"message": "hello1"})");
-  EXPECT_EQ(body2, R"({"message": "hello2"})");
+  EXPECT_EQ(body2, R"({"message": "hellohello2"})");
   EXPECT_EQ(request3, nullptr);
+}
+
+TEST_F(FileBasedRequestSourcePluginTest,
+       CreateRequestSourcePluginWithJsonBodySetsRequestSize) {
+  nighthawk::request_source::FileBasedOptionsListRequestSourceConfig config =
+      MakeFileBasedPluginConfigWithTestYaml(Nighthawk::TestEnvironment::runfilesPath(
+          "test/request_source/test_data/test-jsonconfig-ab.yaml"));
+  config.set_num_requests(2);
+  Envoy::ProtobufWkt::Any config_any;
+  config_any.PackFrom(config);
+  auto& config_factory =
+      Envoy::Config::Utility::getAndCheckFactoryByName<RequestSourcePluginConfigFactory>(
+          "nighthawk.file-based-request-source-plugin");
+  Envoy::Http::RequestHeaderMapPtr header = Envoy::Http::RequestHeaderMapImpl::create();
+  RequestSourcePtr file_based_request_source =
+      config_factory.createRequestSourcePlugin(config_any, *api_, std::move(header));
+  file_based_request_source->initOnThread();
+  Nighthawk::RequestGenerator generator = file_based_request_source->get();
+  Nighthawk::RequestPtr request1 = generator();
+  Nighthawk::RequestPtr request2 = generator();
+  ASSERT_NE(request1, nullptr);
+  ASSERT_NE(request2, nullptr);
+  Nighthawk::HeaderMapPtr header1 = request1->header();
+  Nighthawk::HeaderMapPtr header2 = request2->header();
+  EXPECT_EQ(header1->getContentLengthValue(), "21");
+  EXPECT_EQ(header2->getContentLengthValue(), "26");
+}
+
+TEST_F(FileBasedRequestSourcePluginTest,
+       CreateRequestSourcePluginWithJsonBodySetsRequestContentType) {
+  nighthawk::request_source::FileBasedOptionsListRequestSourceConfig config =
+      MakeFileBasedPluginConfigWithTestYaml(Nighthawk::TestEnvironment::runfilesPath(
+          "test/request_source/test_data/test-jsonconfig-ab.yaml"));
+  config.set_num_requests(2);
+  Envoy::ProtobufWkt::Any config_any;
+  config_any.PackFrom(config);
+  auto& config_factory =
+      Envoy::Config::Utility::getAndCheckFactoryByName<RequestSourcePluginConfigFactory>(
+          "nighthawk.file-based-request-source-plugin");
+  Envoy::Http::RequestHeaderMapPtr header = Envoy::Http::RequestHeaderMapImpl::create();
+  RequestSourcePtr file_based_request_source =
+      config_factory.createRequestSourcePlugin(config_any, *api_, std::move(header));
+  file_based_request_source->initOnThread();
+  Nighthawk::RequestGenerator generator = file_based_request_source->get();
+  Nighthawk::RequestPtr request1 = generator();
+  Nighthawk::RequestPtr request2 = generator();
+  ASSERT_NE(request1, nullptr);
+  ASSERT_NE(request2, nullptr);
+  Nighthawk::HeaderMapPtr header1 = request1->header();
+  Nighthawk::HeaderMapPtr header2 = request1->header();
+  EXPECT_EQ(header1->getContentTypeValue(), "application/json");
+  EXPECT_EQ(header2->getContentTypeValue(), "application/json");
 }
 
 TEST_F(FileBasedRequestSourcePluginTest, CreateRequestSourcePluginWithTooLargeAFileThrowsAnError) {
@@ -436,8 +488,72 @@ TEST_F(InLineRequestSourcePluginTest,
   std::string body1 = request1->body();
   std::string body2 = request2->body();
   EXPECT_EQ(body1, R"({"message": "hello1"})");
-  EXPECT_EQ(body2, R"({"message": "hello2"})");
+  EXPECT_EQ(body2, R"({"message": "hellohello2"})");
   EXPECT_EQ(request3, nullptr);
+}
+
+TEST_F(InLineRequestSourcePluginTest,
+       CreateRequestSourcePluginWithJsonBodyGetsRequestSize) {
+  Envoy::MessageUtil util;
+  nighthawk::client::RequestOptionsList options_list;
+  THROW_IF_NOT_OK(
+      util.loadFromFile(/*file to load*/ Nighthawk::TestEnvironment::runfilesPath(
+                            "test/request_source/test_data/test-jsonconfig-ab.yaml"),
+                        /*out parameter*/ options_list,
+                        /*validation visitor*/ Envoy::ProtobufMessage::getStrictValidationVisitor(),
+                        /*Api*/ *api_));
+  nighthawk::request_source::InLineOptionsListRequestSourceConfig config =
+      MakeInLinePluginConfig(options_list, /*num_requests*/ 2);
+  Envoy::ProtobufWkt::Any config_any;
+  config_any.PackFrom(config);
+  auto& config_factory =
+      Envoy::Config::Utility::getAndCheckFactoryByName<RequestSourcePluginConfigFactory>(
+          "nighthawk.in-line-options-list-request-source-plugin");
+  Envoy::Http::RequestHeaderMapPtr header = Envoy::Http::RequestHeaderMapImpl::create();
+  RequestSourcePtr plugin =
+      config_factory.createRequestSourcePlugin(config_any, *api_, std::move(header));
+  plugin->initOnThread();
+  Nighthawk::RequestGenerator generator = plugin->get();
+  Nighthawk::RequestPtr request1 = generator();
+  Nighthawk::RequestPtr request2 = generator();
+  ASSERT_NE(request1, nullptr);
+  ASSERT_NE(request2, nullptr);
+  Nighthawk::HeaderMapPtr header1 = request1->header();
+  Nighthawk::HeaderMapPtr header2 = request2->header();
+  EXPECT_EQ(header1->getContentLengthValue(), "21");
+  EXPECT_EQ(header2->getContentLengthValue(), "26");
+}
+
+TEST_F(InLineRequestSourcePluginTest,
+       CreateRequestSourcePluginWithJsonBodyGetsContentType) {
+  Envoy::MessageUtil util;
+  nighthawk::client::RequestOptionsList options_list;
+  THROW_IF_NOT_OK(
+      util.loadFromFile(/*file to load*/ Nighthawk::TestEnvironment::runfilesPath(
+                            "test/request_source/test_data/test-jsonconfig-ab.yaml"),
+                        /*out parameter*/ options_list,
+                        /*validation visitor*/ Envoy::ProtobufMessage::getStrictValidationVisitor(),
+                        /*Api*/ *api_));
+  nighthawk::request_source::InLineOptionsListRequestSourceConfig config =
+      MakeInLinePluginConfig(options_list, /*num_requests*/ 2);
+  Envoy::ProtobufWkt::Any config_any;
+  config_any.PackFrom(config);
+  auto& config_factory =
+      Envoy::Config::Utility::getAndCheckFactoryByName<RequestSourcePluginConfigFactory>(
+          "nighthawk.in-line-options-list-request-source-plugin");
+  Envoy::Http::RequestHeaderMapPtr header = Envoy::Http::RequestHeaderMapImpl::create();
+  RequestSourcePtr plugin =
+      config_factory.createRequestSourcePlugin(config_any, *api_, std::move(header));
+  plugin->initOnThread();
+  Nighthawk::RequestGenerator generator = plugin->get();
+  Nighthawk::RequestPtr request1 = generator();
+  Nighthawk::RequestPtr request2 = generator();
+  ASSERT_NE(request1, nullptr);
+  ASSERT_NE(request2, nullptr);
+  Nighthawk::HeaderMapPtr header1 = request1->header();
+  Nighthawk::HeaderMapPtr header2 = request2->header();
+  EXPECT_EQ(header1->getContentTypeValue(), "application/json");
+  EXPECT_EQ(header2->getContentTypeValue(), "application/json");
 }
 
 TEST_F(InLineRequestSourcePluginTest,

--- a/test/request_source/test_data/test-jsonconfig-ab.yaml
+++ b/test/request_source/test_data/test-jsonconfig-ab.yaml
@@ -5,7 +5,8 @@ options:
       - { header: { key: ":path", value: "/a" } }  
       - { header: { key: "x-nighthawk-test-server-config", value: "{response_body_size:13}" } }
   - request_method: 1
-    json_body: '{"message": "hello2"}'
+    json_body: '{"message": "hellohello2"}'
     request_headers:
       - { header: { key: ":path", value: "/b" } }  
-      - { header: { key: "x-nighthawk-test-server-config", value: "{response_body_size:17}" } } 
+      - { header: { key: "x-nighthawk-test-server-config", value: "{response_body_size:17}" } }
+      - { header: { key: ":content-type", value: "application/json" } }   


### PR DESCRIPTION
- If json_body is provided, we should use it to set the content length in request header.
- If json_body is provided, we should set the content type as "application/json" no matter if it is provided in the header.
