### PR TITLE
ci: push nighthawk images tagged with Github SHA

### DIFF
--- a/ci/docker/docker_push.sh
+++ b/ci/docker/docker_push.sh
@@ -25,5 +25,8 @@ fi
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
 docker push "${DOCKER_IMAGE_PREFIX}-dev:latest"
+
+# Push image tagged with Github SHA.
 docker tag "${DOCKER_IMAGE_PREFIX}-dev:latest" \
   "${DOCKER_IMAGE_PREFIX}-dev:${GH_SHA1}"
+docker push "${DOCKER_IMAGE_PREFIX}-dev:${GH_SHA1}"


### PR DESCRIPTION
When using nighthawk docker image it would be helpful for downstream consumers to have a stable tag for reference instead of rely on `latest`.