### PR TITLE
Fix Docker container after adding -latomic

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -21,11 +21,36 @@ filegroup(
     ],
 )
 
+filegroup(
+    name = "nighthawk_static",
+    srcs = [
+        ":nighthawk_adaptive_load_client_static",
+        ":nighthawk_client_static",
+        ":nighthawk_output_transform_static",
+        ":nighthawk_service_static",
+        ":nighthawk_test_server_static",
+    ],
+)
+
 envoy_cc_binary(
     name = "nighthawk_adaptive_load_client",
     linkopts = [
         "-latomic",
         "-lrt",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//source/exe:adaptive_load_client_entry_lib",
+    ],
+)
+
+envoy_cc_binary(
+    name = "nighthawk_adaptive_load_client_static",
+    features = ["fully_static_link"],
+    linkopts = [
+        "-latomic",
+        "-lrt",
+        "-static",
     ],
     repository = "@envoy",
     deps = [
@@ -45,6 +70,20 @@ envoy_cc_binary(
     ],
 )
 
+envoy_cc_binary(
+    name = "nighthawk_client_static",
+    features = ["fully_static_link"],
+    linkopts = [
+        "-latomic",
+        "-lrt",
+        "-static",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//source/exe:nighthawk_client_entry_lib",
+    ],
+)
+
 # A testonly version of the nighthawk client, intended to be built with any required test plugins
 # to enable integration test use cases.
 envoy_cc_binary(
@@ -52,6 +91,22 @@ envoy_cc_binary(
     linkopts = [
         "-latomic",
         "-lrt",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//source/exe:nighthawk_client_entry_lib",
+        "//source/user_defined_output:log_response_headers_plugin",
+        "//test/user_defined_output/fake_plugin:fake_user_defined_output",
+    ],
+)
+
+envoy_cc_binary(
+    name = "nighthawk_client_testonly_static",
+    features = ["fully_static_link"],
+    linkopts = [
+        "-latomic",
+        "-lrt",
+        "-static",
     ],
     repository = "@envoy",
     deps = [
@@ -77,6 +132,23 @@ envoy_cc_binary(
 )
 
 envoy_cc_binary(
+    name = "nighthawk_test_server_static",
+    features = ["fully_static_link"],
+    linkopts = [
+        "-latomic",
+        "-lrt",
+        "-static",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//source/server:http_dynamic_delay_filter_config",
+        "//source/server:http_test_server_filter_config",
+        "//source/server:http_time_tracking_filter_config",
+        "@envoy//source/exe:envoy_main_entry_lib",
+    ],
+)
+
+envoy_cc_binary(
     name = "nighthawk_service",
     linkopts = [
         "-latomic",
@@ -89,10 +161,38 @@ envoy_cc_binary(
 )
 
 envoy_cc_binary(
+    name = "nighthawk_service_static",
+    features = ["fully_static_link"],
+    linkopts = [
+        "-latomic",
+        "-lrt",
+        "-static",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//source/exe:nighthawk_service_entry_lib",
+    ],
+)
+
+envoy_cc_binary(
     name = "nighthawk_output_transform",
     linkopts = [
         "-latomic",
         "-lrt",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//source/exe:output_transform_main_entry_lib",
+    ],
+)
+
+envoy_cc_binary(
+    name = "nighthawk_output_transform_static",
+    features = ["fully_static_link"],
+    linkopts = [
+        "-latomic",
+        "-lrt",
+        "-static",
     ],
     repository = "@envoy",
     deps = [

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -125,7 +125,7 @@ function do_opt_build () {
 function do_opt_build_static () {
     bazel build $BAZEL_BUILD_OPTIONS -c opt --define tcmalloc=gperftools //:nighthawk_static
     bazel build $BAZEL_BUILD_OPTIONS -c opt --define tcmalloc=gperftools //benchmarks:benchmarks
-    maybe_copy_binaries_to_directory
+    maybe_copy_binaries_to_directory_static
 }
 
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -76,6 +76,20 @@ function maybe_copy_binaries_to_directory () {
       done
     fi
 }
+function maybe_copy_binaries_to_directory_static () {
+    if [ -n "${BUILD_DIR}" ]; then
+      echo "Copying built binaries to ${BUILD_DIR}."
+      for BINARY_NAME in \
+        "nighthawk_adaptive_load_client_static" \
+        "nighthawk_client_static" \
+        "nighthawk_output_transform_static" \
+        "nighthawk_service_static" \
+        "nighthawk_test_server_static"; do
+        cp -vf bazel-bin/${BINARY_NAME} ${BUILD_DIR}
+      done
+    fi
+}
+
 
 #######################################
 # Builds non-optimized (fastbuild) binaries of Nighthawk.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -108,6 +108,12 @@ function do_opt_build () {
     bazel build $BAZEL_BUILD_OPTIONS -c opt --define tcmalloc=gperftools //benchmarks:benchmarks
     maybe_copy_binaries_to_directory
 }
+function do_opt_build_static () {
+    bazel build $BAZEL_BUILD_OPTIONS -c opt --define tcmalloc=gperftools //:nighthawk_static
+    bazel build $BAZEL_BUILD_OPTIONS -c opt --define tcmalloc=gperftools //benchmarks:benchmarks
+    maybe_copy_binaries_to_directory
+}
+
 
 function do_test() {
     # The environment variable AZP_BRANCH is used to determine if some expensive
@@ -230,8 +236,8 @@ function do_docker() {
     echo "docker..."
     cd "${SRCDIR}"
     # Note that we implicitly test the opt build in CI here.
-    echo "do_docker: Running do_opt_build."
-    do_opt_build
+    echo "do_docker: Running do_opt_build_static."
+    do_opt_build_static
     echo "do_docker: Running ci/docker/docker_build.sh."
     ./ci/docker/docker_build.sh
     echo "do_docker: Running ci/docker/docker_push.sh."

--- a/ci/docker/Dockerfile-nighthawk
+++ b/ci/docker/Dockerfile-nighthawk
@@ -1,5 +1,7 @@
 FROM frolvlad/alpine-glibc:alpine-3.13_glibc-2.33@sha256:92a8245bd6680b6b256225653369d7b0d3a32ed01ef2c2c397e9622e113cbc42
 
+RUN apk add --no-cache libatomic
+
 ADD nighthawk_client /usr/local/bin/nighthawk_client
 ADD nighthawk_test_server /usr/local/bin/nighthawk_test_server
 ADD nighthawk_output_transform /usr/local/bin/nighthawk_output_transform

--- a/ci/docker/Dockerfile-nighthawk
+++ b/ci/docker/Dockerfile-nighthawk
@@ -1,12 +1,10 @@
 FROM frolvlad/alpine-glibc:alpine-3.13_glibc-2.33@sha256:92a8245bd6680b6b256225653369d7b0d3a32ed01ef2c2c397e9622e113cbc42
 
-RUN apk add --no-cache libatomic
-
-ADD nighthawk_client /usr/local/bin/nighthawk_client
-ADD nighthawk_test_server /usr/local/bin/nighthawk_test_server
-ADD nighthawk_output_transform /usr/local/bin/nighthawk_output_transform
-ADD nighthawk_service /usr/local/bin/nighthawk_service
-ADD nighthawk_adaptive_load_client /usr/local/bin/nighthawk_adaptive_load_client
+ADD nighthawk_client_static /usr/local/bin/nighthawk_client
+ADD nighthawk_test_server_static /usr/local/bin/nighthawk_test_server
+ADD nighthawk_output_transform_static /usr/local/bin/nighthawk_output_transform
+ADD nighthawk_service_static /usr/local/bin/nighthawk_service
+ADD nighthawk_adaptive_load_client_static /usr/local/bin/nighthawk_adaptive_load_client
 ADD default-config.yaml /etc/envoy/envoy.yaml
 
 # Ports for nighthawk_test_server, see default-config.yaml

--- a/ci/docker/docker_build.sh
+++ b/ci/docker/docker_build.sh
@@ -12,7 +12,7 @@ set -e
 
 DOCKER_NAME="nighthawk"
 DOCKER_IMAGE_PREFIX="envoyproxy/${DOCKER_NAME}"
-BINARIES=(nighthawk_test_server nighthawk_client nighthawk_service nighthawk_output_transform nighthawk_adaptive_load_client)
+BINARIES=(nighthawk_test_server_static nighthawk_client_static nighthawk_service_static nighthawk_output_transform_static nighthawk_adaptive_load_client_static)
 BAZEL_BIN="$(bazel info -c opt bazel-bin)"
 WORKSPACE="$(bazel info workspace)"
 TMP_DIR="${WORKSPACE}/tmp-docker-build-context"


### PR DESCRIPTION
In https://github.com/envoyproxy/nighthawk/pull/1309 we added `-latomic -lrt`, but this caused https://github.com/envoyproxy/nighthawk/issues/1312. The binaries in the Docker image can no longer start, failing to find `libatomic.so.1`.

`apk add libatomic` in the Docker container does not work because of unknown Alpine Linux issues.

Instead we now build separate static versions of the Nighthawk binaries, solely for the Nighthawk in Docker.

Statically linking may lead to problems: https://groups.google.com/g/envoy-users/c/XK9M-RhWrxg/m/bgvUqtG2BwAJ.

Confirmed that the static Nighthawk binaries solve the `libatomic.so.1` error and apparently fully start:
```
ci/do_ci.sh docker
...
docker run envoyproxy/nighthawk-dev:latest nighthawk_client
Bad argument: A URI or --multi-target-* options must be specified.
```

It is worth a try publishing this version, since it can't get worse than the status quo where the Nighthawk Docker image doesn't work.

If the statically linked version fails, another possibility is to switch to Ubuntu as in https://github.com/envoyproxy/envoy/blob/main/ci/Dockerfile-envoy.