### PR TITLE
client: log the tunneling startup exception instead of printing it to stdout

### DIFF
--- a/docs/root/version_history.md
+++ b/docs/root/version_history.md
@@ -14,6 +14,7 @@ Version history
 
 ### Changelist
 
+- The Envoy exception on the tunneling startup path is logged instead of printed to stdout, keeping stdout reserved for the formatted output.
 - Introducing termination predicates (https://github.com/envoyproxy/nighthawk/pull/167) and https://github.com/envoyproxy/nighthawk/pull/176
 
 0.2 (July 16, 2019)

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -948,8 +948,7 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const UriPtr& tracing_
                 });
         encap_main_common->run();
       } catch (const Envoy::EnvoyException& ex) {
-        std::cout << "error caught by envoy " << ex.what() << std::endl;
-        ENVOY_LOG(error, ex.what());
+        ENVOY_LOG(error, "error caught by envoy: {}", ex.what());
         // let nighthawk start and close envoy process
         sem_post(&nighthawk_control_sem);
       }


### PR DESCRIPTION
**Description**

This PR is related to #1605

When the encapsulating Envoy fails to start on the tunneling path, the exception was written to `std::cout` in addition to the logger. stdout is where `nighthawk_client` writes its formatted result, so consumers that parse it (for example `--output-format json`) could see a stray line in that error case. This logs it only.

**Notes for Reviewers**

One-line logging change on an error path; builds. Version history updated. Signed off per the DCO.