### PR TITLE
client: always emit request_body_size in toCommandLineOptions()

### DIFF
--- a/docs/root/version_history.md
+++ b/docs/root/version_history.md
@@ -14,6 +14,7 @@ Version history
 
 ### Changelist
 
+- `OptionsImpl::toCommandLineOptions()` now always emits `request_options.request_body_size`; it was only set when at least one `--request-header` was configured, so the size was lost on the gRPC service path otherwise.
 - Introducing termination predicates (https://github.com/envoyproxy/nighthawk/pull/167) and https://github.com/envoyproxy/nighthawk/pull/176
 
 0.2 (July 16, 2019)

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -1137,8 +1137,8 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
       } else {
         throw MalformedArgvException("A ':' is required in a header.");
       }
-      request_options->mutable_request_body_size()->set_value(requestBodySize());
     }
+    request_options->mutable_request_body_size()->set_value(requestBodySize());
   }
 
   if (rate_limiter_plugin_config_.has_value()) {

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -382,6 +382,16 @@ TEST_F(OptionsImplTest, AlmostAll) {
 
 // We test RequestSource here and not in All above because it is exclusive to some of the other
 // options.
+TEST_F(OptionsImplTest, RequestBodySizeIsEmittedWithoutRequestHeaders) {
+  std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(
+      fmt::format("{} --request-body-size 1234 {}", client_name_, good_test_uri_));
+  CommandLineOptionsPtr cmd = options->toCommandLineOptions();
+  EXPECT_EQ(0, cmd->request_options().request_headers_size());
+  EXPECT_EQ(1234, cmd->request_options().request_body_size().value());
+  OptionsImpl round_trip(*cmd);
+  EXPECT_EQ(1234, round_trip.requestBodySize());
+}
+
 TEST_F(OptionsImplTest, RequestSource) {
   Envoy::MessageUtil util;
   const std::string request_source = "127.9.9.4:32323";


### PR DESCRIPTION
**Description**

This PR is related to #1606

`request_options.request_body_size` was only set inside the loop over the configured request headers, so `--request-body-size` without any `--request-header` was dropped from the `CommandLineOptions` proto, and therefore from executions routed through the gRPC service (`--nighthawk-service`). This hoists it out of the loop.

**Notes for Reviewers**

New test `OptionsImplTest.RequestBodySizeIsEmittedWithoutRequestHeaders` covers the proto round trip; `//test:options_test` passes. Version history updated.