### PR TITLE
Add prometheus output format support for nighthawk_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ bazel-bin/nighthawk_client  [--user-defined-plugin-config <string>] ...
 <auto|v4|v6>] [--burst-size <uint32_t>]
 [--prefetch-connections] [--output-format
 <json|human|yaml|dotted|fortio
-|experimental_fortio_pedantic|csv>] [-v
-<trace|debug|info|warn|error|critical>]
-[--concurrency <string>]
+|experimental_fortio_pedantic|csv
+|prometheus>] [-v <trace|debug|info|warn
+|error|critical>] [--concurrency <string>]
 [--http3-protocol-options <string>] [-p
 <http1|http2|http3>] [--h2] [--timeout
 <uint32_t>] [--duration <uint32_t>]
@@ -380,10 +380,10 @@ Release requests in bursts of the specified size (default: 0).
 Use proactive connection prefetching (HTTP/1 only).
 
 --output-format <json|human|yaml|dotted|fortio
-|experimental_fortio_pedantic|csv>
+|experimental_fortio_pedantic|csv|prometheus>
 Output format. Possible values: ["json", "human", "yaml", "dotted",
-"fortio", "experimental_fortio_pedantic", "csv"]. The default output
-format is 'human'.
+"fortio", "experimental_fortio_pedantic", "csv", "prometheus"]. The
+default output format is 'human'.
 
 -v <trace|debug|info|warn|error|critical>,  --verbosity <trace|debug
 |info|warn|error|critical>
@@ -514,16 +514,17 @@ USAGE:
 
 bazel-bin/nighthawk_output_transform  --output-format <json|human|yaml
 |dotted|fortio
-|experimental_fortio_pedantic|csv>
-[--] [--version] [-h]
+|experimental_fortio_pedantic|csv
+|prometheus> [--] [--version] [-h]
 
 
 Where:
 
 --output-format <json|human|yaml|dotted|fortio
-|experimental_fortio_pedantic|csv>
+|experimental_fortio_pedantic|csv|prometheus>
 (required)  Output format. Possible values: ["json", "human", "yaml",
-"dotted", "fortio", "experimental_fortio_pedantic", "csv"].
+"dotted", "fortio", "experimental_fortio_pedantic", "csv",
+"prometheus"].
 
 --,  --ignore_rest
 Ignores the rest of the labeled arguments following this flag.

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -76,6 +76,7 @@ message OutputFormat {
     FORTIO = 5;
     EXPERIMENTAL_FORTIO_PEDANTIC = 6;
     CSV = 7;
+    PROMETHEUS = 8;
   }
   OutputFormatOptions value = 1;
 }
@@ -178,7 +179,7 @@ message CommandLineOptions {
   // error, critical]. The default level is 'info'.
   Verbosity verbosity = 7;
   // Output format. Possible values: {"json", "human", "yaml", "dotted",
-  // "fortio", "csv}. The default output format is 'human'.
+  // "fortio", "csv", "prometheus"}. The default output format is 'human'.
   // NOTE: not relevant to gRPC service
   OutputFormat output_format = 8;
   // Use proactive connection prefetching (HTTP/1 only).

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -115,6 +115,8 @@ OutputFormatterPtr OutputFormatterFactoryImpl::create(
     return std::make_unique<Client::FortioPedanticOutputFormatterImpl>();
   case nighthawk::client::OutputFormat::CSV:
     return std::make_unique<Client::CsvOutputFormatterImpl>();
+  case nighthawk::client::OutputFormat::PROMETHEUS:
+    return std::make_unique<Client::PrometheusOutputFormatterImpl>();
   default:
     PANIC("not reached");
   }

--- a/source/client/output_formatter_impl.h
+++ b/source/client/output_formatter_impl.h
@@ -169,5 +169,19 @@ public:
   absl::StatusOr<std::string> formatProto(const nighthawk::client::Output& output) const override;
 };
 
+/**
+ * Formats Nighthawk's output proto to Prometheus' metric format.
+ */
+class PrometheusOutputFormatterImpl : public OutputFormatterImpl {
+public:
+  absl::StatusOr<std::string> formatProto(const nighthawk::client::Output& output) const override;
+
+private:
+  void populateMetric(const std::string& metric_name, const std::string& metric_type,
+                      const std::string& metric_labels, const std::string& metric_value,
+                      std::map<std::string, std::stringstream>& metrics_output,
+                      std::string metric_name_suffix = "") const;
+};
+
 } // namespace Client
 } // namespace Nighthawk

--- a/test/BUILD
+++ b/test/BUILD
@@ -130,6 +130,7 @@ envoy_cc_test(
         "test_data/output_formatter.medium.fortio.gold",
         "test_data/output_formatter.medium.fortio-noquirks.gold",
         "test_data/output_formatter.medium.proto.gold",
+        "test_data/output_formatter.prometheus.gold",
         "test_data/output_formatter.txt.gold",
         "test_data/output_formatter.yaml.gold",
         "test_data/percentile-column-overflow.json",

--- a/test/output_formatter_test.cc
+++ b/test/output_formatter_test.cc
@@ -146,12 +146,18 @@ TEST_F(OutputCollectorTest, CsvFormatter) {
                         "test/test_data/output_formatter.csv.gold");
 }
 
+TEST_F(OutputCollectorTest, PrometheusFormatter) {
+  PrometheusOutputFormatterImpl formatter;
+  expectEqualToGoldFile((formatter.formatProto(collector_->toProto())).value(),
+                        "test/test_data/output_formatter.prometheus.gold");
+}
+
 TEST_F(OutputCollectorTest, GetLowerCaseOutputFormats) {
   auto output_formats = OutputFormatterImpl::getLowerCaseOutputFormats();
   // When you're looking at this code you probably just added an output format.
   // This is to point out that you might want to update the list below and add a test above.
   ASSERT_THAT(output_formats, ElementsAre("json", "human", "yaml", "dotted", "fortio",
-                                          "experimental_fortio_pedantic", "csv"));
+                                          "experimental_fortio_pedantic", "csv", "prometheus"));
 }
 
 class FortioOutputCollectorTest : public OutputCollectorTest {

--- a/test/test_data/output_formatter.prometheus.gold
+++ b/test/test_data/output_formatter.prometheus.gold
@@ -1,0 +1,102 @@
+# TYPE nighthawk_bar counter
+nighthawk_bar{scope="worker_0"} 2
+nighthawk_bar{scope="worker_1"} 2
+nighthawk_bar{scope="global"} 2
+# TYPE nighthawk_foo counter
+nighthawk_foo{scope="worker_0"} 1
+nighthawk_foo{scope="worker_1"} 1
+nighthawk_foo{scope="global"} 1
+# TYPE nighthawk_foo_latency summary
+nighthawk_foo_latency{scope="worker_0",quantile="0"} 180
+nighthawk_foo_latency{scope="worker_0",quantile="0.5"} 190
+nighthawk_foo_latency{scope="worker_0",quantile="0.75"} 200
+nighthawk_foo_latency{scope="worker_0",quantile="1"} 210
+nighthawk_foo_latency_count{scope="worker_0"} 4
+nighthawk_foo_latency_sum{scope="worker_0"} 780
+nighthawk_foo_latency{scope="worker_1",quantile="0"} 180
+nighthawk_foo_latency{scope="worker_1",quantile="0.5"} 190
+nighthawk_foo_latency{scope="worker_1",quantile="0.75"} 200
+nighthawk_foo_latency{scope="worker_1",quantile="1"} 210
+nighthawk_foo_latency_count{scope="worker_1"} 4
+nighthawk_foo_latency_sum{scope="worker_1"} 780
+nighthawk_foo_latency{scope="global",quantile="0"} 180
+nighthawk_foo_latency{scope="global",quantile="0.5"} 190
+nighthawk_foo_latency{scope="global",quantile="0.75"} 200
+nighthawk_foo_latency{scope="global",quantile="1"} 210
+nighthawk_foo_latency_count{scope="global"} 4
+nighthawk_foo_latency_sum{scope="global"} 780
+# TYPE nighthawk_foo_latency_max counter
+nighthawk_foo_latency_max{scope="worker_0"} 210
+nighthawk_foo_latency_max{scope="worker_1"} 210
+nighthawk_foo_latency_max{scope="global"} 210
+# TYPE nighthawk_foo_latency_mean counter
+nighthawk_foo_latency_mean{scope="worker_0"} 195
+nighthawk_foo_latency_mean{scope="worker_1"} 195
+nighthawk_foo_latency_mean{scope="global"} 195
+# TYPE nighthawk_foo_latency_min counter
+nighthawk_foo_latency_min{scope="worker_0"} 180
+nighthawk_foo_latency_min{scope="worker_1"} 180
+nighthawk_foo_latency_min{scope="global"} 180
+# TYPE nighthawk_foo_latency_pstdev counter
+nighthawk_foo_latency_pstdev{scope="worker_0"} 11
+nighthawk_foo_latency_pstdev{scope="worker_1"} 11
+nighthawk_foo_latency_pstdev{scope="global"} 11
+# TYPE nighthawk_foo_size summary
+nighthawk_foo_size{scope="worker_0",quantile="0"} 14
+nighthawk_foo_size{scope="worker_0",quantile="0.5"} 15
+nighthawk_foo_size{scope="worker_0",quantile="0.75"} 16
+nighthawk_foo_size{scope="worker_0",quantile="1"} 17
+nighthawk_foo_size_count{scope="worker_0"} 4
+nighthawk_foo_size_sum{scope="worker_0"} 62
+nighthawk_foo_size{scope="worker_1",quantile="0"} 14
+nighthawk_foo_size{scope="worker_1",quantile="0.5"} 15
+nighthawk_foo_size{scope="worker_1",quantile="0.75"} 16
+nighthawk_foo_size{scope="worker_1",quantile="1"} 17
+nighthawk_foo_size_count{scope="worker_1"} 4
+nighthawk_foo_size_sum{scope="worker_1"} 62
+nighthawk_foo_size{scope="global",quantile="0"} 14
+nighthawk_foo_size{scope="global",quantile="0.5"} 15
+nighthawk_foo_size{scope="global",quantile="0.75"} 16
+nighthawk_foo_size{scope="global",quantile="1"} 17
+nighthawk_foo_size_count{scope="global"} 4
+nighthawk_foo_size_sum{scope="global"} 62
+# TYPE nighthawk_foo_size_max counter
+nighthawk_foo_size_max{scope="worker_0"} 17
+nighthawk_foo_size_max{scope="worker_1"} 17
+nighthawk_foo_size_max{scope="global"} 17
+# TYPE nighthawk_foo_size_mean counter
+nighthawk_foo_size_mean{scope="worker_0"} 15.5
+nighthawk_foo_size_mean{scope="worker_1"} 15.5
+nighthawk_foo_size_mean{scope="global"} 15.5
+# TYPE nighthawk_foo_size_min counter
+nighthawk_foo_size_min{scope="worker_0"} 14
+nighthawk_foo_size_min{scope="worker_1"} 14
+nighthawk_foo_size_min{scope="global"} 14
+# TYPE nighthawk_foo_size_pstdev counter
+nighthawk_foo_size_pstdev{scope="worker_0"} 1.118033988749895
+nighthawk_foo_size_pstdev{scope="worker_1"} 1.118033988749895
+nighthawk_foo_size_pstdev{scope="global"} 1.118033988749895
+# TYPE nighthawk_stat_id_count counter
+nighthawk_stat_id_count{scope="worker_0"} 3
+nighthawk_stat_id_count{scope="worker_1"} 3
+nighthawk_stat_id_count{scope="global"} 3
+# TYPE nighthawk_stat_id_max counter
+nighthawk_stat_id_max{scope="worker_0"} 3000
+nighthawk_stat_id_max{scope="worker_1"} 3000
+nighthawk_stat_id_max{scope="global"} 3000
+# TYPE nighthawk_stat_id_mean counter
+nighthawk_stat_id_mean{scope="worker_0"} 2000
+nighthawk_stat_id_mean{scope="worker_1"} 2000
+nighthawk_stat_id_mean{scope="global"} 2000
+# TYPE nighthawk_stat_id_min counter
+nighthawk_stat_id_min{scope="worker_0"} 1000
+nighthawk_stat_id_min{scope="worker_1"} 1000
+nighthawk_stat_id_min{scope="global"} 1000
+# TYPE nighthawk_stat_id_pstdev counter
+nighthawk_stat_id_pstdev{scope="worker_0"} 816
+nighthawk_stat_id_pstdev{scope="worker_1"} 816
+nighthawk_stat_id_pstdev{scope="global"} 816
+# TYPE nighthawk_stat_id_sum counter
+nighthawk_stat_id_sum{scope="worker_0"} 6000
+nighthawk_stat_id_sum{scope="worker_1"} 6000
+nighthawk_stat_id_sum{scope="global"} 6000


### PR DESCRIPTION
See commit message for more details.

This Pull Request adds support for `prometheus` output-format support to `nighthawk_client` and `nighthawk_output_transform`.

Example Usage:

```bash
# Run nighthawk_client and report results in prometheus compatible metrics format.
nighthawk_client http://httpbin.org/ --output-format prometheus

# Run nighthawk_client and emit results to prometheus through a pushgateway.
nighthawk_client http://httpbin.org/ --output-format prometheus -v critical | \
    curl --data-binary @- \
    "http://<prom-pushgateway>/metrics/job/http-benchmark/instance/test"

# Run nighthawk_output_transform to convert nighthawk native json results output to prometheus metrics.
nighthawk_client http://httpbin.org/ --output-format json -v critical | \
    nighthawk_output_transform --output-format prometheus
```

Prometheus output format emits nighthawk result counters as prometheus `counters` and statistics as `summary`.