### PR TITLE
migrate Nighthawk Docker image from Alpine to Ubuntu

### DIFF
--- a/ci/docker/Dockerfile-nighthawk
+++ b/ci/docker/Dockerfile-nighthawk
@@ -1,4 +1,6 @@
-FROM frolvlad/alpine-glibc:alpine-3.13_glibc-2.33@sha256:92a8245bd6680b6b256225653369d7b0d3a32ed01ef2c2c397e9622e113cbc42
+FROM ubuntu:22.04@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97
+
+RUN apt-get update && apt-get install libatomic1
 
 ADD nighthawk_client /usr/local/bin/nighthawk_client
 ADD nighthawk_test_server /usr/local/bin/nighthawk_test_server


### PR DESCRIPTION
### Problem

We had to add `-lrt -latomic` when https://github.com/envoyproxy/nighthawk/pull/1309 updated to the latest Envoy.

https://github.com/envoyproxy/nighthawk/issues/1312 found that the Docker image no longer works because `libatomic.so.1` is not found.

### Solution

The minimal solution to add `apk install libatomic` was not sufficient to fix the issue because of unknown Alpine issues.

Migrating from Alpine to Ubuntu 22.04 and including `RUN apt-get update && apt-get install libatomic1` appears to work. (Ubuntu SHA is copied from Envoy: https://github.com/envoyproxy/envoy/blob/f2023ef77bdb4abaf9feef963c9a0c291f55568f/ci/Dockerfile-envoy)

Just changing the `FROM` to Ubuntu 22.04, before adding `apt-get install libatomic1`, we start off with a similar error:

```
ci/do_ci.sh docker
docker run envoyproxy/nighthawk-dev:latest nighthawk_client
nighthawk_client: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```

After adding `apt-get install libatomic1`, the `nighthawk_client` executable can start:

```
ci/do_ci.sh docker
docker run envoyproxy/nighthawk-dev:latest nighthawk_client
Bad argument: A URI or --multi-target-* options must be specified.
```

It is a low risk to publish a new Docker image based on the minimal confirmation above. The image can't be worse than the current image on Docker Hub that doesn't work.