### PR TITLE
Update Envoy to 78a8841 (Mar 07, 2025)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -52,6 +52,9 @@ envoy_cc_binary(
 envoy_cc_binary(
     name = "nighthawk_test_server",
     repository = "@envoy",
+    linkopts = [
+        "-latomic",
+    ],
     deps = [
         "//source/server:http_dynamic_delay_filter_config",
         "//source/server:http_test_server_filter_config",

--- a/BUILD
+++ b/BUILD
@@ -24,6 +24,10 @@ filegroup(
 envoy_cc_binary(
     name = "nighthawk_adaptive_load_client",
     repository = "@envoy",
+    linkopts = [
+        "-latomic",
+        "-lrt",
+    ],
     deps = [
         "//source/exe:adaptive_load_client_entry_lib",
     ],
@@ -32,6 +36,10 @@ envoy_cc_binary(
 envoy_cc_binary(
     name = "nighthawk_client",
     repository = "@envoy",
+    linkopts = [
+        "-latomic",
+        "-lrt",
+    ],
     deps = [
         "//source/exe:nighthawk_client_entry_lib",
     ],
@@ -42,6 +50,10 @@ envoy_cc_binary(
 envoy_cc_binary(
     name = "nighthawk_client_testonly",
     repository = "@envoy",
+    linkopts = [
+        "-latomic",
+        "-lrt",
+    ],
     deps = [
         "//source/exe:nighthawk_client_entry_lib",
         "//source/user_defined_output:log_response_headers_plugin",
@@ -67,6 +79,10 @@ envoy_cc_binary(
 envoy_cc_binary(
     name = "nighthawk_service",
     repository = "@envoy",
+    linkopts = [
+        "-latomic",
+        "-lrt",
+    ],
     deps = [
         "//source/exe:nighthawk_service_entry_lib",
     ],
@@ -75,6 +91,10 @@ envoy_cc_binary(
 envoy_cc_binary(
     name = "nighthawk_output_transform",
     repository = "@envoy",
+    linkopts = [
+        "-latomic",
+        "-lrt",
+    ],
     deps = [
         "//source/exe:output_transform_main_entry_lib",
     ],

--- a/BUILD
+++ b/BUILD
@@ -54,6 +54,7 @@ envoy_cc_binary(
     repository = "@envoy",
     linkopts = [
         "-latomic",
+        "-lrt",
     ],
     deps = [
         "//source/server:http_dynamic_delay_filter_config",

--- a/BUILD
+++ b/BUILD
@@ -23,11 +23,11 @@ filegroup(
 
 envoy_cc_binary(
     name = "nighthawk_adaptive_load_client",
-    repository = "@envoy",
     linkopts = [
         "-latomic",
         "-lrt",
     ],
+    repository = "@envoy",
     deps = [
         "//source/exe:adaptive_load_client_entry_lib",
     ],
@@ -35,11 +35,11 @@ envoy_cc_binary(
 
 envoy_cc_binary(
     name = "nighthawk_client",
-    repository = "@envoy",
     linkopts = [
         "-latomic",
         "-lrt",
     ],
+    repository = "@envoy",
     deps = [
         "//source/exe:nighthawk_client_entry_lib",
     ],
@@ -49,11 +49,11 @@ envoy_cc_binary(
 # to enable integration test use cases.
 envoy_cc_binary(
     name = "nighthawk_client_testonly",
-    repository = "@envoy",
     linkopts = [
         "-latomic",
         "-lrt",
     ],
+    repository = "@envoy",
     deps = [
         "//source/exe:nighthawk_client_entry_lib",
         "//source/user_defined_output:log_response_headers_plugin",
@@ -63,11 +63,11 @@ envoy_cc_binary(
 
 envoy_cc_binary(
     name = "nighthawk_test_server",
-    repository = "@envoy",
     linkopts = [
         "-latomic",
         "-lrt",
     ],
+    repository = "@envoy",
     deps = [
         "//source/server:http_dynamic_delay_filter_config",
         "//source/server:http_test_server_filter_config",
@@ -78,11 +78,11 @@ envoy_cc_binary(
 
 envoy_cc_binary(
     name = "nighthawk_service",
-    repository = "@envoy",
     linkopts = [
         "-latomic",
         "-lrt",
     ],
+    repository = "@envoy",
     deps = [
         "//source/exe:nighthawk_service_entry_lib",
     ],
@@ -90,11 +90,11 @@ envoy_cc_binary(
 
 envoy_cc_binary(
     name = "nighthawk_output_transform",
-    repository = "@envoy",
     linkopts = [
         "-latomic",
         "-lrt",
     ],
+    repository = "@envoy",
     deps = [
         "//source/exe:output_transform_main_entry_lib",
     ],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "46f23ed023b7bf328168fd9957b6ca8354f87be7"
-ENVOY_SHA = "9cab4d0b92a22c95554a0d07aaac1485bee17881668b4139bfc6b09f196bfa8e"
+ENVOY_COMMIT = "78a88415a4e1ba9114a06d1d0a1491398e17e995"
+ENVOY_SHA = "587fbfedf19ee233bf2017fbc08f4723f8adda2a48c3c23e726787073d150fbc"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
Add `-latomic` and `-lrt`  to fix the CI build after https://github.com/envoyproxy/envoy/pull/38430.