### PR TITLE
client: actually terminate the tunnel-encap Envoy subprocess

### DIFF
--- a/source/client/process_bootstrap.cc
+++ b/source/client/process_bootstrap.cc
@@ -445,20 +445,27 @@ absl::Status
 EncapsulationSubProcessRunner::RunWithSubprocess(std::function<void()> nighthawk_fn,
                                                  std::function<void(sem_t&)> envoy_fn) {
 
-  pid_t pid_ = fork();
+  pid_ = fork();
   if (pid_ == -1) {
     return absl::InternalError("fork failed");
   }
   if (pid_ == 0) {
     envoy_fn(*nighthawk_control_sem_);
-    exit(0);
+    // Use _exit() rather than exit(): this child is a fork of a potentially multithreaded
+    // parent (e.g. the gRPC service), where only the forking thread survives. exit() would
+    // run atexit/static-destructor/sanitizer hooks that can deadlock on locks owned by
+    // threads that no longer exist, wedging the child - and, now that the parent reaps the
+    // child via waitpid(), wedging the parent's shutdown along with it.
+    _exit(0);
   } else {
-    // wait for envoy to start and signal nighthawk to start
+    // Wait for envoy to start and signal nighthawk to start. Note that nighthawk_fn only
+    // starts execution and returns; the encap subprocess must outlive the load test, so it
+    // is NOT terminated here. Termination happens via TerminateEncapSubProcess(), which
+    // ProcessImpl invokes on shutdown and on execution cancellation (and the destructor
+    // invokes as a last resort).
     sem_wait(nighthawk_control_sem_);
     // start nighthawk
     nighthawk_fn();
-    // signal envoy to shutdown
-    return TerminateEncapSubProcess();
   }
   return absl::OkStatus();
 }

--- a/source/client/process_bootstrap.h
+++ b/source/client/process_bootstrap.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <semaphore.h>
+#include <unistd.h>
 
 #include <functional>
 #include <vector>
@@ -106,7 +107,10 @@ public:
   absl::Status Run() { return RunWithSubprocess(nighthawk_runner_, encap_envoy_runner_); }
 
   /**
-   * Sends a SIGTERM to Encap Envoy subprocess and blocks till exit
+   * Sends a SIGTERM to the Encap Envoy subprocess and reaps it. Waits up to ~15 seconds
+   * for a graceful exit, then escalates to SIGKILL: an unbounded wait here could wedge the
+   * caller (for example a gRPC service handler running ProcessImpl::shutdown()) if the
+   * subprocess never exits.
    *
    **/
   absl::Status TerminateEncapSubProcess() {
@@ -119,16 +123,31 @@ public:
       return absl::InternalError("Failed to kill encapsulation subprocess");
     }
 
-    int status;
-    waitpid(pid_, &status, 0);
+    int status = 0;
+    pid_t reaped = 0;
+    for (int i = 0; i < 150 && reaped == 0; ++i) {
+      reaped = waitpid(pid_, &status, WNOHANG);
+      if (reaped == 0) {
+        // Waiting on a real OS process; there is no injectable time source here.
+        usleep(100000); // 100ms per attempt, ~15s in total. NO_CHECK_FORMAT(real_time)
+      }
+    }
+    if (reaped == 0) {
+      kill(pid_, SIGKILL);
+      reaped = waitpid(pid_, &status, 0);
+    }
     pid_ = -1;
 
+    if (reaped < 0) {
+      // Nothing to reap (e.g. the child was already reaped elsewhere): not a crash.
+      return absl::OkStatus();
+    }
     if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
       // Child process did not crash.
       return absl::OkStatus();
     }
 
-    // Child process crashed.
+    // Child process crashed or had to be hard-killed.
     return absl::InternalError(absl::StrCat("Envoy crashed with code: ", status));
   }
 


### PR DESCRIPTION
Found during an adversarial review of the shutdown-sequence fixes (a `-Wshadow` class of bug).

`EncapsulationSubProcessRunner::RunWithSubprocess()` declared a local `pid_t pid_ = fork();` shadowing the class member, so the member stayed `-1` and `TerminateEncapSubProcess()` always returned early without signaling the child: the encap Envoy subprocess was never terminated or reaped on shutdown or cancellation, and was orphaned on every tunnel-mode run.

**Fix:** assign the `fork()` result to the member. The shadowing bug was also masking a second defect: `RunWithSubprocess()` ended by calling `TerminateEncapSubProcess()` right after `nighthawk_fn()` returns — but `nighthawk_fn()` only *starts* execution, so with the member populated this would have torn down the tunnel at the start of the load test. That call is removed; termination is owned by the existing call sites that now actually work: `ProcessImpl::shutdown()`, `requestExecutionCancellation()`, and the runner's destructor as a last resort.

**Testing:** `TestWithEncapsulation` (forks a real encap Envoy) behaves identically to main on the machine used for verification, including an environment-specific IPv4 flake that reproduces at the same rate (1-in-3) on unmodified main.

**Open design question for review:** `ProcessImpl::shutdown()` terminates the encap subprocess *before* draining the workers, so tunnel-mode drains will now see connection resets rather than graceful completions. Arguably fine for shutdown, but moving termination after the worker joins would preserve graceful drains; left untouched here to keep this PR minimal.

**Update (asan CI failure on the first revision):** `test_remote_execution.py` failed under asan — the first execution succeeded, then the service stopped answering. Root cause analysis: `RunWithSubprocess()` forks on *every* execution (pre-existing, tunnel or not), and the child exited via `exit(0)` — full C++ exit whose atexit/sanitizer hooks can deadlock in a fork of the multithreaded gRPC service (only the forking thread survives a fork). Before this PR nobody `waitpid()`ed, so a wedged child leaked invisibly; with reaping in place it wedged the service's shutdown. Two hardening changes: the child now exits via `_exit(0)`, and `TerminateEncapSubProcess()` reaps with a bounded wait (SIGTERM, ~15s WNOHANG polling, then SIGKILL) so a stuck child can never hang the caller.
