### PR TITLE
Updating Envoy version to 4d6c488 (Aug 3, 2026)

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -35,6 +35,7 @@ checks:
     on-run:
     - check-build
     - check-build-openssl
+    - check-build-openssl-presubmit
     - check-coverage
     - check-runtime
     - check-san
@@ -181,6 +182,20 @@ run:
   check-build-openssl:
     paths:
     - "**/*"
+  check-build-openssl-presubmit:
+    paths:
+    - compat/openssl/**/*
+    - source/common/tls/**/*
+    - source/common/crypto/**/*
+    - source/extensions/transport_sockets/tls/**/*
+    - test/common/tls/**/*
+    - test/common/crypto/**/*
+    - test/extensions/transport_sockets/tls/**/*
+    - envoy/ssl/**/*
+    - envoy/extensions/transport_sockets/tls/**/*
+    - bazel/**/*
+    - .bazelrc
+    - ci/do_ci.sh
   check-coverage:
     paths:
     - "**/*"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ENVOY_COMMIT = "e4532b6349e89f5aa381b6fd3f4e917388bf6bd0"
-ENVOY_SHA = "16fcae940c519571ffecdeb1645a0aa5ebb641b218bddb9b4f1f98b1eea5b2fd"
+ENVOY_COMMIT = "4d6c488f2889cb7d8a72ab1631d4cf087f356fc8"
+ENVOY_SHA = "954a823603f8422a2b6e22e13a75f1a5dff98bd58a89ecaf6299c7ed9accbe15"
 
 HDR_HISTOGRAM_C_VERSION = "0.11.8"  # June 18th, 2025
 HDR_HISTOGRAM_C_SHA = "bb95351a6a8b242dc9be1f28562761a84d4cf0a874ffc90a9b630770a6468e94"


### PR DESCRIPTION
- Update the ENVOY_COMMIT and ENVOY_SHA in bazel/repositories.bzl to the latest Envoy's commit.
- Update .github/config.yml to https://github.com/envoyproxy/envoy/pull/46422