### PR TITLE
Update envoy to bf9eb6e (Jun 26th 2025).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,6 +32,7 @@ build --incompatible_strict_action_env
 build --java_runtime_version=remotejdk_11
 build --tool_java_runtime_version=remotejdk_11
 # build --platform_mappings=""                                                              # unique
+build --tool_java_language_version=11
 # silence absl logspam.
 build --copt=-DABSL_MIN_LOG_LEVEL=4
 # Global C++ standard and common warning suppressions
@@ -81,7 +82,6 @@ common --experimental_allow_tags_propagation
 # Test configuration flags                                                                  # unique
 # Enable stress tests (expensive tests that are skipped by default)                         # unique
 test:stress --//test/config:run_stress_tests=True                                           # unique
-
 build:linux --copt=-fdebug-types-section
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
@@ -431,7 +431,6 @@ build:remote-ci --remote_download_minimal
 
 build:remote-ci-download --config=ci                                                        # unique
 build:remote-ci-download --remote_download_toplevel                                         # unique
-
 # Note this config is used by mobile CI also.
 common:ci --noshow_progress
 common:ci --noshow_loading_progress

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "25037e74fcd73c65991aac8c3a19efc7db7ede86"
-ENVOY_SHA = "2b95ad37f1f7933e297129cb63e7977e41ffe17755dcbc434df6ee2a19aa0f07"
+ENVOY_COMMIT = "bf9eb6eb00ce6d62b1fb2cecaeba97b012110cb5"
+ENVOY_SHA = "e5a8b3924300f0c7191a474e9ca617cf62a35dd6038cbc187eae86a22b49d4bb"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -176,7 +176,7 @@ public:
 
   Envoy::Stats::Scope& serverScope() override { return *server_scope_; };
 
-  Envoy::ThreadLocal::SlotAllocator& threadLocal() override { return server_.threadLocal(); }
+  Envoy::ThreadLocal::Instance& threadLocal() override { return server_.threadLocal(); }
 
   Envoy::Upstream::ClusterManager& clusterManager() override {
     if (cluster_manager_ != nullptr) {


### PR DESCRIPTION
- synced changes in `.bazelrc` from Envoy.
- no changes in `.bazelversion`, `ci/run_envoy_docker.sh`, `tools/gen_compilation_database.py`, `tools/code_format/config.yaml`.
- no update needed to `tools/base/requirements.in`.
- changed return type of `threadLocal()` to `ThreadLocal::Instance&` as per https://github.com/envoyproxy/envoy/pull/39981.