### PR TITLE
Re-enable TSAN in CI with a fix.

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -72,6 +72,8 @@ stages:
       matrix:
         asan:
           CI_TARGET: "asan"
+        tsan:
+          CI_TARGET: "tsan"
     timeoutInMinutes: 120
     steps:
     - template: bazel.yml

--- a/.bazelrc
+++ b/.bazelrc
@@ -85,8 +85,8 @@ build:linux --cxxopt=-fsized-deallocation --host_cxxopt=-fsized-deallocation
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
 build:linux --features=per_object_debug_info
-#build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-#build:linux --action_env=BAZEL_LINKOPTS=-lm
+build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
+build:linux --action_env=BAZEL_LINKOPTS=-lm
 
 # We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
 build --define absl=1
@@ -208,10 +208,6 @@ build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
 build:clang-tsan --test_env="TSAN_OPTIONS=report_atomic_races=0"
 build:clang-tsan --test_timeout=120,600,1500,4800
 build:clang-tsan --action_env=CC=clang --action_env=CXX=clang++
-# Explicitly choose libc++, otherwise some targets pick up the system's libstdc++,          # unique
-# resulting in a symbol conflict.                                                           # unique
-#build:clang-tsan --action_env=CXXFLAGS=-stdlib=libc++                                       # unique
-#build:clang-tsan --action_env=LDFLAGS=-stdlib=libc++                                        # unique
 
 # Clang MSAN - this is the base config for remote-msan and docker-msan. To run this config without
 # our build image, follow https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo

--- a/.bazelrc
+++ b/.bazelrc
@@ -207,7 +207,6 @@ build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
 # https://github.com/google/sanitizers/issues/953
 build:clang-tsan --test_env="TSAN_OPTIONS=report_atomic_races=0"
 build:clang-tsan --test_timeout=120,600,1500,4800
-build:clang-tsan --action_env=CC=clang --action_env=CXX=clang++
 
 # Clang MSAN - this is the base config for remote-msan and docker-msan. To run this config without
 # our build image, follow https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo

--- a/.bazelrc
+++ b/.bazelrc
@@ -207,6 +207,11 @@ build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
 # https://github.com/google/sanitizers/issues/953
 build:clang-tsan --test_env="TSAN_OPTIONS=report_atomic_races=0"
 build:clang-tsan --test_timeout=120,600,1500,4800
+build:clang-tsan --action_env=CC=clang --action_env=CXX=clang++
+# Explicitly choose libc++, otherwise some targets pick up the system's libstdc++,          # unique
+# resulting in a symbol conflict.                                                           # unique
+build:clang-tsan --action_env=CXXFLAGS=-stdlib=libc++                                       # unique
+build:clang-tsan --action_env=LDFLAGS=-stdlib=libc++                                        # unique
 
 # Clang MSAN - this is the base config for remote-msan and docker-msan. To run this config without
 # our build image, follow https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo

--- a/.bazelrc
+++ b/.bazelrc
@@ -85,8 +85,8 @@ build:linux --cxxopt=-fsized-deallocation --host_cxxopt=-fsized-deallocation
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
 build:linux --features=per_object_debug_info
-build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-build:linux --action_env=BAZEL_LINKOPTS=-lm
+#build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
+#build:linux --action_env=BAZEL_LINKOPTS=-lm
 
 # We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
 build --define absl=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -210,8 +210,8 @@ build:clang-tsan --test_timeout=120,600,1500,4800
 build:clang-tsan --action_env=CC=clang --action_env=CXX=clang++
 # Explicitly choose libc++, otherwise some targets pick up the system's libstdc++,          # unique
 # resulting in a symbol conflict.                                                           # unique
-build:clang-tsan --action_env=CXXFLAGS=-stdlib=libc++                                       # unique
-build:clang-tsan --action_env=LDFLAGS=-stdlib=libc++                                        # unique
+#build:clang-tsan --action_env=CXXFLAGS=-stdlib=libc++                                       # unique
+#build:clang-tsan --action_env=LDFLAGS=-stdlib=libc++                                        # unique
 
 # Clang MSAN - this is the base config for remote-msan and docker-msan. To run this config without
 # our build image, follow https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -194,8 +194,11 @@ function do_sanitizer() {
     cd "${SRCDIR}"
 
     # We build this in steps to avoid running out of memory in CI
-    run_on_build_parts "run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=$CONFIG --"
-    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config="$CONFIG" -- //test/...
+    # The Envoy build system now uses hermetic SAN libraries that come with
+    # Baazel. Those are built with libc++ instead of the GCC libstdc++.
+    # Explicitly setting --config=libc++ to avoid duplicate symbols.
+    run_on_build_parts "run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=$CONFIG --config=libc++ --"
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config="$CONFIG" --config=libc++ -- //test/...
 }
 
 function cleanup_benchmark_artifacts {

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -195,7 +195,7 @@ function do_sanitizer() {
 
     # We build this in steps to avoid running out of memory in CI
     # The Envoy build system now uses hermetic SAN libraries that come with
-    # Baazel. Those are built with libc++ instead of the GCC libstdc++.
+    # Bazel. Those are built with libc++ instead of the GCC libstdc++.
     # Explicitly setting --config=libc++ to avoid duplicate symbols.
     run_on_build_parts "run_bazel build ${BAZEL_TEST_OPTIONS} -c dbg --config=$CONFIG --config=libc++ --"
     run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config="$CONFIG" --config=libc++ -- //test/...


### PR DESCRIPTION
Explicitly select `libc++` now that we are using Bazel's hermetic SAN libraries.