### PR TITLE
Update nighthawk_envoy_updater.py

### DIFF
--- a/tools/nighthawk_envoy_updater.py
+++ b/tools/nighthawk_envoy_updater.py
@@ -338,7 +338,7 @@ class EnvoyCommitIntegration(StepHandler[EnvoyCommitIntegrationStep]):
     match step:
       case EnvoyCommitIntegrationStep.RESET_NIGHTHAWK_REPO:
         _run_command(["git", "reset", "--hard", "HEAD"], cwd=self.nighthawk_git_repo_dir)
-        _run_command(["git", "clean", "-fdx"], cwd=self.nighthawk_git_repo_dir)
+        _run_command(["git", "clean", "-fd"], cwd=self.nighthawk_git_repo_dir)
       case EnvoyCommitIntegrationStep.GET_ENVOY_SHA:
         tarball_url = f"https://github.com/envoyproxy/envoy/archive/{self.target_envoy_commit}.tar.gz"
         self.envoy_sha = _run_command(


### PR DESCRIPTION
Remove `x` from repo cleanup step to preserve .gitignore files.

This was in the description of https://github.com/envoyproxy/nighthawk/commit/e3bae15c74a0c39b45c2a71a850613051ba6d063, but not the PR! I assume I lost it in a merge operation and the PR was doing too many things to facilitate a useful review.