### PR TITLE
add envoy_package to all BUILD files not having a package declaration

### DIFF
--- a/api/adaptive_load/BUILD
+++ b/api/adaptive_load/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 api_cc_py_proto_library(
     name = "adaptive_load_proto",

--- a/api/client/BUILD
+++ b/api/client/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 api_cc_py_proto_library(
     name = "base",

--- a/api/configuration/BUILD
+++ b/api/configuration/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 api_cc_py_proto_library(
     name = "cluster_config_manager",

--- a/api/distributor/BUILD
+++ b/api/distributor/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 api_cc_py_proto_library(
     name = "distributor",

--- a/api/request_source/BUILD
+++ b/api/request_source/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 api_cc_py_proto_library(
     name = "service",

--- a/api/sink/BUILD
+++ b/api/sink/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 api_cc_py_proto_library(
     name = "sink",

--- a/api/user_defined_output/BUILD
+++ b/api/user_defined_output/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 api_cc_py_proto_library(
     name = "log_response_headers_proto",

--- a/benchmarks/BUILD
+++ b/benchmarks/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 py_binary(
     name = "benchmarks",

--- a/dynamic_config/BUILD
+++ b/dynamic_config/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@nh_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 py_library(
     name = "dynamic_config_manager_lib",

--- a/internal_proto/statistic/BUILD
+++ b/internal_proto/statistic/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 api_cc_py_proto_library(
     name = "statistic",

--- a/test/dynamic_config/BUILD
+++ b/test/dynamic_config/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@nh_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 py_test(
     name = "dynamic_config_manager_test",

--- a/test/integration/unit_tests/BUILD
+++ b/test/integration/unit_tests/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@nh_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 py_test(
     name = "test_nighthawk_test_server",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@nh_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 licenses(["notice"])  # Apache 2
+
+envoy_package()
 
 exports_files([
     "check_envoy_includes.py",


### PR DESCRIPTION
This is to get past automated checks that scan for a `package` declaration when Nighthawk is imported into Google.