### PR TITLE
Provide a valid instance of secretManager.

### DIFF
--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -403,7 +403,8 @@ def test_h3_quic_with_custom_upstream_bind_configuration(quic_test_server_fixtur
   asserts.assertCounterEqual(counters, "upstream_cx_http3_total", 1)
 
 
-def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2, ciphers):
+def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2,
+                               use_validation_context, ciphers):
   """Test with different ciphers.
 
   For a given choice of (--tls-context, --transport-socket) x (H1, H2),
@@ -413,15 +414,18 @@ def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2,
     https_test_server_fixture: pytest.fixture that controls a test server and client
     cli_parameter: string, --tls-context or --transport-socket
     use_h2: boolean, whether to pass --h2
+    use_validation_context: boolean, whether enable validation context in the TLS transport socket
     ciphers: list[string], list of ciphers to use with TLS
   """
+  validation_context = ", validation_context:{}" if use_validation_context else ""
   if cli_parameter == "--tls-context":
-    json_template = "{common_tls_context:{tls_params:{cipher_suites:[\"-ALL:%s\"]}}}"
+    json_template = "{common_tls_context:{tls_params:{cipher_suites:[\"-ALL:%s\"]}%s}}" % validation_context
   else:
     json_template = "%s%s%s" % (
         "{name:\"envoy.transport_sockets.tls\",typed_config:{",
         "\"@type\":\"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext\",",
-        "common_tls_context:{tls_params:{cipher_suites:[\"-ALL:%s\"]}}}}")
+        "common_tls_context:{tls_params:{cipher_suites:[\"-ALL:%s\"]}" +
+        "%s}}}" % validation_context)
 
   for cipher in ciphers:
     parsed_json, _ = https_test_server_fixture.runNighthawkClient(
@@ -441,6 +445,7 @@ def test_https_h1_tls_context_configuration_rsa(https_test_server_fixture):
   _do_tls_configuration_test(https_test_server_fixture,
                              "--tls-context",
                              use_h2=False,
+                             use_validation_context=False,
                              ciphers=["ECDHE-RSA-AES256-GCM-SHA384"])
 
 
@@ -451,6 +456,7 @@ def test_https_h1_transport_socket_configuration_rsa(https_test_server_fixture):
   _do_tls_configuration_test(https_test_server_fixture,
                              "--transport-socket",
                              use_h2=False,
+                             use_validation_context=False,
                              ciphers=["ECDHE-RSA-AES256-GCM-SHA384"])
 
 
@@ -461,6 +467,7 @@ def test_https_h2_tls_context_configuration_rsa(https_test_server_fixture):
   _do_tls_configuration_test(https_test_server_fixture,
                              "--tls-context",
                              use_h2=True,
+                             use_validation_context=False,
                              ciphers=["ECDHE-RSA-AES256-GCM-SHA384"])
 
 
@@ -471,6 +478,7 @@ def test_https_h2_transport_socket_configuration_rsa(https_test_server_fixture):
   _do_tls_configuration_test(https_test_server_fixture,
                              "--transport-socket",
                              use_h2=True,
+                             use_validation_context=False,
                              ciphers=["ECDHE-RSA-AES256-GCM-SHA384"])
 
 
@@ -481,6 +489,7 @@ def test_https_h1_tls_context_configuration_dsa(https_test_server_fixture):
   _do_tls_configuration_test(https_test_server_fixture,
                              "--tls-context",
                              use_h2=False,
+                             use_validation_context=False,
                              ciphers=["ECDHE-ECDSA-AES256-GCM-SHA384"])
 
 
@@ -491,6 +500,7 @@ def test_https_h1_transport_socket_configuration_dsa(https_test_server_fixture):
   _do_tls_configuration_test(https_test_server_fixture,
                              "--transport-socket",
                              use_h2=False,
+                             use_validation_context=False,
                              ciphers=["ECDHE-ECDSA-AES256-GCM-SHA384"])
 
 
@@ -501,6 +511,7 @@ def test_https_h2_tls_context_configuration_dsa(https_test_server_fixture):
   _do_tls_configuration_test(https_test_server_fixture,
                              "--tls-context",
                              use_h2=True,
+                             use_validation_context=False,
                              ciphers=["ECDHE-ECDSA-AES256-GCM-SHA384"])
 
 
@@ -511,6 +522,21 @@ def test_https_h2_transport_socket_configuration_dsa(https_test_server_fixture):
   _do_tls_configuration_test(https_test_server_fixture,
                              "--transport-socket",
                              use_h2=True,
+                             use_validation_context=False,
+                             ciphers=["ECDHE-ECDSA-AES256-GCM-SHA384"])
+
+
+@pytest.mark.parametrize(
+    'server_config', ["nighthawk/test/integration/configurations/nighthawk_https_origin_dsa.yaml"])
+def test_secret_manager_regression(https_test_server_fixture):
+  """Test that verifies adding a validation context doesn't crash Nighthawk.
+
+  See https://github.com/envoyproxy/nighthawk/issues/1338.
+  """
+  _do_tls_configuration_test(https_test_server_fixture,
+                             "--transport-socket",
+                             use_h2=True,
+                             use_validation_context=True,
                              ciphers=["ECDHE-ECDSA-AES256-GCM-SHA384"])
 
 

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -419,7 +419,7 @@ def _do_tls_configuration_test(https_test_server_fixture, cli_parameter, use_h2,
   """
   validation_context = ", validation_context:{}" if use_validation_context else ""
   if cli_parameter == "--tls-context":
-    json_template = "{common_tls_context:{tls_params:{cipher_suites:[\"-ALL:%s\"]}%s}}" % validation_context
+    json_template = "{common_tls_context:{tls_params:{cipher_suites:[\"-ALL:%s\"]}" + "%s}}" % validation_context
   else:
     json_template = "%s%s%s" % (
         "{name:\"envoy.transport_sockets.tls\",typed_config:{",


### PR DESCRIPTION
This is required when validation_context is used in transport socket.

Fixes #1338.