### PR TITLE
Update Envoy to 25037e7 (Jun 23, 2025)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "9ceb376da711272e01319d158ba171019ef68ab2"
-ENVOY_SHA = "534b0c34fc50401f463a317479ecb83891d881bbac1115e587797739d03ee1db"
+ENVOY_COMMIT = "25037e74fcd73c65991aac8c3a19efc7db7ede86"
+ENVOY_SHA = "2b95ad37f1f7933e297129cb63e7977e41ffe17755dcbc434df6ee2a19aa0f07"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
Update `ENVOY_COMMIT` and `ENVOY_SHA`.