### PR TITLE
Update nighthawk.yml to block running tests on build failure

### DIFF
--- a/.github/workflows/nighthawk.yml
+++ b/.github/workflows/nighthawk.yml
@@ -13,25 +13,27 @@ concurrency:
 
 
 jobs:
-  check:
+  check_format:
     permissions:
       contents: read
       packages: read
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-        - build
-        - check_format
     uses: ./.github/workflows/_ci.yml
     with:
-      task: ${{ matrix.target }}
+      task: check_format
+
+  build:
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/_ci.yml
+    with:
+      task: build
 
   test:
     permissions:
       contents: read
       packages: read
-    needs: check
+    needs: build
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A CI/CD workflow did not attempt tests because the format check failed. This change moves check_format out to its own job and updates the test job to only block on the successful completion of build.