### PR TITLE
Update envoy version to 3c9f5fc (Apr 27, 2026) 

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "d5d35ddf72aaa86722ea969ad0461fd4eccdd6bf"
-ENVOY_SHA = "34c610d2133abde7c0c9cf9bca5e5a2f4ba5c2aa554d91622936d3189001781a"
+ENVOY_COMMIT = "3c9f5fca3f1769b0dd5c60bd82dbce4135cfc5b0"
+ENVOY_SHA = "f217be9898345401b56043333bc6d6f9e6c897e71ad94ff85984bb3ae856fba9"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.8"  # June 18th, 2025
 HDR_HISTOGRAM_C_SHA = "bb95351a6a8b242dc9be1f28562761a84d4cf0a874ffc90a9b630770a6468e94"

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -1013,7 +1013,7 @@ def test_http_request_release_timing(http_test_server_fixture, qps_parameterizat
 
     # The actual duration is a float, flooring if here allows us to use
     # the GreaterEqual matchers below.
-    total_requests = qps_parameterization_fixture * concurrency * math.floor(actual_duration) 
+    total_requests = qps_parameterization_fixture * concurrency * math.floor(actual_duration)
     asserts.assertGreaterEqual(
         int(global_histograms["benchmark_http_client.request_to_response"]["count"]),
         total_requests)

--- a/test/integration/test_integration_basics.py
+++ b/test/integration/test_integration_basics.py
@@ -130,7 +130,7 @@ def test_http_h2_mini_stress_test_with_client_side_queueing(http_test_server_fix
       "--termination-predicate", "benchmark.http_2xx:99", "--simple-warmup"
   ])
   asserts.assertCounterEqual(counters, "upstream_rq_pending_total", 1)
-  asserts.assertCounterGreaterEqual(counters, "upstream_rq_pending_overflow", 10)
+  asserts.assertCounterGreaterEqual(counters, "upstream_rq_active_overflow", 10)
 
 
 def test_http_h2_mini_stress_test_without_client_side_queueing(http_test_server_fixture):
@@ -1013,7 +1013,7 @@ def test_http_request_release_timing(http_test_server_fixture, qps_parameterizat
 
     # The actual duration is a float, flooring if here allows us to use
     # the GreaterEqual matchers below.
-    total_requests = qps_parameterization_fixture * concurrency * math.floor(actual_duration)
+    total_requests = qps_parameterization_fixture * concurrency * math.floor(actual_duration) 
     asserts.assertGreaterEqual(
         int(global_histograms["benchmark_http_client.request_to_response"]["count"]),
         total_requests)

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -380,6 +380,9 @@ paths:
     - source/extensions/common/wasm/context.h
     - source/extensions/common/wasm/context.cc
     - source/extensions/common/wasm/foreign.cc
+    - contrib/stat_sinks/wasm_filter/source/wasm_filter_stat_sink_impl.cc
+    - contrib/stat_sinks/wasm_filter/test/test_data/stats_filter_plugin.cc
+    - contrib/stat_sinks/wasm_filter/test/wasm_filter_stat_sink_integration_test.cc
     - source/extensions/common/wasm/wasm.h
     - source/extensions/common/wasm/wasm.cc
     - source/extensions/common/wasm/wasm_vm.h


### PR DESCRIPTION
- update envoy_commit
- update test due to newly added upstream_rq_active_overflow counter in https://github.com/envoyproxy/envoy/commit/c2117809b2a44ad619896cb784aa0f53c6b7b493
- update config.yaml