### PR TITLE
Nighthawk Rate Limiter Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ execution. Note that this will be reflected in the counters that
 Nighthawk writes to the output. Default is false.
 
 --rate-limiter-plugin-config <string>
-Rate Limiter plugin configuration in json. Example (json):
+Rate Limiter plugin configuration in json. Mutually exclusive with
+--burst-size and --jitter-uniform. Example (json):
 {name:"nighthawk.stub-rate-limiter-plugin"
 ,typed_config:{"@type":"type.googleapis.com/nighthawk.rate_limiter.Stu
 bRateLimiterConfig",test_value:"3"}}

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ bazel-bin/nighthawk_client  [--user-defined-plugin-config <string>] ...
 [--stats-flush-interval <uint32_t>]
 [--stats-sinks <string>] ... [--no-duration]
 [--simple-warmup]
+[--rate-limiter-plugin-config <string>]
 [--request-source-plugin-config <string>]
 [--request-source <uri format>] [--label
 <string>] ... [--multi-target-use-https]
@@ -251,6 +252,12 @@ will still be added. Mutually exclusive with --duration.
 Perform a simple single warmup request (per worker) before starting
 execution. Note that this will be reflected in the counters that
 Nighthawk writes to the output. Default is false.
+
+--rate-limiter-plugin-config <string>
+Rate Limiter plugin configuration in json. Example (json):
+{name:"nighthawk.stub-rate-limiter-plugin"
+,typed_config:{"@type":"type.googleapis.com/nighthawk.rate_limiter.Stu
+bRateLimiterConfig",test_value:"3"}}
 
 --request-source-plugin-config <string>
 [Request

--- a/README.md
+++ b/README.md
@@ -255,10 +255,11 @@ Nighthawk writes to the output. Default is false.
 
 --rate-limiter-plugin-config <string>
 Rate Limiter plugin configuration in json. Mutually exclusive with
---burst-size and --jitter-uniform. Example (json):
-{name:"nighthawk.stub-rate-limiter-plugin"
-,typed_config:{"@type":"type.googleapis.com/nighthawk.rate_limiter.Stu
-bRateLimiterConfig",test_value:"3"}}
+--burst-size and --jitter-uniform. Possible configurations located in
+api/rate_limiter. Example (json):
+{name:"nighthawk.linear-ramping-rate-limiter-plugin"
+,typed_config:{"@type":"type.googleapis.com/nighthawk.rate_limiter.Lin
+earRampingRateLimiterConfig","ramp_time":"5.5s"}}
 
 --request-source-plugin-config <string>
 [Request

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -136,7 +136,7 @@ message Protocol {
 
 // TODO(oschaaf): Ultimately this will be a load test specification. The fact that it
 // can arrive via CLI is just a concrete detail. Change this to reflect that.
-// Next unused number is 120.
+// Next unused number is 121.
 message CommandLineOptions {
   // The target requests-per-second rate. Default: 5.
   google.protobuf.UInt32Value requests_per_second = 1
@@ -339,4 +339,8 @@ message CommandLineOptions {
   // Nighthawk will abort an execution attempt if a user_defined_plugin_config is provided but the
   // associated plugin factory is not registered through Envoy's plugin system.
   repeated envoy.config.core.v3.TypedExtensionConfig user_defined_plugin_configs = 112;
+
+  // A plugin config that is to be parsed by a RateLimiterPluginConfigFactory
+  // and used to create a custom rate limiter.
+  envoy.config.core.v3.TypedExtensionConfig rate_limiter_plugin_config = 120;
 }

--- a/api/rate_limiter/BUILD
+++ b/api/rate_limiter/BUILD
@@ -1,5 +1,5 @@
-load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])
 

--- a/api/rate_limiter/BUILD
+++ b/api/rate_limiter/BUILD
@@ -1,0 +1,17 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+
+licenses(["notice"])
+
+envoy_package()
+
+api_cc_py_proto_library(
+    name = "rate_limiter_plugin",
+    srcs = [
+        "stub_rate_limiter.proto",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//api/client:base",
+    ],
+)

--- a/api/rate_limiter/BUILD
+++ b/api/rate_limiter/BUILD
@@ -8,6 +8,7 @@ envoy_package()
 api_cc_py_proto_library(
     name = "rate_limiter_plugin",
     srcs = [
+        "linear_ramping_rate_limiter.proto",
         "stub_rate_limiter.proto",
     ],
     visibility = ["//visibility:public"],

--- a/api/rate_limiter/linear_ramping_rate_limiter.proto
+++ b/api/rate_limiter/linear_ramping_rate_limiter.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package nighthawk.rate_limiter;
+
+import "google/protobuf/duration.proto";
+import "validate/validate.proto";
+
+// Config for LinearRampingRateLimiter
+message LinearRampingRateLimiterConfig {
+  // The requests per second will start at 0 and increase at a constant rate
+  // until reaching the target rate specified by --rps after this amount of
+  // ramp_time. Must be less than --duration.
+  google.protobuf.Duration ramp_time = 1
+      [(validate.rules).duration = { gt { seconds: 0 nanos: 0 } }];
+}

--- a/api/rate_limiter/linear_ramping_rate_limiter.proto
+++ b/api/rate_limiter/linear_ramping_rate_limiter.proto
@@ -10,6 +10,5 @@ message LinearRampingRateLimiterConfig {
   // The requests per second will start at 0 and increase at a constant rate
   // until reaching the target rate specified by --rps after this amount of
   // ramp_time. Must be less than --duration.
-  google.protobuf.Duration ramp_time = 1
-      [(validate.rules).duration = { gt { seconds: 0 nanos: 0 } }];
+  google.protobuf.Duration ramp_time = 1 [(validate.rules).duration = {gt {seconds: 0 nanos: 0}}];
 }

--- a/api/rate_limiter/linear_ramping_rate_limiter.proto
+++ b/api/rate_limiter/linear_ramping_rate_limiter.proto
@@ -5,7 +5,7 @@ package nighthawk.rate_limiter;
 import "google/protobuf/duration.proto";
 import "validate/validate.proto";
 
-// Config for LinearRampingRateLimiter
+// Config for LinearRampingRateLimiter. Name is "nighthawk.linear-ramping-rate-limiter-plugin"
 message LinearRampingRateLimiterConfig {
   // The requests per second will start at 0 and increase at a constant rate
   // until reaching the target rate specified by --rps after this amount of

--- a/api/rate_limiter/stub_rate_limiter.proto
+++ b/api/rate_limiter/stub_rate_limiter.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package nighthawk.rate_limiter;
+
+import "google/protobuf/wrappers.proto";
+
+// Configuration used only for testing and as an example in the CLI help text
+// for --rate-limiter-plugin-config.
+message StubRateLimiterConfig {
+  // Used for testing.
+  google.protobuf.DoubleValue test_value = 1;
+}

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -82,7 +82,7 @@ public:
   virtual std::string requestSource() const PURE;
   virtual const std::optional<envoy::config::core::v3::TypedExtensionConfig>&
   requestSourcePluginConfig() const PURE;
-  virtual const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&
+  virtual const std::optional<envoy::config::core::v3::TypedExtensionConfig>&
   rateLimiterPluginConfig() const PURE;
   virtual std::string trace() const PURE;
   virtual nighthawk::client::H1ConnectionReuseStrategy::H1ConnectionReuseStrategyOptions

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -82,6 +82,8 @@ public:
   virtual std::string requestSource() const PURE;
   virtual const std::optional<envoy::config::core::v3::TypedExtensionConfig>&
   requestSourcePluginConfig() const PURE;
+  virtual const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&
+  rateLimiterPluginConfig() const PURE;
   virtual std::string trace() const PURE;
   virtual nighthawk::client::H1ConnectionReuseStrategy::H1ConnectionReuseStrategyOptions
   h1ConnectionReuseStrategy() const PURE;

--- a/include/nighthawk/common/BUILD
+++ b/include/nighthawk/common/BUILD
@@ -17,6 +17,7 @@ envoy_basic_cc_library(
         "phase.h",
         "platform_util.h",
         "rate_limiter.h",
+        "rate_limiter_plugin_config_factory.h",
         "request_source.h",
         "request_stream_grpc_client.h",
         "sequencer.h",

--- a/include/nighthawk/common/factories.h
+++ b/include/nighthawk/common/factories.h
@@ -23,7 +23,8 @@ public:
                               const SequencerTarget& sequencer_target,
                               TerminationPredicatePtr&& termination_predicate,
                               Envoy::Stats::Scope& scope,
-                              const Envoy::MonotonicTime scheduled_starting_time) const PURE;
+                              const Envoy::MonotonicTime scheduled_starting_time,
+                              Envoy::Api::Api& api) const PURE;
 };
 
 class StatisticFactory {

--- a/include/nighthawk/common/rate_limiter_plugin_config_factory.h
+++ b/include/nighthawk/common/rate_limiter_plugin_config_factory.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "envoy/api/api.h"
+#include "envoy/common/pure.h"
+#include "envoy/config/typed_config.h"
+
+#include "nighthawk/common/rate_limiter.h"
+#include "nighthawk/client/options.h"
+
+namespace Nighthawk {
+
+// A factory that must be implemented for each RateLimiterPlugin. It instantiates the specific
+// RateLimiterPlugin class after unpacking the plugin-specific config proto.
+class RateLimiterPluginConfigFactory : public Envoy::Config::TypedFactory {
+public:
+  ~RateLimiterPluginConfigFactory() override = default;
+  // All rate limiter plugins will be in this category.
+  std::string category() const override { return "nighthawk.rate_limiter_plugin"; }
+
+  // Instantiates the specific RateLimiterPlugin class. Casts |typed_config| to Any, unpacks it to the
+  // plugin-specific proto, and passes the strongly typed proto to the plugin constructor.
+  //
+  // @param typed_config Taken from TypedExtensionConfig. This should be a type
+  // listed in a rate limiter proto file.
+  //
+  // @param api Api parameter that contains timesystem, filesystem, and threadfactory.
+  //
+  // @param time_source TimeSource parameter used by many rate limiters to track time.
+  //
+  // @param options Client Options parameter used for command line error checking.
+  //
+  // @return RateLimiterPtr Pointer to the new instance of RateLimiter.
+  //
+  // @throw Envoy::EnvoyException If the Any proto cannot be unpacked as the type expected by the
+  // plugin.
+  virtual RateLimiterPtr createRateLimiterPlugin(const Envoy::Protobuf::Message& typed_config,
+                                                 Envoy::Api::Api& api,
+                                                 Envoy::TimeSource& time_source,
+                                                 const Client::Options& options) PURE;
+};
+
+} // namespace Nighthawk

--- a/include/nighthawk/common/rate_limiter_plugin_config_factory.h
+++ b/include/nighthawk/common/rate_limiter_plugin_config_factory.h
@@ -4,8 +4,8 @@
 #include "envoy/common/pure.h"
 #include "envoy/config/typed_config.h"
 
-#include "nighthawk/common/rate_limiter.h"
 #include "nighthawk/client/options.h"
+#include "nighthawk/common/rate_limiter.h"
 
 namespace Nighthawk {
 
@@ -17,8 +17,8 @@ public:
   // All rate limiter plugins will be in this category.
   std::string category() const override { return "nighthawk.rate_limiter_plugin"; }
 
-  // Instantiates the specific RateLimiterPlugin class. Casts |typed_config| to Any, unpacks it to the
-  // plugin-specific proto, and passes the strongly typed proto to the plugin constructor.
+  // Instantiates the specific RateLimiterPlugin class. Casts |typed_config| to Any, unpacks it to
+  // the plugin-specific proto, and passes the strongly typed proto to the plugin constructor.
   //
   // @param typed_config Taken from TypedExtensionConfig. This should be a type
   // listed in a rate limiter proto file.

--- a/source/client/client_worker_impl.cc
+++ b/source/client/client_worker_impl.cc
@@ -44,7 +44,7 @@ ClientWorkerImpl::ClientWorkerImpl(
                                           },
                                           termination_predicate_factory_.create(
                                               *time_source_, *worker_number_scope_, starting_time),
-                                          *worker_number_scope_, starting_time),
+                                          *worker_number_scope_, starting_time, api),
                                       true)),
       hardcoded_warmup_style_(hardcoded_warmup_style) {}
 

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -4,12 +4,12 @@
 #include <memory>
 #include <utility>
 
-#include "nighthawk/user_defined_output/user_defined_output_plugin.h"
 #include "nighthawk/common/rate_limiter.h"
 #include "nighthawk/common/rate_limiter_plugin_config_factory.h"
+#include "nighthawk/user_defined_output/user_defined_output_plugin.h"
 
-#include "external/envoy/source/common/http/header_map_impl.h"
 #include "external/envoy/source/common/config/utility.h"
+#include "external/envoy/source/common/http/header_map_impl.h"
 
 #include "api/client/options.pb.h"
 
@@ -74,28 +74,29 @@ BenchmarkClientPtr BenchmarkClientFactoryImpl::create(
 SequencerFactoryImpl::SequencerFactoryImpl(const Options& options)
     : OptionBasedFactoryImpl(options) {}
 
-SequencerPtr SequencerFactoryImpl::create(
-    Envoy::TimeSource& time_source, Envoy::Event::Dispatcher& dispatcher,
-    const SequencerTarget& sequencer_target, TerminationPredicatePtr&& termination_predicate,
-    Envoy::Stats::Scope& scope, const Envoy::MonotonicTime scheduled_starting_time,
-    Envoy::Api::Api& api) const {
+SequencerPtr SequencerFactoryImpl::create(Envoy::TimeSource& time_source,
+                                          Envoy::Event::Dispatcher& dispatcher,
+                                          const SequencerTarget& sequencer_target,
+                                          TerminationPredicatePtr&& termination_predicate,
+                                          Envoy::Stats::Scope& scope,
+                                          const Envoy::MonotonicTime scheduled_starting_time,
+                                          Envoy::Api::Api& api) const {
   StatisticFactoryImpl statistic_factory(options_);
   RateLimiterPtr rate_limiter;
 
   // Check if there is a rate limiter plugin to load and use.
   if (options_.rateLimiterPluginConfig().has_value()) {
-    absl::StatusOr<RateLimiterPtr> plugin_or = LoadRateLimiterPlugin(
-        options_.rateLimiterPluginConfig().value(), api, time_source);
+    absl::StatusOr<RateLimiterPtr> plugin_or =
+        LoadRateLimiterPlugin(options_.rateLimiterPluginConfig().value(), api, time_source);
     if (!plugin_or.ok()) {
       throw NighthawkException(
-          absl::StrCat("Rate Limiter plugin loading error: ",
-                       plugin_or.status().message()));
+          absl::StrCat("Rate Limiter plugin loading error: ", plugin_or.status().message()));
     }
     rate_limiter = std::move(plugin_or.value());
-    rate_limiter = std::make_unique<ScheduledStartingRateLimiter>(
-        std::move(rate_limiter), scheduled_starting_time);
+    rate_limiter = std::make_unique<ScheduledStartingRateLimiter>(std::move(rate_limiter),
+                                                                  scheduled_starting_time);
 
-  // If no rate limiter plugin is set, use the default linear rate limiter.
+    // If no rate limiter plugin is set, use the default linear rate limiter.
   } else {
     Frequency frequency(options_.requestsPerSecond());
     rate_limiter = std::make_unique<ScheduledStartingRateLimiter>(
@@ -121,12 +122,14 @@ SequencerPtr SequencerFactoryImpl::create(
 }
 
 absl::StatusOr<RateLimiterPtr> SequencerFactoryImpl::LoadRateLimiterPlugin(
-    const envoy::config::core::v3::TypedExtensionConfig& config, Envoy::Api::Api& api, Envoy::TimeSource& time_source) const {
+    const envoy::config::core::v3::TypedExtensionConfig& config, Envoy::Api::Api& api,
+    Envoy::TimeSource& time_source) const {
   try {
     auto& config_factory =
         Envoy::Config::Utility::getAndCheckFactoryByName<RateLimiterPluginConfigFactory>(
             config.name());
-    return config_factory.createRateLimiterPlugin(config.typed_config(), api, time_source, options_);
+    return config_factory.createRateLimiterPlugin(config.typed_config(), api, time_source,
+                                                  options_);
   } catch (const Envoy::EnvoyException& e) {
     return absl::InvalidArgumentError(
         absl::StrCat("Could not load plugin: ", config.name(), ": ", e.what()));

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -1,8 +1,15 @@
 #include "source/client/factories_impl.h"
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <utility>
 
 #include "nighthawk/user_defined_output/user_defined_output_plugin.h"
+#include "nighthawk/common/rate_limiter.h"
+#include "nighthawk/common/rate_limiter_plugin_config_factory.h"
 
 #include "external/envoy/source/common/http/header_map_impl.h"
+#include "external/envoy/source/common/config/utility.h"
 
 #include "api/client/options.pb.h"
 
@@ -70,28 +77,60 @@ SequencerFactoryImpl::SequencerFactoryImpl(const Options& options)
 SequencerPtr SequencerFactoryImpl::create(
     Envoy::TimeSource& time_source, Envoy::Event::Dispatcher& dispatcher,
     const SequencerTarget& sequencer_target, TerminationPredicatePtr&& termination_predicate,
-    Envoy::Stats::Scope& scope, const Envoy::MonotonicTime scheduled_starting_time) const {
+    Envoy::Stats::Scope& scope, const Envoy::MonotonicTime scheduled_starting_time,
+    Envoy::Api::Api& api) const {
   StatisticFactoryImpl statistic_factory(options_);
-  Frequency frequency(options_.requestsPerSecond());
-  RateLimiterPtr rate_limiter = std::make_unique<ScheduledStartingRateLimiter>(
-      std::make_unique<LinearRateLimiter>(time_source, frequency), scheduled_starting_time);
-  const uint64_t burst_size = options_.burstSize();
+  RateLimiterPtr rate_limiter;
 
-  if (burst_size) {
-    rate_limiter = std::make_unique<BurstingRateLimiter>(std::move(rate_limiter), burst_size);
-  }
+  // Check if there is a rate limiter plugin to load and use.
+  if (options_.rateLimiterPluginConfig().has_value()) {
+    absl::StatusOr<RateLimiterPtr> plugin_or = LoadRateLimiterPlugin(
+        options_.rateLimiterPluginConfig().value(), api, time_source);
+    if (!plugin_or.ok()) {
+      throw NighthawkException(
+          absl::StrCat("Rate Limiter plugin loading error: ",
+                       plugin_or.status().message()));
+    }
+    rate_limiter = std::move(plugin_or.value());
+    rate_limiter = std::make_unique<ScheduledStartingRateLimiter>(
+        std::move(rate_limiter), scheduled_starting_time);
 
-  const std::chrono::nanoseconds jitter_uniform = options_.jitterUniform();
-  if (jitter_uniform.count() > 0) {
-    rate_limiter = std::make_unique<DistributionSamplingRateLimiterImpl>(
-        std::make_unique<UniformRandomDistributionSamplerImpl>(jitter_uniform.count()),
-        std::move(rate_limiter));
+  // If no rate limiter plugin is set, use the default linear rate limiter.
+  } else {
+    Frequency frequency(options_.requestsPerSecond());
+    rate_limiter = std::make_unique<ScheduledStartingRateLimiter>(
+        std::make_unique<LinearRateLimiter>(time_source, frequency), scheduled_starting_time);
+    const uint64_t burst_size = options_.burstSize();
+
+    if (burst_size) {
+      rate_limiter = std::make_unique<BurstingRateLimiter>(std::move(rate_limiter), burst_size);
+    }
+
+    const std::chrono::nanoseconds jitter_uniform = options_.jitterUniform();
+    if (jitter_uniform.count() > 0) {
+      rate_limiter = std::make_unique<DistributionSamplingRateLimiterImpl>(
+          std::make_unique<UniformRandomDistributionSamplerImpl>(jitter_uniform.count()),
+          std::move(rate_limiter));
+    }
   }
 
   return std::make_unique<SequencerImpl>(
       platform_util_, dispatcher, time_source, std::move(rate_limiter), sequencer_target,
       statistic_factory.create(), statistic_factory.create(), options_.sequencerIdleStrategy(),
       std::move(termination_predicate), scope);
+}
+
+absl::StatusOr<RateLimiterPtr> SequencerFactoryImpl::LoadRateLimiterPlugin(
+    const envoy::config::core::v3::TypedExtensionConfig& config, Envoy::Api::Api& api, Envoy::TimeSource& time_source) const {
+  try {
+    auto& config_factory =
+        Envoy::Config::Utility::getAndCheckFactoryByName<RateLimiterPluginConfigFactory>(
+            config.name());
+    return config_factory.createRateLimiterPlugin(config.typed_config(), api, time_source, options_);
+  } catch (const Envoy::EnvoyException& e) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Could not load plugin: ", config.name(), ": ", e.what()));
+  }
 }
 
 StatisticFactoryImpl::StatisticFactoryImpl(const Options& options)

--- a/source/client/factories_impl.h
+++ b/source/client/factories_impl.h
@@ -44,7 +44,21 @@ public:
   SequencerPtr create(Envoy::TimeSource& time_source, Envoy::Event::Dispatcher& dispatcher,
                       const SequencerTarget& sequencer_target,
                       TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope,
-                      const Envoy::MonotonicTime scheduled_starting_time) const override;
+                      const Envoy::MonotonicTime scheduled_starting_time,
+                      Envoy::Api::Api& api) const override;
+
+private:
+
+  /**
+   * Instantiates a RateLimiter using a RateLimiterPluginConfigFactory based on `config`.
+   * @param config Plugin name and typed configuration.
+   * @param api Envoy API context.
+   * @param time_source Time source used by the rate limiter.
+   * @return Initialized plugin or error status.
+   */
+  absl::StatusOr<RateLimiterPtr>
+  LoadRateLimiterPlugin(const envoy::config::core::v3::TypedExtensionConfig& config,
+                         Envoy::Api::Api& api, Envoy::TimeSource& time_source) const;
 };
 
 class StatisticFactoryImpl : public OptionBasedFactoryImpl, public StatisticFactory {

--- a/source/client/factories_impl.h
+++ b/source/client/factories_impl.h
@@ -48,7 +48,6 @@ public:
                       Envoy::Api::Api& api) const override;
 
 private:
-
   /**
    * Instantiates a RateLimiter using a RateLimiterPluginConfigFactory based on `config`.
    * @param config Plugin name and typed configuration.
@@ -58,7 +57,7 @@ private:
    */
   absl::StatusOr<RateLimiterPtr>
   LoadRateLimiterPlugin(const envoy::config::core::v3::TypedExtensionConfig& config,
-                         Envoy::Api::Api& api, Envoy::TimeSource& time_source) const;
+                        Envoy::Api::Api& api, Envoy::TimeSource& time_source) const;
 };
 
 class StatisticFactoryImpl : public OptionBasedFactoryImpl, public StatisticFactory {

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -364,6 +364,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::ValueArg<std::string> rate_limiter_plugin_config(
       "", "rate-limiter-plugin-config",
       "Rate Limiter plugin configuration in json. "
+      "Mutually exclusive with --burst-size and --jitter-uniform. "
       "Example (json): "
       "{name:\"nighthawk.stub-rate-limiter-plugin\",typed_config:{"
       "\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.StubRateLimiterConfig\","
@@ -711,6 +712,13 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
     }
   }
   if (!rate_limiter_plugin_config.getValue().empty()) {
+    if (burst_size.isSet()) {
+      throw MalformedArgvException("--burst-size and --rate-limiter-plugin-config are mutually exclusive");
+    }
+    if (jitter_uniform.isSet()) {
+      throw MalformedArgvException("--jitter-uniform and --rate-limiter-plugin-config are mutually exclusive");
+    }
+
     try {
       rate_limiter_plugin_config_.emplace(envoy::config::core::v3::TypedExtensionConfig());
       Envoy::MessageUtil::loadFromJson(rate_limiter_plugin_config.getValue(),
@@ -893,6 +901,13 @@ OptionsImpl::OptionsImpl(const nighthawk::client::CommandLineOptions& options) {
   }
 
   if (options.has_rate_limiter_plugin_config()) {
+    if (options.has_burst_size() && options.burst_size().value() != 0) {
+      throw MalformedArgvException("burst_size and rate_limiter_plugin_config are mutually exclusive");
+    }
+    if (options.has_jitter_uniform() && (options.jitter_uniform().seconds() != 0 || options.jitter_uniform().nanos() != 0)) {
+      throw MalformedArgvException("jitter_uniform and rate_limiter_plugin_config are mutually exclusive");
+    }
+
     rate_limiter_plugin_config_.emplace(envoy::config::core::v3::TypedExtensionConfig());
     rate_limiter_plugin_config_.value().MergeFrom(options.rate_limiter_plugin_config());
   }

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -713,10 +713,12 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   }
   if (!rate_limiter_plugin_config.getValue().empty()) {
     if (burst_size.isSet()) {
-      throw MalformedArgvException("--burst-size and --rate-limiter-plugin-config are mutually exclusive");
+      throw MalformedArgvException(
+          "--burst-size and --rate-limiter-plugin-config are mutually exclusive");
     }
     if (jitter_uniform.isSet()) {
-      throw MalformedArgvException("--jitter-uniform and --rate-limiter-plugin-config are mutually exclusive");
+      throw MalformedArgvException(
+          "--jitter-uniform and --rate-limiter-plugin-config are mutually exclusive");
     }
 
     try {
@@ -902,10 +904,13 @@ OptionsImpl::OptionsImpl(const nighthawk::client::CommandLineOptions& options) {
 
   if (options.has_rate_limiter_plugin_config()) {
     if (options.has_burst_size() && options.burst_size().value() != 0) {
-      throw MalformedArgvException("burst_size and rate_limiter_plugin_config are mutually exclusive");
+      throw MalformedArgvException(
+          "burst_size and rate_limiter_plugin_config are mutually exclusive");
     }
-    if (options.has_jitter_uniform() && (options.jitter_uniform().seconds() != 0 || options.jitter_uniform().nanos() != 0)) {
-      throw MalformedArgvException("jitter_uniform and rate_limiter_plugin_config are mutually exclusive");
+    if (options.has_jitter_uniform() &&
+        (options.jitter_uniform().seconds() != 0 || options.jitter_uniform().nanos() != 0)) {
+      throw MalformedArgvException(
+          "jitter_uniform and rate_limiter_plugin_config are mutually exclusive");
     }
 
     rate_limiter_plugin_config_.emplace(envoy::config::core::v3::TypedExtensionConfig());

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -365,10 +365,11 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "", "rate-limiter-plugin-config",
       "Rate Limiter plugin configuration in json. "
       "Mutually exclusive with --burst-size and --jitter-uniform. "
+      "Possible configurations located in api/rate_limiter. "
       "Example (json): "
-      "{name:\"nighthawk.stub-rate-limiter-plugin\",typed_config:{"
-      "\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.StubRateLimiterConfig\","
-      "test_value:\"3\"}}",
+      "{name:\"nighthawk.linear-ramping-rate-limiter-plugin\",typed_config:{"
+      "\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.LinearRampingRateLimiterConfig\","
+      "\"ramp_time\":\"5.5s\"}}",
       false, "", "string", cmd);
 
   TCLAP::SwitchArg simple_warmup(

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -360,6 +360,16 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "\"@type\":\"type.googleapis.com/nighthawk.request_source.StubPluginConfig\","
       "test_value:\"3\"}}",
       false, "", "string", cmd);
+
+  TCLAP::ValueArg<std::string> rate_limiter_plugin_config(
+      "", "rate-limiter-plugin-config",
+      "Rate Limiter plugin configuration in json. "
+      "Example (json): "
+      "{name:\"nighthawk.stub-rate-limiter-plugin\",typed_config:{"
+      "\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.StubRateLimiterConfig\","
+      "test_value:\"3\"}}",
+      false, "", "string", cmd);
+
   TCLAP::SwitchArg simple_warmup(
       "", "simple-warmup",
       "Perform a simple single warmup request (per worker) before starting execution. Note that "
@@ -700,6 +710,16 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       throw MalformedArgvException(e.what());
     }
   }
+  if (!rate_limiter_plugin_config.getValue().empty()) {
+    try {
+      rate_limiter_plugin_config_.emplace(envoy::config::core::v3::TypedExtensionConfig());
+      Envoy::MessageUtil::loadFromJson(rate_limiter_plugin_config.getValue(),
+                                       rate_limiter_plugin_config_.value(),
+                                       Envoy::ProtobufMessage::getStrictValidationVisitor());
+    } catch (const Envoy::EnvoyException& e) {
+      throw MalformedArgvException(e.what());
+    }
+  }
   if (!user_defined_output_plugin_configs.getValue().empty()) {
     for (const std::string& plugin_config_string : user_defined_output_plugin_configs.getValue()) {
       try {
@@ -870,6 +890,11 @@ OptionsImpl::OptionsImpl(const nighthawk::client::CommandLineOptions& options) {
   } else if (options.has_request_source_plugin_config()) {
     request_source_plugin_config_.emplace(envoy::config::core::v3::TypedExtensionConfig());
     request_source_plugin_config_.value().MergeFrom(options.request_source_plugin_config());
+  }
+
+  if (options.has_rate_limiter_plugin_config()) {
+    rate_limiter_plugin_config_.emplace(envoy::config::core::v3::TypedExtensionConfig());
+    rate_limiter_plugin_config_.value().MergeFrom(options.rate_limiter_plugin_config());
   }
 
   max_pending_requests_ =
@@ -1093,6 +1118,11 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
       }
       request_options->mutable_request_body_size()->set_value(requestBodySize());
     }
+  }
+
+  if (rate_limiter_plugin_config_.has_value()) {
+    *(command_line_options->mutable_rate_limiter_plugin_config()) =
+        rate_limiter_plugin_config_.value();
   }
 
   // Only set the tls context if needed, to avoid a warning being logged about field deprecation.

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -89,7 +89,7 @@ public:
   requestSourcePluginConfig() const override {
     return request_source_plugin_config_;
   }
-  const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&
+  const std::optional<envoy::config::core::v3::TypedExtensionConfig>&
   rateLimiterPluginConfig() const override {
     return rate_limiter_plugin_config_;
   }

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -89,6 +89,10 @@ public:
   requestSourcePluginConfig() const override {
     return request_source_plugin_config_;
   }
+  const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&
+  rateLimiterPluginConfig() const override {
+    return rate_limiter_plugin_config_;
+  }
 
   std::string trace() const override { return trace_; }
   nighthawk::client::H1ConnectionReuseStrategy::H1ConnectionReuseStrategyOptions
@@ -170,6 +174,7 @@ private:
   std::optional<envoy::config::core::v3::BindConfig> upstream_bind_config_;
   std::optional<envoy::config::core::v3::TransportSocket> transport_socket_;
   std::optional<envoy::config::core::v3::TypedExtensionConfig> request_source_plugin_config_;
+  std::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config_;
 
   uint32_t max_pending_requests_{0};
   // This default is based the minimum recommendation for SETTINGS_MAX_CONCURRENT_STREAMS over at

--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -144,6 +144,7 @@ envoy_cc_library(
     deps = [
         "//api/client:base_cc_proto",
         "//api/client:grpc_service_lib",
+        "//api/rate_limiter:rate_limiter_plugin_cc_proto",
         "//include/nighthawk/client:client_includes",
         "//include/nighthawk/common:base_includes",
         "//internal_proto/statistic:statistic_cc_proto",

--- a/source/common/rate_limiter_impl.cc
+++ b/source/common/rate_limiter_impl.cc
@@ -1,5 +1,6 @@
 #include "source/common/rate_limiter_impl.h"
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <memory>
 
@@ -126,7 +127,9 @@ void LinearRateLimiter::releaseOne() {
 LinearRampingRateLimiterImpl::LinearRampingRateLimiterImpl(Envoy::TimeSource& time_source,
                                                            const std::chrono::nanoseconds ramp_time,
                                                            const Frequency frequency)
-    : RateLimiterBaseImpl(time_source), ramp_time_(ramp_time), frequency_(frequency) {
+    : RateLimiterBaseImpl(time_source), ramp_time_(ramp_time), frequency_(frequency),
+      target_freq_ns_(frequency_.value() / 1e9),
+      total_ramp_requests_(std::round(ramp_time.count() * target_freq_ns_ / 2.0)) {
   if (frequency_.value() <= 0) {
     throw NighthawkException(fmt::format("frequency must be > 0, value: {}", frequency.value()));
   }
@@ -142,16 +145,22 @@ bool LinearRampingRateLimiterImpl::tryAcquireOne() {
     return acquireable_count_--;
   }
   const std::chrono::nanoseconds elapsed_time = elapsed();
-  double elapsed_fraction = 1.0;
+  int64_t total = 0;
+
   if (elapsed_time < ramp_time_) {
+    double elapsed_fraction = 1.0;
     elapsed_fraction -= static_cast<double>(ramp_time_.count() - elapsed_time.count()) /
                         static_cast<double>(ramp_time_.count());
+
+    const double current_frequency = elapsed_fraction * frequency_.value();
+    // If we'd be at a constant pace, we can expect elapsed seconds * frequency requests.
+    // However, as we are linearly ramping, we can expect half of that, hence we
+    // divide by two.
+    total = std::round((elapsed_time.count() / 1e9) * current_frequency / 2.0);
+  } else {
+    total = total_ramp_requests_ +
+            std::round((elapsed_time - ramp_time_).count() * target_freq_ns_);
   }
-  const double current_frequency = elapsed_fraction * frequency_.value();
-  // If we'd be at a constant pace, we can expect elapsed seconds * frequency requests.
-  // However, as we are linearly ramping, we can expect half of that, hence we
-  // divide by two.
-  const int64_t total = std::round((elapsed_time.count() / 1e9) * current_frequency / 2.0);
   acquireable_count_ = total - acquired_count_;
   return acquireable_count_ > 0 ? tryAcquireOne() : false;
 }

--- a/source/common/rate_limiter_impl.cc
+++ b/source/common/rate_limiter_impl.cc
@@ -158,8 +158,8 @@ bool LinearRampingRateLimiterImpl::tryAcquireOne() {
     // divide by two.
     total = std::round((elapsed_time.count() / 1e9) * current_frequency / 2.0);
   } else {
-    total = total_ramp_requests_ +
-            std::round((elapsed_time - ramp_time_).count() * target_freq_ns_);
+    total =
+        total_ramp_requests_ + std::round((elapsed_time - ramp_time_).count() * target_freq_ns_);
   }
   acquireable_count_ = total - acquired_count_;
   return acquireable_count_ > 0 ? tryAcquireOne() : false;

--- a/source/common/rate_limiter_impl.cc
+++ b/source/common/rate_limiter_impl.cc
@@ -4,14 +4,14 @@
 #include <memory>
 
 #include "envoy/api/api.h"
+#include "envoy/common/exception.h"
+#include "external/envoy/source/common/common/macros.h"
 #include "external/envoy/source/common/protobuf/protobuf.h"
 #include "nighthawk/client/options.h"
-#include "external/envoy/source/common/common/macros.h"
-#include "envoy/common/exception.h"
 #include "nighthawk/common/exception.h"
 
-#include "external/envoy/source/common/common/assert.h"
 #include "envoy/registry/registry.h"
+#include "external/envoy/source/common/common/assert.h"
 #include "external/envoy/source/common/protobuf/utility.h"
 #include "nighthawk/common/rate_limiter_plugin_config_factory.h"
 
@@ -173,15 +173,15 @@ RateLimiterPtr LinearRampingRateLimiterImplFactory::createRateLimiterPlugin(
   Envoy::MessageUtil::anyConvert(*any, config);
 
   const uint32_t rps = options.requestsPerSecond();
-  const std::chrono::nanoseconds ramp_time =
-      std::chrono::seconds(config.ramp_time().seconds()) +
-      std::chrono::nanoseconds(config.ramp_time().nanos());
+  const std::chrono::nanoseconds ramp_time = std::chrono::seconds(config.ramp_time().seconds()) +
+                                             std::chrono::nanoseconds(config.ramp_time().nanos());
 
   if (ramp_time <= 0ns) {
     throw NighthawkException("ramp_time must be positive and > 0ns");
   }
   if (!options.noDuration() && ramp_time > options.duration()) {
-    throw NighthawkException("ramp_time must be less than or equal to time specified by --duration");
+    throw NighthawkException(
+        "ramp_time must be less than or equal to time specified by --duration");
   }
 
   return std::make_unique<LinearRampingRateLimiterImpl>(time_source, ramp_time, Frequency(rps));

--- a/source/common/rate_limiter_impl.cc
+++ b/source/common/rate_limiter_impl.cc
@@ -1,8 +1,19 @@
 #include "source/common/rate_limiter_impl.h"
+#include <chrono>
+#include <cstdint>
+#include <memory>
 
+#include "envoy/api/api.h"
+#include "external/envoy/source/common/protobuf/protobuf.h"
+#include "nighthawk/client/options.h"
+#include "external/envoy/source/common/common/macros.h"
+#include "envoy/common/exception.h"
 #include "nighthawk/common/exception.h"
 
 #include "external/envoy/source/common/common/assert.h"
+#include "envoy/registry/registry.h"
+#include "external/envoy/source/common/protobuf/utility.h"
+#include "nighthawk/common/rate_limiter_plugin_config_factory.h"
 
 namespace Nighthawk {
 
@@ -149,6 +160,34 @@ void LinearRampingRateLimiterImpl::releaseOne() {
   acquireable_count_++;
   acquired_count_--;
 }
+
+RateLimiterPtr LinearRampingRateLimiterImplFactory::createRateLimiterPlugin(
+    const Envoy::Protobuf::Message& typed_config, Envoy::Api::Api& api,
+    Envoy::TimeSource& time_source, const Nighthawk::Client::Options& options) {
+  UNREFERENCED_PARAMETER(api);
+  const auto* any = Envoy::Protobuf::DynamicCastMessage<const Envoy::Protobuf::Any>(&typed_config);
+  if (any == nullptr) {
+    throw Envoy::EnvoyException("typed_config cannot be cast to an Any proto");
+  }
+  nighthawk::rate_limiter::LinearRampingRateLimiterConfig config;
+  Envoy::MessageUtil::anyConvert(*any, config);
+
+  const uint32_t rps = options.requestsPerSecond();
+  const std::chrono::nanoseconds ramp_time =
+      std::chrono::seconds(config.ramp_time().seconds()) +
+      std::chrono::nanoseconds(config.ramp_time().nanos());
+
+  if (ramp_time <= 0ns) {
+    throw NighthawkException("ramp_time must be positive and > 0ns");
+  }
+  if (!options.noDuration() && ramp_time > options.duration()) {
+    throw NighthawkException("ramp_time must be less than or equal to time specified by --duration");
+  }
+
+  return std::make_unique<LinearRampingRateLimiterImpl>(time_source, ramp_time, Frequency(rps));
+}
+
+REGISTER_FACTORY(LinearRampingRateLimiterImplFactory, RateLimiterPluginConfigFactory);
 
 DelegatingRateLimiterImpl::DelegatingRateLimiterImpl(
     RateLimiterPtr&& rate_limiter, RateLimiterDelegate random_distribution_generator)

--- a/source/common/rate_limiter_impl.h
+++ b/source/common/rate_limiter_impl.h
@@ -14,6 +14,8 @@
 
 #include "absl/random/random.h"
 #include "absl/random/zipf_distribution.h"
+#include "nighthawk/common/rate_limiter_plugin_config_factory.h"
+#include "api/rate_limiter/linear_ramping_rate_limiter.pb.h"
 
 namespace Nighthawk {
 
@@ -80,6 +82,21 @@ private:
   uint64_t acquired_count_{0};
   const std::chrono::nanoseconds ramp_time_;
   const Frequency frequency_;
+};
+
+// Factory class for creating LinearRampingRateLimiterImpl objects.
+class LinearRampingRateLimiterImplFactory : public virtual Nighthawk::RateLimiterPluginConfigFactory {
+public:
+  std::string name() const override { return "nighthawk.linear-ramping-rate-limiter-plugin"; }
+
+  Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<nighthawk::rate_limiter::LinearRampingRateLimiterConfig>();
+  }
+
+  RateLimiterPtr createRateLimiterPlugin(const Envoy::Protobuf::Message& typed_config,
+                                         Envoy::Api::Api& api,
+                                         Envoy::TimeSource& time_source,
+                                         const Nighthawk::Client::Options& options) override;
 };
 
 /**

--- a/source/common/rate_limiter_impl.h
+++ b/source/common/rate_limiter_impl.h
@@ -82,6 +82,8 @@ private:
   uint64_t acquired_count_{0};
   const std::chrono::nanoseconds ramp_time_;
   const Frequency frequency_;
+  const double target_freq_ns_;
+  const int64_t total_ramp_requests_;
 };
 
 // Factory class for creating LinearRampingRateLimiterImpl objects.

--- a/source/common/rate_limiter_impl.h
+++ b/source/common/rate_limiter_impl.h
@@ -14,8 +14,8 @@
 
 #include "absl/random/random.h"
 #include "absl/random/zipf_distribution.h"
-#include "nighthawk/common/rate_limiter_plugin_config_factory.h"
 #include "api/rate_limiter/linear_ramping_rate_limiter.pb.h"
+#include "nighthawk/common/rate_limiter_plugin_config_factory.h"
 
 namespace Nighthawk {
 
@@ -85,7 +85,8 @@ private:
 };
 
 // Factory class for creating LinearRampingRateLimiterImpl objects.
-class LinearRampingRateLimiterImplFactory : public virtual Nighthawk::RateLimiterPluginConfigFactory {
+class LinearRampingRateLimiterImplFactory
+    : public virtual Nighthawk::RateLimiterPluginConfigFactory {
 public:
   std::string name() const override { return "nighthawk.linear-ramping-rate-limiter-plugin"; }
 
@@ -94,8 +95,7 @@ public:
   }
 
   RateLimiterPtr createRateLimiterPlugin(const Envoy::Protobuf::Message& typed_config,
-                                         Envoy::Api::Api& api,
-                                         Envoy::TimeSource& time_source,
+                                         Envoy::Api::Api& api, Envoy::TimeSource& time_source,
                                          const Nighthawk::Client::Options& options) override;
 };
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -202,6 +202,20 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "rate_limiter_plugin_test",
+    srcs = ["rate_limiter_plugin_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//api/rate_limiter:rate_limiter_plugin_cc_proto",
+        "//source/common:nighthawk_common_lib",
+        "//test/mocks/client:mock_options",
+        "//test/test_common:proto_matchers",
+        "@envoy//test/mocks/stats:stats_mocks",
+        "@envoy//test/test_common:simulated_time_system_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "sequencer_test",
     srcs = ["sequencer_test.cc"],
     data = [

--- a/test/client_worker_test.cc
+++ b/test/client_worker_test.cc
@@ -56,7 +56,7 @@ public:
         .Times(1)
         .WillOnce(Return(ByMove(std::unique_ptr<BenchmarkClient>(benchmark_client_))));
 
-    EXPECT_CALL(sequencer_factory_, create(_, _, _, _, _, _))
+    EXPECT_CALL(sequencer_factory_, create(_, _, _, _, _, _, _))
         .Times(1)
         .WillOnce(Return(ByMove(std::unique_ptr<Sequencer>(sequencer_))));
 

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -1,9 +1,9 @@
-#include <chrono>
 #include "external/envoy/test/mocks/event/mocks.h"
 #include "external/envoy/test/mocks/stats/mocks.h"
 #include "external/envoy/test/mocks/tracing/mocks.h"
 #include "external/envoy/test/test_common/simulated_time_system.h"
 #include "external/envoy/test/test_common/utility.h"
+#include <chrono>
 
 #include "source/client/factories_impl.h"
 #include "source/common/request_source_impl.h"
@@ -185,8 +185,9 @@ public:
                                  sequencer_idle_strategy) {
     SequencerFactoryImpl factory(options_);
     MockBenchmarkClient benchmark_client;
-    absl::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
-    EXPECT_CALL(options_, rateLimiterPluginConfig()).WillOnce(ReturnRef(rate_limiter_plugin_config));
+    std::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
+    EXPECT_CALL(options_, rateLimiterPluginConfig())
+        .WillOnce(ReturnRef(rate_limiter_plugin_config));
     EXPECT_CALL(options_, requestsPerSecond()).WillOnce(Return(1));
     EXPECT_CALL(options_, burstSize()).WillOnce(Return(2));
     EXPECT_CALL(options_, sequencerIdleStrategy())
@@ -208,7 +209,7 @@ public:
 TEST_P(SequencerFactoryTest, TestCreation) { testSequencerCreation(GetParam()); }
 
 TEST_P(SequencerFactoryTest, ValidRateLimiterPluginCreatesWorkingSequencer) {
-  absl::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
+  std::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
   std::string rate_limiter_plugin_config_json =
       "{"
       "name:\"nighthawk.linear-ramping-rate-limiter-plugin\","
@@ -238,7 +239,9 @@ TEST_P(SequencerFactoryTest, ValidRateLimiterPluginCreatesWorkingSequencer) {
   EXPECT_CALL(options_, duration()).WillOnce(Return(std::chrono::seconds(10)));
 
   Envoy::Event::SimulatedTimeSystem time_system;
-  const SequencerTarget dummy_sequencer_target = [](const CompletionCallback&) -> bool { return true; };
+  const SequencerTarget dummy_sequencer_target = [](const CompletionCallback&) -> bool {
+    return true;
+  };
 
   auto sequencer = factory.create(api_->timeSource(), dispatcher_, dummy_sequencer_target,
                                   std::make_unique<MockTerminationPredicate>(), stats_scope_,
@@ -247,7 +250,7 @@ TEST_P(SequencerFactoryTest, ValidRateLimiterPluginCreatesWorkingSequencer) {
 }
 
 TEST_P(SequencerFactoryTest, UnknownRateLimiterPluginThrowsException) {
-  absl::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
+  std::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
   std::string rate_limiter_plugin_config_json =
       "{"
       "name:\"nighthawk.unknown-rate-limiter-plugin\","
@@ -269,14 +272,14 @@ TEST_P(SequencerFactoryTest, UnknownRateLimiterPluginThrowsException) {
       .WillRepeatedly(ReturnRef(rate_limiter_plugin_config));
 
   Envoy::Event::SimulatedTimeSystem time_system;
-  const SequencerTarget dummy_sequencer_target = [](const CompletionCallback&) -> bool { return true; };
+  const SequencerTarget dummy_sequencer_target = [](const CompletionCallback&) -> bool {
+    return true;
+  };
 
-  EXPECT_THROW_WITH_REGEX(
-      factory.create(api_->timeSource(), dispatcher_, dummy_sequencer_target,
-                     std::make_unique<MockTerminationPredicate>(), stats_scope_,
-                     time_system.monotonicTime() + 10ms, *api_),
-      NighthawkException,
-      "Rate Limiter plugin loading error");
+  EXPECT_THROW_WITH_REGEX(factory.create(api_->timeSource(), dispatcher_, dummy_sequencer_target,
+                                         std::make_unique<MockTerminationPredicate>(), stats_scope_,
+                                         time_system.monotonicTime() + 10ms, *api_),
+                          NighthawkException, "Rate Limiter plugin loading error");
 }
 
 INSTANTIATE_TEST_SUITE_P(SequencerIdleStrategies, SequencerFactoryTest,

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -1,3 +1,4 @@
+#include <chrono>
 #include "external/envoy/test/mocks/event/mocks.h"
 #include "external/envoy/test/mocks/stats/mocks.h"
 #include "external/envoy/test/mocks/tracing/mocks.h"
@@ -11,7 +12,7 @@
 #include "test/mocks/client/mock_options.h"
 #include "test/mocks/common/mock_termination_predicate.h"
 #include "test/test_common/environment.h"
-
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using namespace testing;
@@ -184,6 +185,8 @@ public:
                                  sequencer_idle_strategy) {
     SequencerFactoryImpl factory(options_);
     MockBenchmarkClient benchmark_client;
+    absl::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
+    EXPECT_CALL(options_, rateLimiterPluginConfig()).WillOnce(ReturnRef(rate_limiter_plugin_config));
     EXPECT_CALL(options_, requestsPerSecond()).WillOnce(Return(1));
     EXPECT_CALL(options_, burstSize()).WillOnce(Return(2));
     EXPECT_CALL(options_, sequencerIdleStrategy())
@@ -197,12 +200,84 @@ public:
     };
     auto sequencer = factory.create(api_->timeSource(), dispatcher_, dummy_sequencer_target,
                                     std::make_unique<MockTerminationPredicate>(), stats_scope_,
-                                    time_system.monotonicTime() + 10ms);
+                                    time_system.monotonicTime() + 10ms, *api_);
     EXPECT_NE(nullptr, sequencer.get());
   }
 };
 
 TEST_P(SequencerFactoryTest, TestCreation) { testSequencerCreation(GetParam()); }
+
+TEST_P(SequencerFactoryTest, ValidRateLimiterPluginCreatesWorkingSequencer) {
+  absl::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
+  std::string rate_limiter_plugin_config_json =
+      "{"
+      "name:\"nighthawk.linear-ramping-rate-limiter-plugin\","
+      "typed_config:{"
+      "\"@type\":\"type.googleapis.com/"
+      "nighthawk.rate_limiter.LinearRampingRateLimiterConfig\","
+      "ramp_time:{seconds:5}"
+      "}"
+      "}";
+  rate_limiter_plugin_config.emplace(envoy::config::core::v3::TypedExtensionConfig());
+  Envoy::MessageUtil::loadFromJson(rate_limiter_plugin_config_json,
+                                   rate_limiter_plugin_config.value(),
+                                   Envoy::ProtobufMessage::getStrictValidationVisitor());
+
+  SequencerFactoryImpl factory(options_);
+
+  EXPECT_CALL(options_, rateLimiterPluginConfig())
+      .Times(AtLeast(1))
+      .WillRepeatedly(ReturnRef(rate_limiter_plugin_config));
+  EXPECT_CALL(options_, sequencerIdleStrategy()).WillOnce(Return(GetParam()));
+  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(2);
+
+  // LinearRampingRateLimiter specific. Adjust if test fails because of any
+  // changes made to the LinearRampingRateLimiterImplFactory.
+  EXPECT_CALL(options_, requestsPerSecond()).WillOnce(Return(100));
+  EXPECT_CALL(options_, noDuration()).WillOnce(Return(false));
+  EXPECT_CALL(options_, duration()).WillOnce(Return(std::chrono::seconds(10)));
+
+  Envoy::Event::SimulatedTimeSystem time_system;
+  const SequencerTarget dummy_sequencer_target = [](const CompletionCallback&) -> bool { return true; };
+
+  auto sequencer = factory.create(api_->timeSource(), dispatcher_, dummy_sequencer_target,
+                                  std::make_unique<MockTerminationPredicate>(), stats_scope_,
+                                  time_system.monotonicTime() + 10ms, *api_);
+  EXPECT_NE(nullptr, sequencer.get());
+}
+
+TEST_P(SequencerFactoryTest, UnknownRateLimiterPluginThrowsException) {
+  absl::optional<envoy::config::core::v3::TypedExtensionConfig> rate_limiter_plugin_config;
+  std::string rate_limiter_plugin_config_json =
+      "{"
+      "name:\"nighthawk.unknown-rate-limiter-plugin\","
+      "typed_config:{"
+      "\"@type\":\"type.googleapis.com/"
+      "nighthawk.rate_limiter.LinearRampingRateLimiterConfig\","
+      "ramp_time:{seconds:5}"
+      "}"
+      "}";
+  rate_limiter_plugin_config.emplace(envoy::config::core::v3::TypedExtensionConfig());
+  Envoy::MessageUtil::loadFromJson(rate_limiter_plugin_config_json,
+                                   rate_limiter_plugin_config.value(),
+                                   Envoy::ProtobufMessage::getStrictValidationVisitor());
+
+  SequencerFactoryImpl factory(options_);
+
+  EXPECT_CALL(options_, rateLimiterPluginConfig())
+      .Times(AtLeast(1))
+      .WillRepeatedly(ReturnRef(rate_limiter_plugin_config));
+
+  Envoy::Event::SimulatedTimeSystem time_system;
+  const SequencerTarget dummy_sequencer_target = [](const CompletionCallback&) -> bool { return true; };
+
+  EXPECT_THROW_WITH_REGEX(
+      factory.create(api_->timeSource(), dispatcher_, dummy_sequencer_target,
+                     std::make_unique<MockTerminationPredicate>(), stats_scope_,
+                     time_system.monotonicTime() + 10ms, *api_),
+      NighthawkException,
+      "Rate Limiter plugin loading error");
+}
 
 INSTANTIATE_TEST_SUITE_P(SequencerIdleStrategies, SequencerFactoryTest,
                          ValuesIn({nighthawk::client::SequencerIdleStrategy::POLL,

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -154,6 +154,12 @@ py_library(
     deps = [":integration_test_base"],
 )
 
+py_library(
+    name = "test_rate_limiter_plugin_lib",
+    srcs = ["test_rate_limiter_plugin.py"],
+    deps = [":integration_test_base"],
+)
+
 py_binary(
     name = "integration_test",
     srcs = ["integration_test.py"],
@@ -178,6 +184,7 @@ py_binary(
         ":test_integration_basics_lib",
         ":test_integration_zipkin_lib",
         ":test_output_transform_lib",
+        ":test_rate_limiter_plugin_lib",
         ":test_remote_execution_lib",
         ":test_request_source_plugin_lib",
         ":test_user_defined_output_plugins_lib",

--- a/test/integration/test_rate_limiter_plugin.py
+++ b/test/integration/test_rate_limiter_plugin.py
@@ -1,0 +1,33 @@
+"""Tests for Rate Limiter Plugins."""
+
+import pytest
+from test.integration.integration_test_fixtures import http_test_server_fixture
+from test.integration import asserts
+
+
+@pytest.mark.parametrize('server_config',
+                         ["nighthawk/test/integration/configurations/nighthawk_http_origin.yaml"])
+def test_linear_ramping_rate_limiter_plugin(http_test_server_fixture):
+  """Test LinearRampingRateLimiter plugin.
+
+  Ramp time: 5.5 seconds
+  Duration: 12 seconds
+  RPS: 100
+  Expected total requests: 925 (margin of 5)
+  """
+  rate_limiter_config = (
+      "{name:\"nighthawk.linear-ramping-rate-limiter-plugin\","
+      "typed_config:{\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.LinearRampingRateLimiterConfig\","
+      "ramp_time:{seconds:5,nanos:500000000}}}")  # 5.5 seconds
+
+  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+      http_test_server_fixture.getTestServerRootUri(), "--duration", "12", "--concurrency", "1",
+      "--rps", "100", "--rate-limiter-plugin-config", rate_limiter_config
+  ])
+  counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
+
+  expected_total = 925
+  margin = 5
+  asserts.assertCounterBetweenInclusive(
+      counters, "benchmark.http_2xx", expected_total - margin, expected_total + margin
+  )

--- a/test/integration/test_rate_limiter_plugin.py
+++ b/test/integration/test_rate_limiter_plugin.py
@@ -28,6 +28,5 @@ def test_linear_ramping_rate_limiter_plugin(http_test_server_fixture):
 
   expected_total = 925
   margin = 5
-  asserts.assertCounterBetweenInclusive(
-      counters, "benchmark.http_2xx", expected_total - margin, expected_total + margin
-  )
+  asserts.assertCounterBetweenInclusive(counters, "benchmark.http_2xx", expected_total - margin,
+                                        expected_total + margin)

--- a/test/integration/test_rate_limiter_plugin.py
+++ b/test/integration/test_rate_limiter_plugin.py
@@ -10,23 +10,23 @@ from test.integration import asserts
 def test_linear_ramping_rate_limiter_plugin(http_test_server_fixture):
   """Test LinearRampingRateLimiter plugin.
 
-  Ramp time: 5.5 seconds
-  Duration: 12 seconds
-  RPS: 100
-  Expected total requests: 925 (margin of 5)
+  Ramp time: 5.4 seconds
+  Duration: 10 seconds
+  RPS: 10
+  Expected total requests: 73 (margin of 3)
   """
   rate_limiter_config = (
       "{name:\"nighthawk.linear-ramping-rate-limiter-plugin\","
       "typed_config:{\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.LinearRampingRateLimiterConfig\","
-      "ramp_time:{seconds:5,nanos:500000000}}}")  # 5.5 seconds
+      "ramp_time:{seconds:5,nanos:400000000}}}")  # 5.4 seconds
 
   parsed_json, _ = http_test_server_fixture.runNighthawkClient([
-      http_test_server_fixture.getTestServerRootUri(), "--duration", "12", "--concurrency", "1",
-      "--rps", "100", "--rate-limiter-plugin-config", rate_limiter_config
+      http_test_server_fixture.getTestServerRootUri(), "--duration", "10", "--concurrency", "1",
+      "--rps", "10", "--rate-limiter-plugin-config", rate_limiter_config
   ])
   counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
 
-  expected_total = 925
-  margin = 5
+  expected_total = 73
+  margin = 3
   asserts.assertCounterBetweenInclusive(counters, "benchmark.http_2xx", expected_total - margin,
                                         expected_total + margin)

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -60,6 +60,8 @@ public:
   MOCK_METHOD(std::string, requestSource, (), (const, override));
   MOCK_METHOD(std::optional<envoy::config::core::v3::TypedExtensionConfig>&,
               requestSourcePluginConfig, (), (const, override));
+  MOCK_METHOD(std::optional<envoy::config::core::v3::TypedExtensionConfig>&,
+              rateLimiterPluginConfig, (), (const, override));
   MOCK_METHOD(std::string, trace, (), (const, override));
   MOCK_METHOD(nighthawk::client::H1ConnectionReuseStrategy::H1ConnectionReuseStrategyOptions,
               h1ConnectionReuseStrategy, (), (const, override));

--- a/test/mocks/common/mock_sequencer_factory.h
+++ b/test/mocks/common/mock_sequencer_factory.h
@@ -13,8 +13,7 @@ public:
               (Envoy::TimeSource & time_source, Envoy::Event::Dispatcher& dispatcher,
                const SequencerTarget& sequencer_target,
                TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope,
-               const Envoy::MonotonicTime scheduled_starting_time,
-               Envoy::Api::Api& api),
+               const Envoy::MonotonicTime scheduled_starting_time, Envoy::Api::Api& api),
               (const, override));
 };
 

--- a/test/mocks/common/mock_sequencer_factory.h
+++ b/test/mocks/common/mock_sequencer_factory.h
@@ -13,7 +13,8 @@ public:
               (Envoy::TimeSource & time_source, Envoy::Event::Dispatcher& dispatcher,
                const SequencerTarget& sequencer_target,
                TerminationPredicatePtr&& termination_predicate, Envoy::Stats::Scope& scope,
-               const Envoy::MonotonicTime scheduled_starting_time),
+               const Envoy::MonotonicTime scheduled_starting_time,
+               Envoy::Api::Api& api),
               (const, override));
 };
 

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -1,14 +1,14 @@
-#include <memory>
 #include "external/envoy/test/test_common/utility.h"
+#include <memory>
 
 #include "fmt/format.h"
 #include "source/client/options_impl.h"
 
+#include "api/rate_limiter/stub_rate_limiter.pb.h"
 #include "test/client/utility.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/proto_matchers.h"
 #include "test/user_defined_output/fake_plugin/fake_user_defined_output.pb.h"
-#include "api/rate_limiter/stub_rate_limiter.pb.h"
 
 #include "gtest/gtest.h"
 
@@ -511,36 +511,34 @@ TEST_F(OptionsImplTest, BadRequestSourcePluginSpecification) {
 TEST_F(OptionsImplTest, RateLimiterPluginConfig_ValidConfig_Success) {
   Envoy::MessageUtil util;
 
-  std::string stub_rate_limiter_json =
-      "{"
-      "name:\"nighthawk.stub-rate-limiter-plugin\","
-      "typed_config:{"
-      "\"@type\":\"type.googleapis.com/"
-      "nighthawk.rate_limiter.StubRateLimiterConfig\","
-      "test_value:\"3\""
-      "}"
-      "}";
+  std::string stub_rate_limiter_json = "{"
+                                       "name:\"nighthawk.stub-rate-limiter-plugin\","
+                                       "typed_config:{"
+                                       "\"@type\":\"type.googleapis.com/"
+                                       "nighthawk.rate_limiter.StubRateLimiterConfig\","
+                                       "test_value:\"3\""
+                                       "}"
+                                       "}";
 
   std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(
-      fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
-                  stub_rate_limiter_json, good_test_uri_));
+      fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_, stub_rate_limiter_json,
+                  good_test_uri_));
 
   // Check that fields in OptionsImpl contain the right values.
   ASSERT_TRUE(options->rateLimiterPluginConfig().has_value());
-  EXPECT_EQ(options->rateLimiterPluginConfig()->name(),
-            "nighthawk.stub-rate-limiter-plugin");
+  EXPECT_EQ(options->rateLimiterPluginConfig()->name(), "nighthawk.stub-rate-limiter-plugin");
 
   nighthawk::rate_limiter::StubRateLimiterConfig stub_config;
-  EXPECT_TRUE(Envoy::MessageUtil::unpackTo(
-                options->rateLimiterPluginConfig()->typed_config(), stub_config)
-                .ok());
+  EXPECT_TRUE(
+      Envoy::MessageUtil::unpackTo(options->rateLimiterPluginConfig()->typed_config(), stub_config)
+          .ok());
   EXPECT_EQ(stub_config.test_value().value(), 3.0);
 
   // Check that generated CommandLineOptions is equivalent to OptionsImpl.
   CommandLineOptionsPtr command = options->toCommandLineOptions();
 
-  EXPECT_TRUE(util(command->rate_limiter_plugin_config(),
-                   options->rateLimiterPluginConfig().value()));
+  EXPECT_TRUE(
+      util(command->rate_limiter_plugin_config(), options->rateLimiterPluginConfig().value()));
 
   // The predicates are defined as proto maps, and these seem to re-serialize into a different
   // order. Hence we trim the maps to contain a single entry so they don't thwart our textual
@@ -553,11 +551,9 @@ TEST_F(OptionsImplTest, RateLimiterPluginConfig_ValidConfig_Success) {
   // Reconstruct OptionsImpl from CommandLineOptions.
   OptionsImpl options_from_proto(*command);
 
-  std::string yaml_for_options_proto =
-      Envoy::MessageUtil::getYamlStringFromMessage(
-          *(options_from_proto.toCommandLineOptions()), true, true);
-  std::string yaml_for_command =
-      Envoy::MessageUtil::getYamlStringFromMessage(*command, true, true);
+  std::string yaml_for_options_proto = Envoy::MessageUtil::getYamlStringFromMessage(
+      *(options_from_proto.toCommandLineOptions()), true, true);
+  std::string yaml_for_command = Envoy::MessageUtil::getYamlStringFromMessage(*command, true, true);
 
   // Check if reconstructed OptionsImpl is equivalent to CommandLineOptions
   // by comparing their YAML representations.
@@ -574,23 +570,20 @@ TEST_F(OptionsImplTest, RateLimiterPluginConfig_BrokenJson_ThrowsException) {
       "\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.StubRateLimiterConfig\","
       "test_value:\"3\""
       "}";
-  EXPECT_THROW_WITH_REGEX(
-      TestUtility::createOptionsImpl(
-          fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
-                      broken_realistic_json, good_test_uri_)),
-                          MalformedArgvException,
-                          "Unable to parse JSON as proto");
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
+                              fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
+                                          broken_realistic_json, good_test_uri_)),
+                          MalformedArgvException, "Unable to parse JSON as proto");
 }
 
 TEST_F(OptionsImplTest, RateLimiterPluginConfig_TypeMismatch_ThrowsException) {
   // Name is valid, but typed_config is a number instead of a JSON object.
   std::string config_with_number_typed_config =
       "{name:\"nighthawk.stub-rate-limiter-plugin\",typed_config:123}";
-  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
-                          "{} --rate-limiter-plugin-config {} {}", client_name_,
-                          config_with_number_typed_config, good_test_uri_)),
-                          MalformedArgvException,
-                          "Unable to parse JSON as proto");
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
+                              fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
+                                          config_with_number_typed_config, good_test_uri_)),
+                          MalformedArgvException, "Unable to parse JSON as proto");
 }
 
 TEST_F(OptionsImplTest, RateLimiterPluginConfig_ExtraField_ThrowsException) {
@@ -604,63 +597,61 @@ TEST_F(OptionsImplTest, RateLimiterPluginConfig_ExtraField_ThrowsException) {
       "},"
       "invalid_field:\"4\""
       "}";
-  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
-                          "{} --rate-limiter-plugin-config {} {}", client_name_,
-                          config_with_extra_field, good_test_uri_)),
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
+                              fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
+                                          config_with_extra_field, good_test_uri_)),
                           MalformedArgvException,
                           "envoy.config.core.v3.TypedExtensionConfig reason INVALID_ARGUMENT");
 }
 
 TEST_F(OptionsImplTest, RateLimiterPluginConfig_ConflictingFlags_ThrowsException) {
-  std::string stub_rate_limiter_json =
-      "{"
-      "name:\"nighthawk.stub-rate-limiter-plugin\","
-      "typed_config:{"
-      "\"@type\":\"type.googleapis.com/"
-      "nighthawk.rate_limiter.StubRateLimiterConfig\","
-      "test_value:\"3\""
-      "}"
-      "}";
-  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
-                        "{} --burst-size 10 --rate-limiter-plugin-config {} {}",
-                        client_name_, stub_rate_limiter_json, good_test_uri_)),
-                        MalformedArgvException, "mutually exclusive");
+  std::string stub_rate_limiter_json = "{"
+                                       "name:\"nighthawk.stub-rate-limiter-plugin\","
+                                       "typed_config:{"
+                                       "\"@type\":\"type.googleapis.com/"
+                                       "nighthawk.rate_limiter.StubRateLimiterConfig\","
+                                       "test_value:\"3\""
+                                       "}"
+                                       "}";
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
+                              fmt::format("{} --burst-size 10 --rate-limiter-plugin-config {} {}",
+                                          client_name_, stub_rate_limiter_json, good_test_uri_)),
+                          MalformedArgvException, "mutually exclusive");
 
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
-                          "{} --jitter-uniform 1s --rate-limiter-plugin-config {} {}",
-                          client_name_, stub_rate_limiter_json, good_test_uri_)),
+                              "{} --jitter-uniform 1s --rate-limiter-plugin-config {} {}",
+                              client_name_, stub_rate_limiter_json, good_test_uri_)),
                           MalformedArgvException, "mutually exclusive");
 }
 
 TEST_F(OptionsImplTest, RateLimiterPluginConfig_ProtoConflictingFields_ThrowsException) {
-  std::string stub_rate_limiter_json =
-      "{"
-      "name:\"nighthawk.stub-rate-limiter-plugin\","
-      "typed_config:{"
-      "\"@type\":\"type.googleapis.com/"
-      "nighthawk.rate_limiter.StubRateLimiterConfig\","
-      "test_value:\"3\""
-      "}"
-      "}";
+  std::string stub_rate_limiter_json = "{"
+                                       "name:\"nighthawk.stub-rate-limiter-plugin\","
+                                       "typed_config:{"
+                                       "\"@type\":\"type.googleapis.com/"
+                                       "nighthawk.rate_limiter.StubRateLimiterConfig\","
+                                       "test_value:\"3\""
+                                       "}"
+                                       "}";
   std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(
-      fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
-                  stub_rate_limiter_json, good_test_uri_));
+      fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_, stub_rate_limiter_json,
+                  good_test_uri_));
 
   // Test with burst_size
   {
     CommandLineOptionsPtr cmd = options->toCommandLineOptions();
     cmd->mutable_burst_size()->set_value(10);
-    EXPECT_THROW_WITH_REGEX((void)std::make_unique<OptionsImpl>(*cmd),
-                            MalformedArgvException, "mutually exclusive");
+    EXPECT_THROW_WITH_REGEX((void)std::make_unique<OptionsImpl>(*cmd), MalformedArgvException,
+                            "mutually exclusive");
   }
 
   // Test with jitter_uniform
   {
     CommandLineOptionsPtr cmd = options->toCommandLineOptions();
     cmd->mutable_jitter_uniform()->set_seconds(1);
-    cmd->mutable_jitter_uniform()->set_nanos(0); 
-    EXPECT_THROW_WITH_REGEX((void)std::make_unique<OptionsImpl>(*cmd),
-                            MalformedArgvException, "mutually exclusive");
+    cmd->mutable_jitter_uniform()->set_nanos(0);
+    EXPECT_THROW_WITH_REGEX((void)std::make_unique<OptionsImpl>(*cmd), MalformedArgvException,
+                            "mutually exclusive");
   }
 }
 

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -1,11 +1,13 @@
 #include "external/envoy/test/test_common/utility.h"
 
+#include "fmt/format.h"
 #include "source/client/options_impl.h"
 
 #include "test/client/utility.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/proto_matchers.h"
 #include "test/user_defined_output/fake_plugin/fake_user_defined_output.pb.h"
+#include "api/rate_limiter/stub_rate_limiter.pb.h"
 
 #include "gtest/gtest.h"
 
@@ -501,6 +503,109 @@ TEST_F(OptionsImplTest, BadRequestSourcePluginSpecification) {
   EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
                               fmt::format("{} --request-source-plugin-config {} {}", client_name_,
                                           "{misspelled_field:{}}", good_test_uri_)),
+                          MalformedArgvException,
+                          "envoy.config.core.v3.TypedExtensionConfig reason INVALID_ARGUMENT");
+}
+
+TEST_F(OptionsImplTest, RateLimiterPluginConfig_ValidConfig_Success) {
+  Envoy::MessageUtil util;
+
+  std::string stub_rate_limiter_json =
+      "{"
+      "name:\"nighthawk.stub-rate-limiter-plugin\","
+      "typed_config:{"
+      "\"@type\":\"type.googleapis.com/"
+      "nighthawk.rate_limiter.StubRateLimiterConfig\","
+      "test_value:\"3\""
+      "}"
+      "}";
+
+  std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(
+      fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
+                  stub_rate_limiter_json, good_test_uri_));
+
+  // Check that fields in OptionsImpl contain the right values.
+  ASSERT_TRUE(options->rateLimiterPluginConfig().has_value());
+  EXPECT_EQ(options->rateLimiterPluginConfig()->name(),
+            "nighthawk.stub-rate-limiter-plugin");
+
+  nighthawk::rate_limiter::StubRateLimiterConfig stub_config;
+  EXPECT_TRUE(Envoy::MessageUtil::unpackTo(
+                options->rateLimiterPluginConfig()->typed_config(), stub_config)
+                .ok());
+  EXPECT_EQ(stub_config.test_value().value(), 3.0);
+
+  // Check that generated CommandLineOptions is equivalent to OptionsImpl.
+  CommandLineOptionsPtr command = options->toCommandLineOptions();
+
+  EXPECT_TRUE(util(command->rate_limiter_plugin_config(),
+                   options->rateLimiterPluginConfig().value()));
+
+  // The predicates are defined as proto maps, and these seem to re-serialize into a different
+  // order. Hence we trim the maps to contain a single entry so they don't thwart our textual
+  // comparison below.
+  EXPECT_EQ(1, command->mutable_failure_predicates()->erase("benchmark.http_4xx"));
+  EXPECT_EQ(1, command->mutable_failure_predicates()->erase("benchmark.http_5xx"));
+  EXPECT_EQ(1, command->mutable_failure_predicates()->erase("benchmark.stream_resets"));
+  EXPECT_EQ(1, command->mutable_failure_predicates()->erase("requestsource.upstream_rq_5xx"));
+
+  // Reconstruct OptionsImpl from CommandLineOptions.
+  OptionsImpl options_from_proto(*command);
+
+  std::string yaml_for_options_proto =
+      Envoy::MessageUtil::getYamlStringFromMessage(
+          *(options_from_proto.toCommandLineOptions()), true, true);
+  std::string yaml_for_command =
+      Envoy::MessageUtil::getYamlStringFromMessage(*command, true, true);
+
+  // Check if reconstructed OptionsImpl is equivalent to CommandLineOptions
+  // by comparing their YAML representations.
+  EXPECT_EQ(yaml_for_options_proto, yaml_for_command);
+  EXPECT_TRUE(util(*(options_from_proto.toCommandLineOptions()), *command));
+}
+
+TEST_F(OptionsImplTest, RateLimiterPluginConfig_BrokenJson_ThrowsException) {
+  // Name and typed_config present, but missing closing }.
+  std::string broken_realistic_json =
+      "{"
+      "name:\"nighthawk.stub-rate-limiter-plugin\","
+      "typed_config:{"
+      "\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.StubRateLimiterConfig\","
+      "test_value:\"3\""
+      "}";
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(
+          fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
+                      broken_realistic_json, good_test_uri_)),
+                          MalformedArgvException,
+                          "Unable to parse JSON as proto");
+}
+
+TEST_F(OptionsImplTest, RateLimiterPluginConfig_TypeMismatch_ThrowsException) {
+  // Name is valid, but typed_config is a number instead of a JSON object.
+  std::string config_with_number_typed_config =
+      "{name:\"nighthawk.stub-rate-limiter-plugin\",typed_config:123}";
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
+                          "{} --rate-limiter-plugin-config {} {}", client_name_,
+                          config_with_number_typed_config, good_test_uri_)),
+                          MalformedArgvException,
+                          "Unable to parse JSON as proto");
+}
+
+TEST_F(OptionsImplTest, RateLimiterPluginConfig_ExtraField_ThrowsException) {
+  // Name and typed_config present, but with an incorrect third field.
+  std::string config_with_extra_field =
+      "{"
+      "name:\"nighthawk.stub-rate-limiter-plugin\","
+      "typed_config:{"
+      "\"@type\":\"type.googleapis.com/nighthawk.rate_limiter.StubRateLimiterConfig\","
+      "test_value:\"3\""
+      "},"
+      "invalid_field:\"4\""
+      "}";
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
+                          "{} --rate-limiter-plugin-config {} {}", client_name_,
+                          config_with_extra_field, good_test_uri_)),
                           MalformedArgvException,
                           "envoy.config.core.v3.TypedExtensionConfig reason INVALID_ARGUMENT");
 }

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include "external/envoy/test/test_common/utility.h"
 
 #include "fmt/format.h"
@@ -608,6 +609,59 @@ TEST_F(OptionsImplTest, RateLimiterPluginConfig_ExtraField_ThrowsException) {
                           config_with_extra_field, good_test_uri_)),
                           MalformedArgvException,
                           "envoy.config.core.v3.TypedExtensionConfig reason INVALID_ARGUMENT");
+}
+
+TEST_F(OptionsImplTest, RateLimiterPluginConfig_ConflictingFlags_ThrowsException) {
+  std::string stub_rate_limiter_json =
+      "{"
+      "name:\"nighthawk.stub-rate-limiter-plugin\","
+      "typed_config:{"
+      "\"@type\":\"type.googleapis.com/"
+      "nighthawk.rate_limiter.StubRateLimiterConfig\","
+      "test_value:\"3\""
+      "}"
+      "}";
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
+                        "{} --burst-size 10 --rate-limiter-plugin-config {} {}",
+                        client_name_, stub_rate_limiter_json, good_test_uri_)),
+                        MalformedArgvException, "mutually exclusive");
+
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
+                          "{} --jitter-uniform 1s --rate-limiter-plugin-config {} {}",
+                          client_name_, stub_rate_limiter_json, good_test_uri_)),
+                          MalformedArgvException, "mutually exclusive");
+}
+
+TEST_F(OptionsImplTest, RateLimiterPluginConfig_ProtoConflictingFields_ThrowsException) {
+  std::string stub_rate_limiter_json =
+      "{"
+      "name:\"nighthawk.stub-rate-limiter-plugin\","
+      "typed_config:{"
+      "\"@type\":\"type.googleapis.com/"
+      "nighthawk.rate_limiter.StubRateLimiterConfig\","
+      "test_value:\"3\""
+      "}"
+      "}";
+  std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(
+      fmt::format("{} --rate-limiter-plugin-config {} {}", client_name_,
+                  stub_rate_limiter_json, good_test_uri_));
+
+  // Test with burst_size
+  {
+    CommandLineOptionsPtr cmd = options->toCommandLineOptions();
+    cmd->mutable_burst_size()->set_value(10);
+    EXPECT_THROW_WITH_REGEX((void)std::make_unique<OptionsImpl>(*cmd),
+                            MalformedArgvException, "mutually exclusive");
+  }
+
+  // Test with jitter_uniform
+  {
+    CommandLineOptionsPtr cmd = options->toCommandLineOptions();
+    cmd->mutable_jitter_uniform()->set_seconds(1);
+    cmd->mutable_jitter_uniform()->set_nanos(0); 
+    EXPECT_THROW_WITH_REGEX((void)std::make_unique<OptionsImpl>(*cmd),
+                            MalformedArgvException, "mutually exclusive");
+  }
 }
 
 // We test --no-duration here and not in All above because it is exclusive to --duration.

--- a/test/rate_limiter_plugin_test.cc
+++ b/test/rate_limiter_plugin_test.cc
@@ -1,20 +1,20 @@
-#include <chrono>
-#include <string>
+#include "external/envoy/source/common/config/utility.h"
+#include "nighthawk/common/exception.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "nighthawk/common/exception.h"
-#include "external/envoy/source/common/config/utility.h"
+#include <chrono>
+#include <string>
 
 #include "envoy/api/api.h"
 #include "external/envoy/source/common/protobuf/protobuf.h"
 #include "external/envoy/test/mocks/stats/mocks.h"
 #include "external/envoy/test/test_common/simulated_time_system.h"
-#include "test/mocks/client/mock_options.h"
 #include "external/envoy/test/test_common/utility.h"
+#include "test/mocks/client/mock_options.h"
 
+#include "api/rate_limiter/linear_ramping_rate_limiter.pb.h"
 #include "nighthawk/common/rate_limiter.h"
 #include "nighthawk/common/rate_limiter_plugin_config_factory.h"
-#include "api/rate_limiter/linear_ramping_rate_limiter.pb.h"
 #include "source/common/rate_limiter_impl.h"
 
 #include "test/test_common/proto_matchers.h"

--- a/test/rate_limiter_plugin_test.cc
+++ b/test/rate_limiter_plugin_test.cc
@@ -1,0 +1,134 @@
+#include <chrono>
+#include <string>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "nighthawk/common/exception.h"
+#include "external/envoy/source/common/config/utility.h"
+
+#include "envoy/api/api.h"
+#include "external/envoy/source/common/protobuf/protobuf.h"
+#include "external/envoy/test/mocks/stats/mocks.h"
+#include "external/envoy/test/test_common/simulated_time_system.h"
+#include "test/mocks/client/mock_options.h"
+#include "external/envoy/test/test_common/utility.h"
+
+#include "nighthawk/common/rate_limiter.h"
+#include "nighthawk/common/rate_limiter_plugin_config_factory.h"
+#include "api/rate_limiter/linear_ramping_rate_limiter.pb.h"
+#include "source/common/rate_limiter_impl.h"
+
+#include "test/test_common/proto_matchers.h"
+
+namespace Nighthawk {
+namespace Client {
+
+class LinearRampingRateLimiterPluginTest : public testing::Test {
+public:
+  LinearRampingRateLimiterPluginTest() : api_(Envoy::Api::createApiForTest(stats_store_)) {}
+  Envoy::Stats::MockIsolatedStatsStore stats_store_;
+  Envoy::Api::ApiPtr api_;
+  Envoy::Event::SimulatedTimeSystem time_system_;
+  testing::NiceMock<MockOptions> options_;
+  const std::string plugin_name_ = "nighthawk.linear-ramping-rate-limiter-plugin";
+};
+
+TEST_F(LinearRampingRateLimiterPluginTest, CreateEmptyConfigProtoCreatesCorrectType) {
+  auto& config_factory =
+      Envoy::Config::Utility::getAndCheckFactoryByName<RateLimiterPluginConfigFactory>(
+          plugin_name_);
+  const Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
+  const nighthawk::rate_limiter::LinearRampingRateLimiterConfig expected_config;
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
+}
+
+TEST_F(LinearRampingRateLimiterPluginTest, FactoryRegistrationUsesCorrectPluginName) {
+  auto& config_factory =
+      Envoy::Config::Utility::getAndCheckFactoryByName<RateLimiterPluginConfigFactory>(
+          plugin_name_);
+  EXPECT_EQ(config_factory.name(), plugin_name_);
+}
+
+TEST_F(LinearRampingRateLimiterPluginTest, ValidConfigInitializesWorkingRateLimiter) {
+  const unsigned int requests_per_second = 100;
+  const unsigned int ramp_time = 5;
+  const unsigned int duration = 5;
+
+  // Verify factory is initialized correctly from plugin name.
+  auto& config_factory =
+      Envoy::Config::Utility::getAndCheckFactoryByName<RateLimiterPluginConfigFactory>(
+          plugin_name_);
+
+  EXPECT_EQ(config_factory.name(), plugin_name_);
+
+  const Envoy::ProtobufTypes::MessagePtr empty_config = config_factory.createEmptyConfigProto();
+  const nighthawk::rate_limiter::LinearRampingRateLimiterConfig expected_config;
+  EXPECT_THAT(*empty_config, EqualsProto(expected_config));
+
+  // Verify rate limiter is initialized correctly from config proto.
+  nighthawk::rate_limiter::LinearRampingRateLimiterConfig config;
+  config.mutable_ramp_time()->set_seconds(ramp_time);
+  Envoy::Protobuf::Any config_any;
+  std::ignore = config_any.PackFrom(config);
+
+  EXPECT_CALL(options_, requestsPerSecond()).WillOnce(testing::Return(requests_per_second));
+  EXPECT_CALL(options_, noDuration()).WillOnce(testing::Return(false));
+  EXPECT_CALL(options_, duration()).WillOnce(testing::Return(std::chrono::seconds(duration)));
+
+  RateLimiterPtr plugin =
+      config_factory.createRateLimiterPlugin(config_any, *api_, time_system_, options_);
+
+  ASSERT_NE(plugin, nullptr);
+  EXPECT_NE(dynamic_cast<LinearRampingRateLimiterImpl*>(plugin.get()), nullptr);
+}
+
+TEST_F(LinearRampingRateLimiterPluginTest, RampTimeExceedingDurationThrowsException) {
+  LinearRampingRateLimiterImplFactory config_factory;
+
+  nighthawk::rate_limiter::LinearRampingRateLimiterConfig config;
+  config.mutable_ramp_time()->set_seconds(15);
+  Envoy::Protobuf::Any config_any;
+  std::ignore = config_any.PackFrom(config);
+
+  EXPECT_CALL(options_, requestsPerSecond()).WillOnce(testing::Return(100));
+  EXPECT_CALL(options_, noDuration()).WillOnce(testing::Return(false));
+  EXPECT_CALL(options_, duration()).WillOnce(testing::Return(std::chrono::seconds(10)));
+
+  EXPECT_THROW_WITH_REGEX(
+      config_factory.createRateLimiterPlugin(config_any, *api_, time_system_, options_),
+      NighthawkException, "ramp_time must be less than or equal to time specified by --duration");
+}
+
+TEST_F(LinearRampingRateLimiterPluginTest, NoDurationInitializesCorrectly) {
+  LinearRampingRateLimiterImplFactory config_factory;
+
+  nighthawk::rate_limiter::LinearRampingRateLimiterConfig config;
+  config.mutable_ramp_time()->set_seconds(100);
+  Envoy::Protobuf::Any config_any;
+  std::ignore = config_any.PackFrom(config);
+
+  EXPECT_CALL(options_, requestsPerSecond()).WillOnce(testing::Return(100));
+  EXPECT_CALL(options_, noDuration()).WillOnce(testing::Return(true));
+
+  RateLimiterPtr plugin =
+      config_factory.createRateLimiterPlugin(config_any, *api_, time_system_, options_);
+  ASSERT_NE(plugin, nullptr);
+}
+
+TEST_F(LinearRampingRateLimiterPluginTest, ZeroRampTimeThrowsException) {
+  LinearRampingRateLimiterImplFactory config_factory;
+
+  nighthawk::rate_limiter::LinearRampingRateLimiterConfig config;
+  config.mutable_ramp_time()->set_seconds(0);
+  config.mutable_ramp_time()->set_nanos(0);
+  Envoy::Protobuf::Any config_any;
+  std::ignore = config_any.PackFrom(config);
+
+  EXPECT_CALL(options_, requestsPerSecond()).WillOnce(testing::Return(100));
+
+  EXPECT_THROW_WITH_REGEX(
+      config_factory.createRateLimiterPlugin(config_any, *api_, time_system_, options_),
+      NighthawkException, "ramp_time must be positive");
+}
+
+} // namespace Client
+} // namespace Nighthawk

--- a/test/rate_limiter_test.cc
+++ b/test/rate_limiter_test.cc
@@ -412,10 +412,10 @@ TEST_F(LinearRampingRateLimiterImplTest, ExtendedDurationGivesCorrectTotalReques
   const unsigned int duration_sec = 12;
   const Frequency frequency = 100_Hz;
 
-  LinearRampingRateLimiterImpl rate_limiter(
-      time_system, std::chrono::seconds(ramp_time_sec), frequency);
+  LinearRampingRateLimiterImpl rate_limiter(time_system, std::chrono::seconds(ramp_time_sec),
+                                            frequency);
 
-  EXPECT_FALSE(rate_limiter.tryAcquireOne());  // Sets up rate limiter
+  EXPECT_FALSE(rate_limiter.tryAcquireOne()); // Sets up rate limiter
 
   unsigned int count = 0;
   const auto clock_tick = 10us; // small step

--- a/test/rate_limiter_test.cc
+++ b/test/rate_limiter_test.cc
@@ -406,6 +406,33 @@ TEST_F(LinearRampingRateLimiterImplTest, TimingVerificationTest) {
   checkAcquisitionTimings(40000_Hz, 7s);
 }
 
+TEST_F(LinearRampingRateLimiterImplTest, ExtendedDurationGivesCorrectTotalRequests) {
+  Envoy::Event::SimulatedTimeSystem time_system;
+  const unsigned int ramp_time_sec = 5;
+  const unsigned int duration_sec = 12;
+  const Frequency frequency = 100_Hz;
+
+  LinearRampingRateLimiterImpl rate_limiter(
+      time_system, std::chrono::seconds(ramp_time_sec), frequency);
+
+  EXPECT_FALSE(rate_limiter.tryAcquireOne());  // Sets up rate limiter
+
+  unsigned int count = 0;
+  const auto clock_tick = 10us; // small step
+  auto total_elapsed = 0us;
+
+  do {
+    if (rate_limiter.tryAcquireOne()) {
+      count++;
+    }
+    time_system.advanceTimeWait(clock_tick);
+    total_elapsed += clock_tick;
+  } while (total_elapsed <= std::chrono::seconds(duration_sec));
+
+  EXPECT_EQ(count, (frequency.value() * ramp_time_sec / 2) +
+                       (frequency.value() * (duration_sec - ramp_time_sec)));
+}
+
 TEST_F(RateLimiterTest, GraduallyOpeningRateLimiterFilterInvalidArgumentTest) {
   // Negative ramp throws.
   EXPECT_THROW(GraduallyOpeningRateLimiterFilter gorl(


### PR DESCRIPTION
Introduces a new command line flag --rate-limiter-plugin-config. Enables rate limiters to be detected and loaded as a plugin depending on the Json configuration passed into --rate-limiter-plugin-config. Exposes LinearRampingRateLimiterImpl as a plugin.