### PR TITLE
Update Envoy to 108dd56 (Mar 24, 2025)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "7cb808b41da5259235c9b7496a90b9d29d6afdb9"
-ENVOY_SHA = "acbcb36d05d287974ef4fed6e30d3209382ddfc03496aae915864858e2ab4d4f"
+ENVOY_COMMIT = "108dd56175abe1b4059628f6b399a2075e84d557"
+ENVOY_SHA = "cc51d66b4c21bac37678ed86cd4d6c1283be542c5de5bc5adbe81e32461a7e54"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -106,6 +106,7 @@ paths:
     - source/common/formatter/http_specific_formatter.cc
     - source/common/formatter/stream_info_formatter.cc
     - source/common/formatter/substitution_formatter.h
+    - source/common/formatter/substitution_formatter.cc
     - source/common/stats/tag_extractor_impl.cc
     - source/common/protobuf/yaml_utility.cc
     - source/common/protobuf/utility.cc


### PR DESCRIPTION
- Updated `tools/code_format/config.yaml`
- no changes in `.bazelrc`, `.bazelversion`, `ci/run_envoy_docker.sh.` or `tools/gen_compilation_database.py`
- Deduped `NighthawkServerFactoryContext ` into `NighthawkServerInstance ` so that we can successfully call xdsManager() from NighthawkServerFactoryContext. Necessary due to https://github.com/envoyproxy/envoy/pull/38792, which added Instance parameter into xDS Manager.

Signed-off-by: Sebastian Avila <sebastianavila@google.com>