### PR TITLE
Update to Envoy commit 4c1daf37d2 (2026-05-07 2:19pm EDT)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -160,7 +160,6 @@ build:gcc --cxxopt=-Wno-nonnull-compare
 build:gcc --cxxopt=-Wno-trigraphs
 build:gcc --linkopt=-fuse-ld=gold --host_linkopt=-fuse-ld=gold
 build:gcc --host_platform=@envoy//bazel/rbe/toolchains:rbe_linux_gcc_platform
-build:gcc --linkopt=-fuse-ld=gold --host_linkopt=-fuse-ld=gold
 build:gcc --action_env=BAZEL_LINKOPTS=-lm:-fuse-ld=gold
 
 # libc++ - default for clang
@@ -457,6 +456,11 @@ common:engflow-common --credential_helper=*.engflow.com=%workspace%/bazel/engflo
 common:engflow-common --grpc_keepalive_time=60s
 common:engflow-common --grpc_keepalive_timeout=30s
 common:engflow-common --remote_cache_compression
+# Recover from transient gRPC failures (e.g. UNAVAILABLE: io exception) talking to engflow.
+common:engflow-common --remote_retries=10
+common:engflow-common --remote_retry_max_delay=60s
+# Recover when blobs are evicted from the CAS mid-build (common during patch releases).
+common:engflow-common --experimental_remote_cache_eviction_retries=5
 
 # this provides access to RBE+cache
 common:rbe --config=remote-cache
@@ -465,6 +469,7 @@ common:rbe --config=remote-exec
 # this provides access to just cache
 common:remote-cache --config=engflow-common
 common:remote-cache --remote_cache=grpcs://mordenite.cluster.engflow.com
+common:remote-cache --experimental_remote_downloader=grpcs://mordenite.cluster.engflow.com
 common:remote-cache --remote_timeout=3600s
 
 common:remote-exec --remote_executor=grpcs://mordenite.cluster.engflow.com

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,16 +4,16 @@ build-image:
   repo: docker.io/envoyproxy/envoy-build
   repo-gcr: gcr.io/envoy-ci/envoy-build
   # default ci caching (ci)
-  sha: 20656853fae51927cda557e7af80ccff175f5de6f84bd0f092cd8672b2a6e0fe
-  sha-ci: 20656853fae51927cda557e7af80ccff175f5de6f84bd0f092cd8672b2a6e0fe
-  sha-devtools: 6e7a82d4f1ba040f4ebef0c1aae00cdbd205ff7a1284c20cc20984fdfa4a91d8
-  sha-docker: 85b6c3e76f093d9c9d10a968b5615cc8d82f38d7aef311100d542e4d640f5a74
-  sha-gcc: 439e870260c1599646d05b8b5d3bf1b6dd585c2e3cdac78dcb9f4081564c27fd
-  sha-mobile: bd1338a8951376211e4f4f6ff3171675670c4c582b0966f1d247abd3ba6a8a67
-  sha-worker: 25a68eff24b7414a346977d545687b87851d1c5746c466798050fa12fc5d0686
+  sha: afe3addcdb7a5177bcca77d041f079acf4a6c5fb32701aadb2ab96fd0933e0b2
+  sha-ci: afe3addcdb7a5177bcca77d041f079acf4a6c5fb32701aadb2ab96fd0933e0b2
+  sha-devtools: 420d53d577ba85245db3791255c53423ebc8869d7ca9940c0f29d1decba0c00a
+  sha-docker: 5fbafb6f366bc7815e9941f813854301ad4341d5dae4efc783bd1e3d602d58ba
+  sha-gcc: b344f62c6160304d002290f73339ac648b735c3700e28a1c6ad05d9fc2815cec
+  sha-mobile: 25ef9a9e8977150fe1278e7358307cd039bc90b0ebc5c16fea1a5cd566af4e38
+  sha-worker: 7189239fbbc3983b15840609b122a35ce228a1af83aa440b022b1c949adcc32a
   # TODO: remove this dupe (currently used by ci request handler)
-  mobile-sha: bd1338a8951376211e4f4f6ff3171675670c4c582b0966f1d247abd3ba6a8a67
-  tag: 86873047235e9b8232df989a5999b9bebf9db69c
+  mobile-sha: 25ef9a9e8977150fe1278e7358307cd039bc90b0ebc5c16fea1a5cd566af4e38
+  tag: 99bbf423a0d1ff5a7332fb1e23bd62b90754fcd2
 
 config:
   envoy:

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "3c9f5fca3f1769b0dd5c60bd82dbce4135cfc5b0"
-ENVOY_SHA = "f217be9898345401b56043333bc6d6f9e6c897e71ad94ff85984bb3ae856fba9"
+ENVOY_COMMIT = "4c1daf37d261bef857cb40413a3e9503e9656801"
+ENVOY_SHA = "1cbd066aad84b4d2bd2bd10f94fc1a884a12416ba67e9c6eceffd3edb669c760"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.8"  # June 18th, 2025
 HDR_HISTOGRAM_C_SHA = "bb95351a6a8b242dc9be1f28562761a84d4cf0a874ffc90a9b630770a6468e94"

--- a/test/stream_decoder_test.cc
+++ b/test/stream_decoder_test.cc
@@ -143,6 +143,7 @@ TEST_F(StreamDecoderTest, LatencyIsMeasured) {
             auto* span = new Envoy::Tracing::MockSpan();
             EXPECT_CALL(*span, injectContext(_, _));
             EXPECT_CALL(*span, setTag(_, _)).Times(12);
+            EXPECT_CALL(*span, exportedSpan());
             EXPECT_CALL(*span, finishSpan());
             return span;
           }));

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -12,9 +12,9 @@ attrs==26.1.0 \
     --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309 \
     --hash=sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32
     # via -r tools/base/requirements.in
-certifi==2026.2.25 \
-    --hash=sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa \
-    --hash=sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7
+certifi==2026.4.22 \
+    --hash=sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a \
+    --hash=sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580
     # via
     #   -r tools/base/requirements.in
     #   requests
@@ -201,9 +201,9 @@ flake8-docstrings==1.7.0 \
     --hash=sha256:4c8cc748dc16e6869728699e5d0d685da9a10b0ea718e090b1ba088e67a941af \
     --hash=sha256:51f2344026da083fc084166a9353f5082b01f72901df422f74b4d953ae88ac75
     # via -r tools/base/requirements.in
-idna==3.11 \
-    --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
-    --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+idna==3.13 \
+    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
+    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
     # via
     #   -r tools/base/requirements.in
     #   requests
@@ -225,9 +225,9 @@ more-itertools==11.0.2 \
     --hash=sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804 \
     --hash=sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4
     # via -r tools/base/requirements.in
-packaging==26.1 \
-    --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
-    --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
     #   -r tools/base/requirements.in
     #   pytest
@@ -362,9 +362,9 @@ snowballstemmer==3.0.1 \
     --hash=sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064 \
     --hash=sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895
     # via pydocstyle
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
     #   -r tools/base/requirements.in
     #   requests

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -392,6 +392,7 @@ paths:
     - test/extensions/common/wasm/wasm_test.cc
     - test/extensions/dynamic_modules/test_data/cpp/http_integration_test.cc
     - test/extensions/dynamic_modules/test_data/cpp/http.cc
+    - test/extensions/dynamic_modules/test_data/cpp/network_integration_test.cc
     - test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
     - test/test_common/wasm_base.h
 


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/commit/4c1daf37d2 - update range https://github.com/envoyproxy/envoy/compare/3c9f5fca3f1..4c1daf37d2

Includes one manual fix to test/stream_decoder_test.cc adding an expectation for the exportedSpan() method. Envoy now calls exportedSpan() during the finalizeDownstreamSpan() utility function and the MockSpan was configured to fail on unexpected calls.