### PR TITLE
refactor: Remove references to MetricSnapshotImpl

### DIFF
--- a/source/client/flush_worker_impl.cc
+++ b/source/client/flush_worker_impl.cc
@@ -37,13 +37,11 @@ void FlushWorkerImpl::shutdownThread() {
 
 void FlushWorkerImpl::flushStats() {
   Envoy::Thread::SkipAsserts skip;
-  // Create a snapshot and flush to all sinks. Even if there are no sinks,
-  // creating the snapshot has the important property that it latches all counters on a periodic
-  // basis.
-  Envoy::Server::MetricSnapshotImpl snapshot(store_, cluster_manager_, time_source_);
-  for (std::unique_ptr<Envoy::Stats::Sink>& sink : stats_sinks_) {
-    sink->flush(snapshot);
-  }
+
+  // Create a snapshot and flush to all sinks.
+  Envoy::Server::InstanceUtil::flushMetricsToSinks(
+      stats_sinks_, store_, cluster_manager_, time_source_);
+
   if (stat_flush_timer_ != nullptr) {
     stat_flush_timer_->enableTimer(stats_flush_interval_);
   }

--- a/source/client/flush_worker_impl.cc
+++ b/source/client/flush_worker_impl.cc
@@ -39,8 +39,8 @@ void FlushWorkerImpl::flushStats() {
   Envoy::Thread::SkipAsserts skip;
 
   // Create a snapshot and flush to all sinks.
-  Envoy::Server::InstanceUtil::flushMetricsToSinks(
-      stats_sinks_, store_, cluster_manager_, time_source_);
+  Envoy::Server::InstanceUtil::flushMetricsToSinks(stats_sinks_, store_, cluster_manager_,
+                                                   time_source_);
 
   if (stat_flush_timer_ != nullptr) {
     stat_flush_timer_->enableTimer(stats_flush_interval_);


### PR DESCRIPTION
 This refactor is required to improve stats sink efficiency.
