### PR TITLE
client: actively drain the connection pool during shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,9 @@ Mutually exclusive with --protocol. Requests are encapsulated in
 HTTP/1 by default when neither of --h2 or --protocol is used.
 
 --timeout <uint32_t>
-Connection connect timeout period in seconds. Default: 30.
+Connection connect timeout period in seconds. Also used as the upper
+bound on the time spent draining in-flight requests during shutdown.
+Default: 30.
 
 --duration <uint32_t>
 The number of seconds that the test should run. Default: 5. Mutually

--- a/source/client/benchmark_client_impl.cc
+++ b/source/client/benchmark_client_impl.cc
@@ -1,5 +1,6 @@
 #include "source/client/benchmark_client_impl.h"
 
+#include "envoy/common/conn_pool.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/thread_local/thread_local.h"
 
@@ -128,6 +129,19 @@ void BenchmarkClientHttpImpl::terminate() {
       dispatcher_.exit();
     });
     drain_timer_->enableTimer(timeout_);
+    // Actively drain the pool. Without this, completed requests leave ready keep-alive
+    // connections behind, and the pool never becomes idle (all of the pool's client lists must
+    // be empty for that), so the idle callback above would never fire and we would always
+    // block for the full timeout. DrainAndDelete closes idle connections right away and closes
+    // busy ones as their in-flight streams complete; it does not reset in-flight streams, so
+    // the drain timer above remains the hard cap for streams that never complete.
+    // The drain call is posted rather than made inline, so that it runs at loop entry of
+    // dispatcher_.run() below, after the idle callback and drain timer above are fully set
+    // up; this keeps terminate() correct regardless of whether draining ever invokes idle
+    // callbacks synchronously.
+    dispatcher_.post([pool_data]() mutable {
+      pool_data.value().drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
+    });
     dispatcher_.run(Envoy::Event::Dispatcher::RunType::RunUntilExit);
   }
 }

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -62,8 +62,10 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       false, 0, "uint32_t", cmd);
   TCLAP::ValueArg<uint32_t> timeout(
       "", "timeout",
-      fmt::format("Connection connect timeout period in seconds. Default: {}.", timeout_), false, 0,
-      "uint32_t", cmd);
+      fmt::format("Connection connect timeout period in seconds. Also used as the upper bound "
+                  "on the time spent draining in-flight requests during shutdown. Default: {}.",
+                  timeout_),
+      false, 0, "uint32_t", cmd);
 
   TCLAP::SwitchArg h2(
       "", "h2",

--- a/test/benchmark_http_client_test.cc
+++ b/test/benchmark_http_client_test.cc
@@ -440,6 +440,8 @@ TEST_F(BenchmarkClientHttpTest, RequestGeneratorProvidingDifferentPathsSendsRequ
 TEST_F(BenchmarkClientHttpTest, DrainTimeoutFires) {
   RequestGenerator default_request_generator = getDefaultRequestGenerator();
   setupBenchmarkClient(default_request_generator);
+  // Keep the test fast; the default drain timeout is 30 seconds of real time.
+  client_->setTimeout(std::chrono::seconds(2));
   EXPECT_CALL(pool_, newStream(_, _, _))
       .WillOnce([this](Envoy::Http::ResponseDecoder& decoder,
                        Envoy::Http::ConnectionPool::Callbacks&,
@@ -454,11 +456,127 @@ TEST_F(BenchmarkClientHttpTest, DrainTimeoutFires) {
       });
   EXPECT_CALL(pool_, hasActiveConnections()).WillOnce([]() -> bool { return true; });
   EXPECT_CALL(pool_, addIdleCallback(_));
+  // terminate() actively drains the pool; in this test no stream ever completes, so
+  // draining doesn't make the pool idle and the drain timeout still fires.
+  EXPECT_CALL(pool_, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
   // We don't expect the callback that we pass here to fire.
   client_->tryStartRequest([](bool, bool) { EXPECT_TRUE(false); });
   // To get past this, the drain timeout within the benchmark client must execute.
   dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
   EXPECT_EQ(0, getCounter("http_2xx"));
+}
+
+// Regression test: BenchmarkClientHttpImpl::terminate() used to block for the full drain
+// timeout (timeout_) whenever an in-flight request completed onto a keep-alive connection
+// during the drain, because the pool idle callback never fired. terminate() now actively
+// drains the pool (drainConnections()), so completed keep-alive connections are closed,
+// the pool can become idle, and terminate() returns promptly.
+//
+// Background: terminate() registers an idle callback via HttpPoolData::addIdleCallback()
+// and then runs the dispatcher until either that callback or a drain timer (timeout_)
+// exits it. In Envoy (@ c821577, source/common/conn_pool/conn_pool_base.cc),
+// ConnPoolImplBase::isIdleImpl() is:
+//   pending_streams_.empty() && ready_clients_.empty() && busy_clients_.empty() &&
+//   connecting_clients_.empty() && early_data_clients_.empty()
+// and checkForIdleAndNotify() only invokes idle callbacks when that predicate holds.
+// When an in-flight request completes, its connection moves from busy_clients_ to
+// ready_clients_ (keep-alive) - so the pool never becomes idle unless something closes
+// the ready connections. Nighthawk never calls drainConnections(), so the idle callback
+// never fires and terminate() only returns when the drain timer hard-exits after the
+// full timeout, logging "Wait for the connection pool drain timed out...".
+//
+// The mock pool below models exactly those semantics: the captured idle callback is
+// invoked once the last stream has completed, but only if the pool was told to drain
+// (drainConnections()); without draining, a completed stream leaves a ready keep-alive
+// client behind and the pool stays non-idle forever, faithful to the real pool.
+TEST_F(BenchmarkClientHttpTest, TerminateReturnsPromptlyWhenRequestCompletesDuringDrain) {
+  RequestGenerator default_request_generator = getDefaultRequestGenerator();
+  setupBenchmarkClient(default_request_generator);
+  // Small drain timeout to bound the runtime of this test while it is red. The margin
+  // between the fast path (~0.25s) and the timeout path (5s) is seconds wide, so the
+  // timing assertion below is robust on loaded CI machines.
+  client_->setTimeout(std::chrono::seconds(5));
+
+  // Start a single request and capture its response decoder so we can complete the
+  // response later, while terminate() is draining.
+  Envoy::Http::ResponseDecoder* decoder = nullptr;
+  EXPECT_CALL(pool_, newStream(_, _, _))
+      .WillOnce([this, &decoder](Envoy::Http::ResponseDecoder& response_decoder,
+                                 Envoy::Http::ConnectionPool::Callbacks& callbacks,
+                                 const Envoy::Http::ConnectionPool::Instance::StreamOptions&)
+                    -> Envoy::Http::ConnectionPool::Cancellable* {
+        decoder = &response_decoder;
+        NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+        callbacks.onPoolReady(stream_encoder_, Envoy::Upstream::HostDescriptionConstSharedPtr{},
+                              stream_info, {} /*std::optional<Envoy::Http::Protocol> protocol*/);
+        return nullptr;
+      });
+  EXPECT_CALL(stream_encoder_, encodeHeaders(_, _));
+
+  bool stream_completed = false;
+  ASSERT_TRUE(
+      client_->tryStartRequest([&stream_completed](bool, bool) { stream_completed = true; }));
+  ASSERT_NE(nullptr, decoder);
+
+  // Model of the real pool state, following ConnPoolImplBase::isIdleImpl() semantics
+  // described above: after the stream completes the connection becomes a ready
+  // keep-alive client, so the pool is only considered idle - and the idle callback is
+  // only invoked - if the pool has additionally been told to drain its connections.
+  bool drain_requested = false;
+  bool idle_callback_invoked = false;
+  Envoy::Http::ConnectionPool::Instance::IdleCb idle_cb;
+  auto maybe_fire_idle_callback = [&]() {
+    if (stream_completed && drain_requested && !idle_callback_invoked && idle_cb != nullptr) {
+      idle_callback_invoked = true;
+      idle_cb();
+    }
+  };
+  // One active stream exists when terminate() starts.
+  EXPECT_CALL(pool_, hasActiveConnections()).WillOnce([]() -> bool { return true; });
+  EXPECT_CALL(pool_, addIdleCallback(_))
+      .WillOnce([&idle_cb](Envoy::Http::ConnectionPool::Instance::IdleCb cb) { idle_cb = cb; });
+  // Only a DrainAndDelete drain closes stream-less keep-alive connections in the real
+  // pool, which is what allows the modeled pool to go idle once the last stream
+  // completes; requiring the exact behavior here guards against regressing to another
+  // enumerator.
+  EXPECT_CALL(pool_, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .Times(AnyNumber())
+      .WillRepeatedly([&](Envoy::ConnectionPool::DrainBehavior) {
+        drain_requested = true;
+        maybe_fire_idle_callback();
+      });
+
+  // Arm a timer that completes the in-flight response shortly after terminate() starts
+  // draining. This puts the pool in the exact state under test: zero active streams,
+  // one ready keep-alive connection.
+  Envoy::Event::TimerPtr response_timer = dispatcher_->createTimer([&]() {
+    Envoy::Http::ResponseHeaderMapPtr response_headers{
+        new Envoy::Http::TestResponseHeaderMapImpl{{":status", "200"}}};
+    decoder->decodeHeaders(std::move(response_headers), false);
+    Envoy::Buffer::OwnedImpl buffer(std::string(97, 'a'));
+    decoder->decodeData(buffer, true);
+    // The stream is done; the connection transitions busy -> ready (keep-alive).
+    maybe_fire_idle_callback();
+  });
+  response_timer->enableTimer(std::chrono::milliseconds(250));
+
+  const Envoy::MonotonicTime start_time = time_system_.monotonicTime();
+  client_->terminate();
+  const Envoy::MonotonicTime end_time = time_system_.monotonicTime();
+  const int64_t terminate_duration_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+
+  // Premise checks: the in-flight request really did complete during the drain.
+  EXPECT_TRUE(stream_completed);
+  EXPECT_EQ(1, getCounter("http_2xx"));
+  // Core assertion: terminate() must return comfortably before the 5s drain timeout,
+  // since the pool held zero active streams from ~250ms onwards. While the bug exists,
+  // terminate() blocks until the drain timer fires (~5000ms), failing this check.
+  EXPECT_LT(terminate_duration_ms, 2500);
+  // Second angle: the dispatcher should have been exited by the pool idle callback path
+  // rather than by the hard-shutdown drain timer path. While the bug exists the idle
+  // callback is never invoked (the pool is never drained, so it never goes idle).
+  EXPECT_TRUE(idle_callback_invoked);
 }
 
 UserDefinedOutputPluginPtr


### PR DESCRIPTION
Part 1/3 of fixing nighthawk failing to shut down when a target can't keep up.

**Symptom:** with requests in flight at the end of execution, shutdown stalls for the full `--timeout` per worker and logs "Wait for the connection pool drain timed out, proceeding to hard shutdown" — even when the in-flight requests complete milliseconds later.

**Root cause:** `terminate()` registers a pool idle callback, but `ConnPoolImplBase::isIdleImpl()` requires pending, ready, busy, connecting, and early-data client lists to all be empty. Completed keep-alive connections sit in `ready_clients_`, and nothing ever calls `drainConnections()`, so idle is unreachable and only the drain timer exits the wait.

**Fix:** post a `drainConnections(DrainAndDelete)` onto the dispatcher as the drain wait starts. Verified against the pinned Envoy commit: `DrainAndDelete` closes stream-less clients immediately, closes busy clients as streams finish (H1 via `StreamWrapper::onDecodeComplete`, H2/H3 via `onStreamDestroy` — no GOAWAY, no stream resets), and never resets in-flight streams, so measured results are unaffected and `--timeout` still caps a wedged server.

**Testing:** new regression test (`TerminateReturnsPromptlyWhenRequestCompletesDuringDrain`) models the pinned pool-idle semantics; before the fix it measured `terminate()` blocking 5004ms vs. the 2500ms bound with the idle path never taken, after the fix ~375ms via the idle path. `DrainTimeoutFires` updated for the new drain call and no longer burns 30 real seconds (2s cap). The `--timeout` CLI help and README now document that the flag also bounds the shutdown drain.
