### PR TITLE
Fix local test runs when using RBE.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -124,11 +124,13 @@ function do_test() {
     # E.g. test_http_h1_mini_stress_test_open_loop.
     if [[ -n "${GH_BRANCH:-}" ]]; then
         STRESS_TEST_FLAG="--//test/config:run_stress_tests=True"
+        BUILD_TYPE_FLAG="--define build_type=github_ci"
     else
         STRESS_TEST_FLAG="--//test/config:run_stress_tests=False"
+        BUILD_TYPE_FLAG=""
     fi
-    run_on_build_parts "bazel build -c dbg $BAZEL_BUILD_OPTIONS $STRESS_TEST_FLAG"
-    bazel test -c dbg $BAZEL_TEST_OPTIONS $STRESS_TEST_FLAG //test/...
+    run_on_build_parts "bazel build -c dbg $BAZEL_BUILD_OPTIONS $STRESS_TEST_FLAG $BUILD_TYPE_FLAG"
+    bazel test -c dbg $BAZEL_TEST_OPTIONS $STRESS_TEST_FLAG $BUILD_TYPE_FLAG //test/...
 }
 
 function do_clang_tidy() {

--- a/test/BUILD
+++ b/test/BUILD
@@ -319,9 +319,12 @@ envoy_cc_test(
     size = "enormous",
     srcs = ["python_test.cc"],
     data = ["//test/integration:integration_test"],
-    exec_properties = {
-        "Pool": "linux_x64_large",
-    },
+    exec_properties = select({
+        "//test/config:github_ci_build": {
+            "Pool": "linux_x64_large",
+        },
+        "//conditions:default": {},
+    }),
     repository = "@envoy",
     deps = [
         "//source/client:nighthawk_client_lib",

--- a/test/config/BUILD
+++ b/test/config/BUILD
@@ -13,3 +13,8 @@ config_setting(
         ":run_stress_tests": "True",
     },
 )
+
+config_setting(
+    name = "github_ci_build",
+    define_values = {"build_type": "github_ci"},
+)


### PR DESCRIPTION
Setting `exec_properties` on `//test:python_test` is required when running on the CI via Github actions, but fails when running on RBE with:

```
ERROR: /usr/local/google/home/mumak/github.com/mum4k/nighthawk/test/BUILD:317:14: Compiling test/python_test.cc failed: (Exit 34): FAILED_PRECONDITION: there are no bots capable of executing the action, requested action properties: Pool = linux_x64_large, OSFamily = Linux
java.io.IOException: io.grpc.StatusRuntimeException: FAILED_PRECONDITION: there are no bots capable of executing the action, requested action properties: Pool = linux_x64_large, OSFamily = Linux
```

This is because the pool `linux_x64_large` isn't defined on RBE.

Making the `exec_properties` conditional (a `select`) that sets it only when running on Github actions. This is determined via a new custom flag.