### PR TITLE
Update Envoy to 1f468dd (Jul 18, 2025)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "8537e5c4d9f4c53e86c90247d0a735e06a33cacb"
-ENVOY_SHA = "935690b4381de995aa37e0b4cfc5a7f3a4a6a9553cb7edf05d79a67b9efabeff"
+ENVOY_COMMIT = "1f468dda227cc72aa5e697fe58f3225c3ea9a5b7"
+ENVOY_SHA = "3d5cad21c6dcd53f3979efe39a103451e1aa017be9e6c2e3aa09335a47df8409"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.2"  # October 12th, 2020
 HDR_HISTOGRAM_C_SHA = "637f28b5f64de2e268131e4e34e6eef0b91cf5ff99167db447d9b2825eae6bad"


### PR DESCRIPTION
No updates except `ENVOY_COMMIT` and `ENVOY_SHA`.