### PR TITLE
Address bugs in updater utility: Bazel clean, remove --gpg-sign, commit last-known-good in mixed case

### DIFF
--- a/docs/root/updating_envoy_dependency.md
+++ b/docs/root/updating_envoy_dependency.md
@@ -268,16 +268,6 @@ merge_from_envoy "tools/code_format/config.yaml"
 
 ### Step 11
 
-Perform this step if [tools/base/requirements.in](/tools/base/requirements.in)
-has not been updated in the last 30 days (based on comment at top of file).
-
-```bash
-head -1 tools/base/requirements.in
-```
-
-- If less than 30 days ago, skip to next step.
-- If more than 30 days ago, do the rest of this step.
-
 The Python dependencies need to be updated regularly. The list of packages
 the Nighthawk codebase uses is listed in
 [tools/base/requirements.in](/tools/base/requirements.in). This file specifies
@@ -287,15 +277,9 @@ incompatibility is found, you can pin a package by specifying a `<=` constraint.
 These should always be accompanied with a comment explaining them. Avoid using
 `==` constraint to the extent possible.
 
-First attempt to remove all existing pins in
-[tools/base/requirements.in](/tools/base/requirements.in) to see if they are
-still necessary. Once done editing
-[tools/base/requirements.in](/tools/base/requirements.in), delete the contents
-of [tools/base/requirements.txt](/tools/base/requirements.txt) and update the
-dependencies by running:
+Update the dependencies by running:
 
 ```bash
-echo > tools/base/requirements.txt
 bazel run //tools/base:requirements.update
 ```
 


### PR DESCRIPTION
Addressing usability concerns and bugs noticed in use:

- Run `bazel clean --expunge` before running through Envoy commits; one integration attempt failed because of a messy workspace rather than any actual problem with the Envoy commit.
- Remove the `--gpg-sign` flag from the `git commit` step, which is not required by the Nighthawk repo.
- Update the handling for a mixed case bisection result (some passing, some failing) to ensure the generated temporary commit applies the latest _passing_ Envoy commit. Previously, in the case where the bisection runs a failing commit as its last attempt, the utility wouldn't revert state to the last-known-good commit integration.
- Remove `x` from repo cleanup step to preserve .gitignore files.
- Update manual Envoy update docs to remove version pinning (as all pins have been removed and should stay removed).

Tested by running the updater and producing https://github.com/envoyproxy/nighthawk/pull/1416 (see https://gist.github.com/ebyerly/61e710c91227ccfb656ee3d64976bb63).