### PR TITLE
Add agent_invocation for LLM-in-the-loop Envoy commit integration

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -58,6 +58,9 @@ You can customize the script's behavior using the following arguments:
 *   `--branch_name NAME`: The name of the branch to create in the Nighthawk
     repository for the update. Default: `update-envoy-YYYYMMDD` (e.g.,
     `update-envoy-20250809`)
+*   `--agent_invocation CMD`: Command to invoke an LLM agent (e.g., `gemini`) to
+    attempt to automatically fix errors. The agent will be called with the
+    prompt provided via stdin. Default: `None`
 
 The script provides detailed output for each step it performs, prefixed with
 `NighthawkEnvoyUpdate:` or `....EnvoyCommitIntegration:` for sub-steps.
@@ -71,6 +74,21 @@ manual step (like resolving merge conflicts):
 
 The script will detect the existing branch, rebase it on `origin/main` if
 necessary, and attempt to continue the update process.
+
+### LLM-in-the-loop automated integration fix
+
+To experimentaly enable automated fixes, you can use the `--agent_invocation`
+argument. The utility will use the specified command (e.g. `gemini`) when a step
+fails and pass a detailed prompt via stdin. The agent can then attempt to modify
+the files in your local Nighthawk repository to resolve the issue. The utility
+gives the agent 3 tries to fix an error before returning the error to the user.
+
+```bash
+./tools/nighthawk_envoy_updater.py \
+  --nighthawk_dir ~/my_local_nighthawk_git_repo \
+  --branch_name my-envoy-update-with-agent \
+  --agent_invocation gemini
+```
 
 ### Outcomes
 

--- a/tools/nighthawk_envoy_updater.py
+++ b/tools/nighthawk_envoy_updater.py
@@ -13,11 +13,15 @@ import argparse
 import datetime
 import enum
 import pathlib
+import pprint
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
 from typing import Generic, TypeVar
+
+MAX_AGENT_ATTEMPTS = 3
 
 # Files Nighthawk re-uses (almost) verbatim from its Envoy dependency.
 shared_files: list[str] = [
@@ -28,11 +32,6 @@ shared_files: list[str] = [
     "tools/code_format/config.yaml",
     "tools/gen_compilation_database.py",
 ]
-
-
-def _print_command(command: list[str], cwd: pathlib.Path | None = None):
-  cwd = cwd if cwd else pathlib.Path.cwd()
-  print(f'$ pushd {cwd} && {" ".join(command)} && popd')
 
 
 def _run_command(
@@ -46,7 +45,9 @@ def _run_command(
   if interactive:
     print("\nThe current operation may require human attention to proceed.")
     input("Press enter and monitor for ~10 seconds for more prompts...")
-  _print_command(command=command, cwd=cwd)
+  cmd = (f'pushd {cwd if cwd else pathlib.Path.cwd()} && {" ".join(command)} &&'
+         " popd")
+  print(f"$ {cmd}")
   try:
     result = subprocess.run(
         command,
@@ -59,11 +60,9 @@ def _run_command(
     )
     return result.stdout.strip() if result.stdout else ""
   except subprocess.CalledProcessError as e:
-    print(f"Command failed: {e}", file=sys.stderr)
-    if e.stdout:
-      print(f"STDOUT:\n{e.stdout.strip()}", file=sys.stderr)
-    if e.stderr:
-      print(f"STDERR:\n{e.stderr.strip()}", file=sys.stderr)
+    print(e, file=sys.stderr)
+    # Update the captured command to include the subprocess's working directory.
+    setattr(e, "cmd", cmd)
     raise
 
 
@@ -76,7 +75,8 @@ def _run_sed_replace(old_pattern: str, new_pattern: str, filename: str):
     raise RuntimeError("Failed to replace file contents.")
 
 
-def _non_trivial_merge_instructions(envoy_commit: str, nighthawk_dir: str, branch_name: str):
+def _non_trivial_merge_instructions(envoy_commit: str, nighthawk_git_repo_dir: str,
+                                    branch_name: str):
   return f"""Ran partial integration of Envoy commit {envoy_commit}.
 
       The Nighthawk repository branch {branch_name} has been left in a state
@@ -87,15 +87,15 @@ def _non_trivial_merge_instructions(envoy_commit: str, nighthawk_dir: str, branc
       Please address any merge conflicts, tooling failures, and build or test
       failures, then commit your manual changes using:
 
-        git -C {nighthawk_dir} add . && \
-          git -C {nighthawk_dir} commit -m 'Updating Envoy to {envoy_commit}'
+        git -C {nighthawk_git_repo_dir} add . && \
+          git -C {nighthawk_git_repo_dir} commit -m 'Updating Envoy to {envoy_commit}'
 
       Link to failing commit:
       https://github.com/envoyproxy/envoy/commit/{envoy_commit}
       """
 
 
-def _patch_merge_conflict_instructions(envoy_commit: str, nighthawk_dir: str):
+def _patch_merge_conflict_instructions(envoy_commit: str, nighthawk_git_repo_dir: str):
   return f"""New merge conflicts from integrating changes in shared files.
 
       Nighthawk maintains separate copies of a subset of files from the Envoy
@@ -108,7 +108,7 @@ def _patch_merge_conflict_instructions(envoy_commit: str, nighthawk_dir: str):
 
       Integrating changes in shared files from commit {envoy_commit}
       introduced merge conflicts because Envoy modified a lined marked by
-      `# unique`. These merge conflicts are recorded in the {nighthawk_dir} repo
+      `# unique`. These merge conflicts are recorded in the {nighthawk_git_repo_dir} repo
       as ".rej" files.
 
       For merge conflicts, you must manually inspect Nighthawk's copy and
@@ -142,59 +142,86 @@ class StepHandler(Generic[TStep]):
     step_enum: The enum type for the steps.
     steps: A list of all possible steps.
     step_tracker: A dictionary to track the status and errors of each step.
+    agent_invocation: Command template to invoke an LLM agent to fix step
+      failures.
   """
 
-  def __init__(self, step_enum: TStep):
+  def __init__(self, step_enum: TStep, agent_invocation: str | None = None):
     """Initialize the StepHandler.
 
     Args:
       step_enum: The enum type defining the sequence of steps.
+      agent_invocation: Command template to invoke the agent.
     """
-    self.step_enum = step_enum
     self.steps = list(step_enum)
-    self.step_tracker = {
-        step: {
-            "status": StepStatus.PENDING,
-            "error": None,
-        } for step in self.steps
-    }
+    self.step_tracker = {step: StepStatus.PENDING for step in self.steps}
+    self.agent_invocation = agent_invocation
 
   def _set_step_success(self, step: TStep):
     """Set the status of a step to SUCCESS."""
-    self.step_tracker[step]["status"] = StepStatus.SUCCESS
+    self.step_tracker[step] = StepStatus.SUCCESS
 
   def _set_step_failure(self, step: TStep, error: str):
     """Set the status of a step to FAILED and record the error."""
-    self.step_tracker[step]["status"] = StepStatus.FAILED
-    self.step_tracker[step]["error"] = error
-    for member in self.step_enum:
-      if self.step_tracker[member]["status"] == StepStatus.PENDING:
-        self.step_tracker[member]["status"] = StepStatus.CANCELLED
-
-  def _set_step_cancelled(self, step: TStep):
-    """Set the status of a step to CANCELLED."""
-    self.step_tracker[step]["status"] = StepStatus.CANCELLED
+    self.step_tracker[step] = StepStatus.FAILED
+    for member in self.steps:
+      if self.step_tracker[member] == StepStatus.PENDING:
+        self.step_tracker[step] = StepStatus.CANCELLED
 
   def _set_step_not_planned(self, step: TStep):
     """Set the status of a step to NOT_PLANNED."""
-    self.step_tracker[step]["status"] = StepStatus.NOT_PLANNED
+    self.step_tracker[step] = StepStatus.NOT_PLANNED
 
   def _run_step(self, step: TStep):
     """Run the logic for a single step. Must be overridden by subclasses."""
     raise RuntimeError("Must be overridden")
 
-  def _get_summary(self, line_prefix: str = "") -> str:
-    """Return a string summarizing the status of all steps."""
-    summary = f"\n{line_prefix}\n" if line_prefix else ""
-    for step in self.steps:
-      step_tracker = self.step_tracker[step]
-      out = f"{line_prefix}{step.name:<36}{step_tracker['status']}\n"
-      if step_tracker["error"]:
-        out += f"  Error: {step_tracker['error']}\n"
-      summary += out
-    return summary
+  def _get_step_failure_summary(self, step: TStep, error: Exception) -> str:
+    """Create a readable and understandable summary of a step execution failure."""
+    stdout = getattr(error, "stdout", "N/A")
+    stderr = getattr(error, "stderr", "N/A")
+    cmd = getattr(error, "cmd", "N/A")
 
-  def _run_steps(self, line_prefix: str) -> bool:
+    return "\n".join([
+        "## Failing Step Context\n",
+        f"- **Failing Step:** {step.name}",
+        f"- **Error:** {error}",
+        f"- **Failed Command:** `{cmd}`",
+        "",
+        "### STDOUT\n",
+        f"```\n{stdout}\n```",
+        "",
+        "### STDERR\n",
+        f"```\n{stderr}\n```",
+        "",
+        "## StepHandler Instance State\n",
+        pprint.pformat(vars(self), sort_dicts=False),
+        "",
+    ])
+
+  def _get_additional_agent_context(self, step: TStep, error: Exception) -> str:
+    """Return additional context for the agent prompt. Can be overridden."""
+    return ""
+
+  def _create_agent_prompt(self, step: TStep, error: Exception) -> str:
+    """Create a prompt file for the agent and return the path."""
+    cmd = getattr(error, "cmd", "N/A")
+
+    failure_summary = self._get_step_failure_summary(step, error)
+    additional_context = self._get_additional_agent_context(step, error)
+    instructions = "\n".join([
+        "## Agent Instructions\n",
+        "Based on the context and instance state above, fix the files in the ",
+        "nighthawk_git_repo_dir to resolve the error. The primary goal ",
+        "is to make the failing command pass:",
+        f"```sh\n{cmd}\n```",
+        "Avoid changing the behavior of Nighthawk's tests, if possible.",
+        "The Envoy source code for the target commit is available in a tmp ",
+        "directory under the Nighthawk project root parent, envoy_git_repo_dir.",
+    ])
+    return "\n".join([failure_summary, additional_context, instructions])
+
+  def _run_steps(self, line_prefix: str, prior_attempts=0) -> bool:
     """Run all pending steps in sequence.
 
     Args:
@@ -205,10 +232,7 @@ class StepHandler(Generic[TStep]):
     """
     clean_finish = True
     for step in self.steps:
-      if self.step_tracker[step]["status"] in [
-          StepStatus.CANCELLED,
-          StepStatus.NOT_PLANNED,
-      ]:
+      if self.step_tracker[step] != StepStatus.PENDING:
         continue
       print(f"\n{line_prefix}{step}")
       try:
@@ -220,9 +244,25 @@ class StepHandler(Generic[TStep]):
           ValueError,
           subprocess.CalledProcessError,
       ) as e:
-        self._set_step_failure(step, e)
-        clean_finish = False
-    print(self._get_summary(line_prefix))
+        if not self.agent_invocation or prior_attempts >= MAX_AGENT_ATTEMPTS:
+          self._set_step_failure(step, e)
+          clean_finish = False
+          print(self._get_step_failure_summary(step, e))
+        else:
+          print(f"\n\nStep {step.name} failed. Invoking agent (attempt"
+                f" {prior_attempts + 1}/{MAX_AGENT_ATTEMPTS})...")
+          prompt = self._create_agent_prompt(step, e)
+          print(f"\n\nAgent prompt:\n\n{prompt}\n\n")
+          subprocess.run(
+              shlex.split(self.agent_invocation),
+              cwd=self.nighthawk_git_repo_dir.parent
+              if hasattr(self, "nighthawk_git_repo_dir") else None,
+              input=prompt,
+              text=True,
+              check=True,
+          )
+          print("Agent fix attempt finished. Retrying...")
+          self._run_steps(line_prefix, prior_attempts + 1)
     return clean_finish
 
 
@@ -245,32 +285,60 @@ class EnvoyCommitIntegration(StepHandler[EnvoyCommitIntegrationStep]):
 
   def __init__(
       self,
-      nighthawk_dir: pathlib.Path,
-      envoy_dir: pathlib.Path,
+      nighthawk_git_repo_dir: pathlib.Path,
+      envoy_git_repo_dir: pathlib.Path,
       current_envoy_commit: str,
       target_envoy_commit: str,
+      agent_invocation: str,
   ):
     """Initialize the EnvoyCommitIntegration.
 
     Args:
-      nighthawk_dir: The path to the local Nighthawk git repository.
-      envoy_dir: The path to the local Envoy git repository.
+      nighthawk_git_repo_dir: The path to the local Nighthawk git repository.
+      envoy_git_repo_dir: The path to the local Envoy git repository.
       current_envoy_commit: The current Envoy commit hash in Nighthawk.
       target_envoy_commit: The target Envoy commit hash to integrate.
+      agent_invocation: Command template to invoke an LLM agent to fix step
+        failures.
     """
-    super().__init__(EnvoyCommitIntegrationStep)
-    self.nighthawk_dir = nighthawk_dir
-    self.envoy_dir = envoy_dir
+    super().__init__(EnvoyCommitIntegrationStep, agent_invocation)
+    self.nighthawk_git_repo_dir = nighthawk_git_repo_dir
+    self.envoy_git_repo_dir = envoy_git_repo_dir
     self.current_envoy_commit = current_envoy_commit
     self.target_envoy_commit = target_envoy_commit
     self.envoy_sha = None
+
+  def _get_additional_agent_context(self, step: EnvoyCommitIntegrationStep,
+                                    error: Exception) -> str:
+    """Provide the git repo diff information as additional context for the agent."""
+    try:
+      nighthawk_diff = _run_command(["git", "diff", "--no-color", "-U1"],
+                                    cwd=self.nighthawk_git_repo_dir)
+      envoy_diff_stat = _run_command([
+          "git", "diff", "--no-color", "--stat",
+          f"{self.current_envoy_commit}..{self.target_envoy_commit}"
+      ],
+                                     cwd=self.envoy_git_repo_dir)
+      return "\n".join([
+          "## Nighthawk diff\n",
+          "The Nighthawk git repo has already been modified, per the following diff:",
+          f"```diff\n{nighthawk_diff}\n```",
+          "",
+          "## Envoy Diff (current to target)\n",
+          "The following diff stat describes how Envoy has been modified between ",
+          "Nighthawk's current Envoy commit and its new target Envoy commit:",
+          f"```diff\n{envoy_diff_stat}\n```",
+          "",
+      ])
+    except Exception:
+      return ""
 
   def _run_step(self, step: EnvoyCommitIntegrationStep):
     """Run the logic for a single Envoy commit integration step."""
     match step:
       case EnvoyCommitIntegrationStep.RESET_NIGHTHAWK_REPO:
-        _run_command(["git", "reset", "--hard", "HEAD"], cwd=self.nighthawk_dir)
-        _run_command(["git", "clean", "-fdx"], cwd=self.nighthawk_dir)
+        _run_command(["git", "reset", "--hard", "HEAD"], cwd=self.nighthawk_git_repo_dir)
+        _run_command(["git", "clean", "-fdx"], cwd=self.nighthawk_git_repo_dir)
       case EnvoyCommitIntegrationStep.GET_ENVOY_SHA:
         tarball_url = f"https://github.com/envoyproxy/envoy/archive/{self.target_envoy_commit}.tar.gz"
         self.envoy_sha = _run_command(
@@ -278,7 +346,7 @@ class EnvoyCommitIntegration(StepHandler[EnvoyCommitIntegrationStep]):
             shell=True,
         )
       case EnvoyCommitIntegrationStep.SET_NIGHTHAWK_BAZEL_DEP:
-        repo_file = self.nighthawk_dir / "bazel/repositories.bzl"
+        repo_file = self.nighthawk_git_repo_dir / "bazel/repositories.bzl"
         _run_sed_replace(
             old_pattern='ENVOY_COMMIT = ".*"',
             new_pattern=f'ENVOY_COMMIT = "{self.target_envoy_commit}"',
@@ -297,7 +365,7 @@ class EnvoyCommitIntegration(StepHandler[EnvoyCommitIntegrationStep]):
                 f" {self.current_envoy_commit}..{self.target_envoy_commit} -- " +
                 " ".join(shared_files) + f" > {patch_file_name}"
             ],
-            cwd=self.envoy_dir,
+            cwd=self.envoy_git_repo_dir,
             shell=True,
         )
 
@@ -309,7 +377,7 @@ class EnvoyCommitIntegration(StepHandler[EnvoyCommitIntegrationStep]):
           _run_command(
               ["git apply --ignore-whitespace --ignore-space-change"
                f" < {patch_file_name}"],
-              cwd=self.nighthawk_dir,
+              cwd=self.nighthawk_git_repo_dir,
               shell=True,
           )
         except subprocess.CalledProcessError as e:
@@ -318,28 +386,28 @@ class EnvoyCommitIntegration(StepHandler[EnvoyCommitIntegrationStep]):
                   "git apply --reject --ignore-whitespace --ignore-space-change"
                   f" < {patch_file_name}"
               ],
-              cwd=self.nighthawk_dir,
+              cwd=self.nighthawk_git_repo_dir,
               shell=True,
           )
           raise RuntimeError(
               _patch_merge_conflict_instructions(self.target_envoy_commit,
-                                                 self.nighthawk_dir)) from e
+                                                 self.nighthawk_git_repo_dir)) from e
       case EnvoyCommitIntegrationStep.BAZEL_UPDATE_REQUIREMENTS:
         _run_command(
             ["bazel", "run", "//tools/base:requirements.update"],
-            cwd=self.nighthawk_dir,
+            cwd=self.nighthawk_git_repo_dir,
         )
       case EnvoyCommitIntegrationStep.BUILD_NIGHTHAWK:
-        _run_command(["./ci/do_ci.sh", "build"], cwd=self.nighthawk_dir)
+        _run_command(["./ci/do_ci.sh", "build"], cwd=self.nighthawk_git_repo_dir)
       case EnvoyCommitIntegrationStep.TEST_NIGHTHAWK:
-        _run_command(["./ci/do_ci.sh", "test"], cwd=self.nighthawk_dir)
+        _run_command(["./ci/do_ci.sh", "test"], cwd=self.nighthawk_git_repo_dir)
       case EnvoyCommitIntegrationStep.UPDATE_CLI_README:
         _run_command(
             ["./tools/update_cli_readme_documentation.sh", "--mode=fix"],
-            cwd=self.nighthawk_dir,
+            cwd=self.nighthawk_git_repo_dir,
         )
       case EnvoyCommitIntegrationStep.FIX_FORMAT:
-        _run_command(["./ci/do_ci.sh", "fix_format"], cwd=self.nighthawk_dir)
+        _run_command(["./ci/do_ci.sh", "fix_format"], cwd=self.nighthawk_git_repo_dir)
       case _:
         raise ValueError(f"{step} is not supported.")
 
@@ -375,26 +443,30 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
 
   def __init__(
       self,
-      nighthawk_dir: pathlib.Path,
+      nighthawk_git_repo_dir: pathlib.Path,
       branch_name: str,
       envoy_clone_depth: int,
       sync_nighthawk_repo: bool,
+      agent_invocation: str | None = None,
   ):
     """Initialize the NighthawkEnvoyUpdate.
 
     Args:
-      nighthawk_dir: The path to the local Nighthawk git repository.
+      nighthawk_git_repo_dir: The path to the local Nighthawk git repository.
       branch_name: The name of the branch to create for the update.
       sync_nighthawk_repo: Whether to sync the Nighthawk repo with upstream.
       envoy_clone_depth: The depth to use when cloning the Envoy repository.
+      agent_invocation: Command template to invoke an LLM agent to fix step
+        failures.
     """
-    super().__init__(NighthawkEnvoyUpdateStep)
-    self.nighthawk_dir = nighthawk_dir.expanduser()
+    super().__init__(NighthawkEnvoyUpdateStep, agent_invocation)
+    self.nighthawk_git_repo_dir = nighthawk_git_repo_dir.expanduser()
     self.branch_name = branch_name
     self.envoy_clone_depth = envoy_clone_depth
 
-    self._envoy_tmp_dir = tempfile.TemporaryDirectory()
-    self.envoy_dir = pathlib.Path(self._envoy_tmp_dir.name)
+    self._envoy_tmp_dir = tempfile.TemporaryDirectory(dir=self.nighthawk_git_repo_dir.parent,
+                                                      prefix="envoy-clone-")
+    self.envoy_git_repo_dir = pathlib.Path(self._envoy_tmp_dir.name)
 
     self.github_username = None
     self.current_envoy_commit = None
@@ -407,20 +479,24 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
     if not sync_nighthawk_repo:
       self._set_step_not_planned(NighthawkEnvoyUpdateStep.SYNC_NIGHTHAWK_REPO)
 
+  def cleanup(self):
+    """Clean up state modifications made by NighthawkEnvoyUpdate."""
+    self._envoy_tmp_dir.cleanup()
+
   def _run_step(self, step: NighthawkEnvoyUpdateStep):
     """Run the logic for a single Nighthawk Envoy update step."""
     match step:
       case NighthawkEnvoyUpdateStep.CHECK_NIGHTHAWK_DIR:
-        if not self.nighthawk_dir.is_dir():
-          raise RuntimeError(f"Nighthawk directory not found: {self.nighthawk_dir}")
+        if not self.nighthawk_git_repo_dir.is_dir():
+          raise RuntimeError(f"Nighthawk directory not found: {self.nighthawk_git_repo_dir}")
       case NighthawkEnvoyUpdateStep.CHECK_NIGHTHAWK_GIT_REPO:
         try:
           _run_command(
               ["git", "rev-parse", "--is-inside-work-tree"],
-              cwd=self.nighthawk_dir,
+              cwd=self.nighthawk_git_repo_dir,
           )
         except subprocess.CalledProcessError as e:
-          raise RuntimeError(f"Nighthawk directory {self.nighthawk_dir} is not a git"
+          raise RuntimeError(f"Nighthawk directory {self.nighthawk_git_repo_dir} is not a git"
                              " repository.") from e
       case NighthawkEnvoyUpdateStep.CHECK_NIGHTHAWK_GIT_SIGNING:
         try:
@@ -431,57 +507,67 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
                   "support/hooks/prepare-commit-msg",
                   ".git/hooks/prepare-commit-msg",
               ],
-              cwd=self.nighthawk_dir,
+              cwd=self.nighthawk_git_repo_dir,
           )
         except subprocess.CalledProcessError as e:
-          raise RuntimeError(f"Nighthawk directory {self.nighthawk_dir} is not configured to"
-                             " use a signing key with commits.") from e
+          raise RuntimeError(f"Nighthawk directory {self.nighthawk_git_repo_dir} is not"
+                             " configured to use a signing key with commits.") from e
       case NighthawkEnvoyUpdateStep.CHECK_NIGHTHAWK_GIT_STATUS:
-        if _run_command(["git", "status", "--porcelain"], cwd=self.nighthawk_dir):
+        if _run_command(["git", "status", "--porcelain"], cwd=self.nighthawk_git_repo_dir):
           raise RuntimeError("Nighthawk has uncommitted changes. Please reset or commit them.")
       case NighthawkEnvoyUpdateStep.CHECK_NIGHTHAWK_UPSTREAM_REMOTE:
         expected_upstream = "https://github.com/envoyproxy/nighthawk"
         try:
-          upstream_url = _run_command(["git", "remote", "get-url", "upstream"],
-                                      cwd=self.nighthawk_dir)
+          upstream_url = _run_command(
+              ["git", "remote", "get-url", "upstream"],
+              cwd=self.nighthawk_git_repo_dir,
+          )
           if upstream_url != expected_upstream:
-            raise RuntimeError(f"Nighthawk directory {self.nighthawk_dir} remote upstream is"
-                               f" not set to {expected_upstream}. Got: {upstream_url}")
+            raise RuntimeError(f"Nighthawk directory {self.nighthawk_git_repo_dir} remote"
+                               f" upstream is not set to {expected_upstream}. Got:"
+                               f" {upstream_url}")
         except subprocess.CalledProcessError as e:
-          raise RuntimeError(f"Nighthawk directory {self.nighthawk_dir} does not have a"
-                             f" remote named upstream set to {expected_upstream}.") from e
+          raise RuntimeError(f"Nighthawk directory {self.nighthawk_git_repo_dir} does not have"
+                             f" a remote named upstream set to {expected_upstream}.") from e
       case NighthawkEnvoyUpdateStep.CHECK_NIGHTHAWK_ORIGIN_REMOTE:
         try:
-          origin_url = _run_command(["git", "remote", "get-url", "origin"], cwd=self.nighthawk_dir)
+          origin_url = _run_command(
+              ["git", "remote", "get-url", "origin"],
+              cwd=self.nighthawk_git_repo_dir,
+          )
         except subprocess.CalledProcessError as e:
-          raise RuntimeError(f"Failed to get remote origin URL. Is {self.nighthawk_dir} a"
-                             " git repository with an origin remote configured?") from e
+          raise RuntimeError("Failed to get remote origin URL. Is"
+                             f" {self.nighthawk_git_repo_dir} a git repository with an origin"
+                             " remote configured?") from e
         match = re.search(r"github.com[:/](.*?)/nighthawk(?:.git)?$", origin_url)
         if match:
           self.github_username = match.group(1)
         else:
           raise RuntimeError(f"Could not extract GitHub username from origin URL: {origin_url}")
       case NighthawkEnvoyUpdateStep.SYNC_NIGHTHAWK_REPO:
-        _run_command(["git", "checkout", "main"], cwd=self.nighthawk_dir)
+        _run_command(["git", "checkout", "main"], cwd=self.nighthawk_git_repo_dir)
         _run_command(
-            ["git", "fetch", "--all"],
-            cwd=self.nighthawk_dir,
+            ["git fetch --all && git merge upstream/main && git push origin"
+             " main"],
+            cwd=self.nighthawk_git_repo_dir,
             interactive=True,
+            shell=True,
         )
-        _run_command(["git", "merge", "upstream/main"], cwd=self.nighthawk_dir)
-        _run_command(["git", "push", "origin", "main"], cwd=self.nighthawk_dir)
       case NighthawkEnvoyUpdateStep.CHECKOUT_UPDATE_BRANCH:
         try:
           _run_command(
               ["git", "checkout", "-b", self.branch_name, "origin/main"],
-              cwd=self.nighthawk_dir,
+              cwd=self.nighthawk_git_repo_dir,
           )
         except subprocess.CalledProcessError:
           # Failed to create branch, attempting to checkout.
-          _run_command(["git", "checkout", self.branch_name], cwd=self.nighthawk_dir)
-          _run_command(["git", "rebase", "origin/main"], cwd=self.nighthawk_dir)
+          _run_command(
+              ["git", "checkout", self.branch_name],
+              cwd=self.nighthawk_git_repo_dir,
+          )
+          _run_command(["git", "rebase", "origin/main"], cwd=self.nighthawk_git_repo_dir)
       case NighthawkEnvoyUpdateStep.GET_CURRENT_ENVOY_COMMIT:
-        repo_file = self.nighthawk_dir / "bazel/repositories.bzl"
+        repo_file = self.nighthawk_git_repo_dir / "bazel/repositories.bzl"
         self.current_envoy_commit = _run_command(
             [r"""sed -nE 's/^ENVOY_COMMIT = "(.*)"$/\1/p' """ + str(repo_file)],
             shell=True,
@@ -494,13 +580,13 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
             "clone",
             f"--depth={self.envoy_clone_depth}",
             "https://github.com/envoyproxy/envoy.git",
-            str(self.envoy_dir),
+            str(self.envoy_git_repo_dir),
         ],)
       case NighthawkEnvoyUpdateStep.CHECK_ENVOY_CLONE_DEPTH:
         try:
           _run_command(
               ["git", "cat-file", "-e", self.current_envoy_commit],
-              cwd=self.envoy_dir,
+              cwd=self.envoy_git_repo_dir,
           )
         except subprocess.CalledProcessError as e:
           raise RuntimeError(f"The current Envoy commit {self.current_envoy_commit} used in"
@@ -508,7 +594,8 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
                              " history. Please try again with a larger --envoy_clone_depth"
                              f" value than {self.envoy_clone_depth}.") from e
       case NighthawkEnvoyUpdateStep.GET_LATEST_ENVOY_COMMIT:
-        self.latest_envoy_commit = _run_command(["git", "rev-parse", "main"], cwd=self.envoy_dir)
+        self.latest_envoy_commit = _run_command(["git", "rev-parse", "main"],
+                                                cwd=self.envoy_git_repo_dir)
         if self.current_envoy_commit == self.latest_envoy_commit:
           print("\n\nNighthawk is up-to-date, no new commits in Envoy repo.")
           sys.exit(0)
@@ -521,12 +608,12 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
                 "--pretty=%H",
                 f"{self.current_envoy_commit}..{self.latest_envoy_commit}",
             ],
-            cwd=self.envoy_dir,
+            cwd=self.envoy_git_repo_dir,
         )
 
         self.envoy_commits_current_to_latest = [c for c in current_to_latest_raw.splitlines() if c]
       case NighthawkEnvoyUpdateStep.BAZEL_CLEAN_EXPUNGE:
-        _run_command(["bazel", "clean", "--expunge"], cwd=self.nighthawk_dir)
+        _run_command(["bazel", "clean", "--expunge"], cwd=self.nighthawk_git_repo_dir)
       case NighthawkEnvoyUpdateStep.FIND_LATEST_TRIVIAL_MERGE:
         statuses = [" " * 8] * len(self.envoy_commits_current_to_latest)
 
@@ -550,10 +637,11 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
           print("")
 
           clean_integration = EnvoyCommitIntegration(
-              nighthawk_dir=self.nighthawk_dir,
-              envoy_dir=self.envoy_dir,
+              nighthawk_git_repo_dir=self.nighthawk_git_repo_dir,
+              envoy_git_repo_dir=self.envoy_git_repo_dir,
               current_envoy_commit=self.current_envoy_commit,
               target_envoy_commit=target_envoy_commit,
+              agent_invocation=self.agent_invocation,
           ).run_envoy_commit_integration_steps()
 
           if clean_integration:
@@ -586,24 +674,27 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
           # Set the Nighthawk repo to the latest best commit
           self.best_envoy_commit = self.envoy_commits_current_to_latest[latest_passing_commit_index]
           EnvoyCommitIntegration(
-              nighthawk_dir=self.nighthawk_dir,
-              envoy_dir=self.envoy_dir,
+              nighthawk_git_repo_dir=self.nighthawk_git_repo_dir,
+              envoy_git_repo_dir=self.envoy_git_repo_dir,
               current_envoy_commit=self.current_envoy_commit,
               target_envoy_commit=self.best_envoy_commit,
+              agent_invocation=self.agent_invocation,
           ).run_envoy_commit_integration_steps()
       case NighthawkEnvoyUpdateStep.COMMIT_AND_PUSH_UPDATE_BRANCH:
         if not self.best_envoy_commit:
           raise RuntimeError("Nighthawk repo attempting to commit when no trivial Envoy"
                              " merges were found.")
-        _run_command(["git", "add", "."], cwd=self.nighthawk_dir)
+        _run_command(["git", "add", "."], cwd=self.nighthawk_git_repo_dir)
         _run_command(
             [
                 "git",
                 "commit",
                 "-m",
-                f"Updating Envoy version to {self.best_envoy_commit[:7]} ({datetime.datetime.now().strftime('%b %d, %Y')})",
+                ("Updating Envoy version to"
+                 f" {self.best_envoy_commit[:7]} ({datetime.datetime.now().strftime('%b %d, %Y')})"
+                ),
             ],
-            cwd=self.nighthawk_dir,
+            cwd=self.nighthawk_git_repo_dir,
             interactive=True,
         )
         _run_command(
@@ -615,7 +706,7 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
                 "origin",
                 self.branch_name,
             ],
-            cwd=self.nighthawk_dir,
+            cwd=self.nighthawk_git_repo_dir,
             interactive=True,
         )
         print(f"""
@@ -627,15 +718,16 @@ class NighthawkEnvoyUpdate(StepHandler[NighthawkEnvoyUpdateStep]):
           raise RuntimeError("Nighthawk repo attempting to apply partial merge when"
                              " first_non_trivial_commit is not set.")
         EnvoyCommitIntegration(
-            nighthawk_dir=self.nighthawk_dir,
-            envoy_dir=self.envoy_dir,
+            nighthawk_git_repo_dir=self.nighthawk_git_repo_dir,
+            envoy_git_repo_dir=self.envoy_git_repo_dir,
             current_envoy_commit=self.current_envoy_commit,
             target_envoy_commit=self.first_non_trivial_commit,
+            agent_invocation=self.agent_invocation,
         ).run_envoy_commit_integration_steps()
         raise RuntimeError(
             _non_trivial_merge_instructions(
                 envoy_commit=self.first_non_trivial_commit,
-                nighthawk_dir=self.nighthawk_dir,
+                nighthawk_git_repo_dir=self.nighthawk_git_repo_dir,
                 branch_name=self.branch_name,
             ))
       case _:
@@ -675,16 +767,26 @@ def main() -> None:
       help=("If set, the script will not sync the local Nighthawk repository with"
             " the upstream remote before starting the update process."),
   )
+  parser.add_argument(
+      "--agent_invocation",
+      type=str,
+      default=None,
+      help=("Command to invoke an LLM agent, e.g. 'gemini', with prompt by stdin."),
+  )
 
   args = parser.parse_args()
 
   updater = NighthawkEnvoyUpdate(
-      nighthawk_dir=args.nighthawk_dir,
+      nighthawk_git_repo_dir=args.nighthawk_dir,
       branch_name=args.branch_name,
       envoy_clone_depth=args.envoy_clone_depth,
       sync_nighthawk_repo=args.sync_nighthawk_repo,
+      agent_invocation=args.agent_invocation,
   )
-  updater.run_update()
+  try:
+    updater.run_update()
+  finally:
+    updater.cleanup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Used to produce our latest Envoy commit integration (https://github.com/envoyproxy/nighthawk/commit/e410cce1e308213d61d362e96a56ed86c8d68fea).

The  invoked agent addressed the build and test errors in this week's not-quite-trivial merge without user intervention. 

* The updater script ran procedurally (updating the commit and SHA - https://github.com/envoyproxy/nighthawk/commit/e410cce1e308213d61d362e96a56ed86c8d68fea#diff-8e1b8edd0dd49f5a7468a7071405b488c7ffb93fd46c68de99df0a8d7d25b0d4R3-R4 - and merging shared file contents - https://github.com/envoyproxy/nighthawk/commit/e410cce1e308213d61d362e96a56ed86c8d68fea#diff-f9c0de5fe38c8a8e8aed5b77a0f694cc4158b071d56662d9c618d93814e84984R330-R331)
* the script ran into its first error when attempting to build Nighthawk and invoked the agent
* the agent addressed the API issue https://github.com/envoyproxy/nighthawk/commit/e410cce1e308213d61d362e96a56ed86c8d68fea#diff-e528c3973715873e2ec7fcac6a842e5d9a59d6523a77bf1219d295dd4c7285cdR844
* the script resumed by first making sure Nighthawk builds and then proceeding to see if Nighthawk tests passed, which they did not, so the script passed back to the agent using the new context
* the agent addressed the test issue by implementing a method (https://github.com/envoyproxy/nighthawk/commit/e410cce1e308213d61d362e96a56ed86c8d68fea#diff-e528c3973715873e2ec7fcac6a842e5d9a59d6523a77bf1219d295dd4c7285cdR175)
* the script resumed by making sure Nighthawk tests passed and then proceeded with the flow to create a commit
