### PR TITLE
stats: add UDP statsd / DogStatsD stats sinks and --stats-sink-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ bazel-bin/nighthawk_client  [--user-defined-plugin-config <string>] ...
 [--simple-warmup]
 [--rate-limiter-plugin-config <string>]
 [--request-source-plugin-config <string>]
-[--request-source <uri format>] [--label
+[--request-source <uri format>]
+[--stats-sink-tag <string>] ... [--label
 <string>] ... [--multi-target-use-https]
 [--multi-target-path <string>]
 [--multi-target-endpoint <string>] ...
@@ -275,6 +276,11 @@ Remote gRPC source that will deliver to-be-replayed traffic. Each
 worker will separately connect to this source. For example
 grpc://127.0.0.1:8443/. Mutually exclusive with
 --request_source_plugin_config.
+
+--stats-sink-tag <string>  (accepted multiple times)
+Tag in 'key:value' form added to every metric pushed to a tag-capable
+stats sink (envoy.stat_sinks.dog_statsd), e.g. run:phase-c. May be
+specified multiple times. Ignored by sinks that cannot carry tags.
 
 --label <string>  (accepted multiple times)
 Label. Allows specifying multiple labels which will be persisted in

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -182,6 +182,11 @@ message CommandLineOptions {
 
   TunnelOptions tunnel_options = 114;
 
+  // Tags added to every metric pushed to a tag-capable stats sink (currently
+  // envoy.stat_sinks.dog_statsd), as "key:value" strings, e.g. "run:phase-c" or "pod:driver-1".
+  // Ignored by sinks that cannot carry tags.
+  repeated string stats_sink_tags = 123;
+
   // Allows user to set specific HTTP3 protocol options.
   // Only valid when protocol is set to HTTP3.
   // Is exclusive with any other command line option that would modify the

--- a/docs/root/statistics.md
+++ b/docs/root/statistics.md
@@ -63,7 +63,32 @@ backend-specific wire format. Currently Envoy supports the TCP and UDP
 [statsd](https://github.com/b/statsd_spec) protocol (implemented in
 [statsd.h](https://github.com/envoyproxy/envoy/blob/main/source/extensions/stat_sinks/common/statsd/statsd.h)).
 Users can create their own Sink subclass to translate Envoy metrics into
-backend-specific format.	
+backend-specific format.
+
+Nighthawk ships a UDP statsd sink, registered under the same names as Envoy's
+sinks so the `--stats-sinks` examples work as documented:
+`envoy.stat_sinks.statsd` (config `envoy.config.metrics.v3.StatsdSink`, UDP
+`address` only; an IP literal or a host name resolved at startup) and `envoy.stat_sinks.dog_statsd`
+(`envoy.config.metrics.v3.DogStatsdSink`, adds DogStatsD tags and optional
+datagram batching via `max_bytes_per_datagram`). Metric names are prefixed with
+`nighthawk` unless `prefix` is set. Counters are flushed as deltas (`|c`) every
+`--stats-flush-interval`, gauges as values (`|g`), and every latency sample of
+the sinkable Nighthawk statistics (`benchmark_http_client.latency_*`,
+`benchmark_http_client.latency_grpc_ok`, `benchmark_stream.message_latency`) is
+sent as a timing in milliseconds with microsecond precision (`|ms`). One UDP
+socket is shared by the whole process. With `max_bytes_per_datagram` set
+(DogStatsD sink), messages are packed newline-separated into datagrams of up to
+that size: counters and gauges per flush, latency samples per recording thread,
+which are sent when the batch fills, on the next flush, and when the sink is
+destroyed at the end of the run. `--stats-sink-tag key:value` adds tags to
+every message of the DogStatsD sink, e.g. to identify the run or pod. Per-worker metrics (the store's `cluster.<n>.` / `worker.<n>.` scopes and
+the per-worker latency statistics) are named `worker.<n>.<rest>` with the plain
+statsd sink; the DogStatsD sink drops the prefix and emits a `worker:<n>` tag
+instead. Example:
+
+```bash
+nighthawk_client --stats-sinks '{name:"envoy.stat_sinks.dog_statsd",typed_config:{"@type":"type.googleapis.com/envoy.config.metrics.v3.DogStatsdSink",address:{socket_address:{address:"127.0.0.1",port_value:8125}},max_bytes_per_datagram:1400}}' --stats-flush-interval 1 http://localhost:8080/
+```	
 
 Envoy metrics can be defined using a macro, e.g.	
 ```cc

--- a/docs/root/version_history.md
+++ b/docs/root/version_history.md
@@ -14,6 +14,7 @@ Version history
 
 ### Changelist
 
+- `--stats-sinks` now works: Nighthawk registers UDP statsd sinks under `envoy.stat_sinks.statsd` and `envoy.stat_sinks.dog_statsd` (previously no sink implementation was linked and any `--stats-sinks` value aborted at startup). Counters are flushed as deltas, latency samples as millisecond timings, optionally batched and tagged (`--stats-sink-tag`); see [statistics](statistics.md). `NighthawkStatsSinkFactory::createStatsSink` now receives the sink's typed config, a thread-local slot allocator and the configured tags.
 - Introducing termination predicates (https://github.com/envoyproxy/nighthawk/pull/167) and https://github.com/envoyproxy/nighthawk/pull/176
 
 0.2 (July 16, 2019)

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -97,6 +97,10 @@ public:
   virtual std::string multiTargetPath() const PURE;
   virtual bool multiTargetUseHttps() const PURE;
   virtual std::vector<std::string> labels() const PURE;
+  /**
+   * @return std::vector<std::string> "key:value" tags for tag-capable stats sinks.
+   */
+  virtual std::vector<std::string> statsSinkTags() const PURE;
   virtual bool simpleWarmup() const PURE;
   virtual bool noDuration() const PURE;
   virtual std::vector<envoy::config::metrics::v3::StatsSink> statsSinks() const PURE;

--- a/include/nighthawk/common/factories.h
+++ b/include/nighthawk/common/factories.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "envoy/api/api.h"
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "nighthawk/common/platform_util.h"
@@ -63,11 +65,21 @@ public:
    * implementation is unable to produce a Sink with the provided parameters, it
    * should throw an EnvoyException. The returned pointer should always be
    * valid.
+   * @param config the sink's typed_config, already translated to the message type returned by
+   * createEmptyConfigProto() and validated.
    * @param symbol_table supplies the symbol_table instance. For the definition
    * of SymbolTable, see envoy/include/envoy/stats/symbol_table.h.
+   * @param tls thread local slot allocator, for sinks that keep per-thread state such as a
+   * socket. Sinks are created on the main thread before the flush worker starts, and may be
+   * invoked from the flush worker thread (flush) and from the client worker threads
+   * (onHistogramComplete).
+   * @param tags "key:value" tags the user asked to attach to every metric; sinks that cannot
+   * carry tags ignore them.
    */
   virtual std::unique_ptr<Envoy::Stats::Sink>
-  createStatsSink(Envoy::Stats::SymbolTable& symbol_table) PURE;
+  createStatsSink(const Envoy::Protobuf::Message& config, Envoy::Stats::SymbolTable& symbol_table,
+                  Envoy::ThreadLocal::SlotAllocator& tls,
+                  const std::vector<std::string>& tags) PURE;
 
   std::string category() const override { return "nighthawk.stats_sinks"; }
 };

--- a/source/client/BUILD
+++ b/source/client/BUILD
@@ -103,6 +103,7 @@ envoy_cc_library(
         "//source/common:nighthawk_common_lib",
         "//source/common:nighthawk_service_client_impl",
         "//source/common:request_source_impl_lib",
+        "//source/common:statsd_sink_lib",
         "//source/request_source:llm_request_source_plugin_cc_proto",
         "//source/request_source:llm_request_source_plugin_impl",
         "//source/request_source:request_options_list_plugin_impl",

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -335,6 +335,12 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
                                       "Label. Allows specifying multiple labels which will be "
                                       "persisted in structured output formats.",
                                       false, "string", cmd);
+  TCLAP::MultiArg<std::string> stats_sink_tags(
+      "", "stats-sink-tag",
+      "Tag in 'key:value' form added to every metric pushed to a tag-capable stats sink "
+      "(envoy.stat_sinks.dog_statsd), e.g. run:phase-c. May be specified multiple times. Ignored "
+      "by sinks that cannot carry tags.",
+      false, "string", cmd);
 
   TCLAP::UnlabeledValueArg<std::string> uri(
       "uri",
@@ -596,6 +602,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
     }
   }
   TCLAP_SET_IF_SPECIFIED(labels, labels_);
+  TCLAP_SET_IF_SPECIFIED(stats_sink_tags, stats_sink_tags_);
   TCLAP_SET_IF_SPECIFIED(simple_warmup, simple_warmup_);
   TCLAP_SET_IF_SPECIFIED(no_duration, no_duration_);
   if (stats_sinks.isSet()) {
@@ -979,6 +986,8 @@ OptionsImpl::OptionsImpl(const nighthawk::client::CommandLineOptions& options) {
     no_duration_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(options, no_duration, no_duration_);
   }
   std::copy(options.labels().begin(), options.labels().end(), std::back_inserter(labels_));
+  std::copy(options.stats_sink_tags().begin(), options.stats_sink_tags().end(),
+            std::back_inserter(stats_sink_tags_));
   latency_response_header_name_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
       options, latency_response_header_name, latency_response_header_name_);
   if (options.has_scheduled_start()) {
@@ -1013,6 +1022,13 @@ void OptionsImpl::setNonTrivialDefaults() {
 }
 
 void OptionsImpl::validate() const {
+  for (const std::string& tag : stats_sink_tags_) {
+    const size_t colon = tag.find(':');
+    if (colon == 0 || colon == std::string::npos || colon == tag.size() - 1) {
+      throw MalformedArgvException(
+          fmt::format("--stats-sink-tag '{}' must be in key:value form", tag));
+    }
+  }
   if (h2_use_multiple_connections_) {
     throw MalformedArgvException(
         "The experimental_h2_use_multiple_connections option is deprecated, set "
@@ -1185,6 +1201,9 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
   command_line_options->mutable_nighthawk_service()->set_value(nighthawk_service_);
   for (const auto& label : labels_) {
     *command_line_options->add_labels() = label;
+  }
+  for (const auto& tag : stats_sink_tags_) {
+    command_line_options->add_stats_sink_tags(tag);
   }
   command_line_options->mutable_simple_warmup()->set_value(simple_warmup_);
   if (no_duration_) {

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -107,6 +107,7 @@ public:
   std::chrono::nanoseconds jitterUniform() const override { return jitter_uniform_; }
   std::string nighthawkService() const override { return nighthawk_service_; }
   std::vector<std::string> labels() const override { return labels_; };
+  std::vector<std::string> statsSinkTags() const override { return stats_sink_tags_; }
 
   std::vector<nighthawk::client::MultiTarget::Endpoint> multiTargetEndpoints() const override {
     return multi_target_endpoints_;
@@ -199,6 +200,7 @@ private:
   std::string multi_target_path_;
   bool multi_target_use_https_{false};
   std::vector<std::string> labels_;
+  std::vector<std::string> stats_sink_tags_;
   bool simple_warmup_{false};
   bool no_duration_{false};
   std::vector<envoy::config::metrics::v3::StatsSink> stats_sinks_;

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -877,7 +877,10 @@ void ProcessImpl::setupStatsSinks(const envoy::config::bootstrap::v3::Bootstrap&
     ENVOY_LOG(info, "loading stats sink configuration in Nighthawk");
     auto& factory =
         Envoy::Config::Utility::getAndCheckFactory<NighthawkStatsSinkFactory>(stats_sink);
-    stats_sinks.emplace_back(factory.createStatsSink(store_root_.symbolTable()));
+    Envoy::ProtobufTypes::MessagePtr message = Envoy::Config::Utility::translateToFactoryConfig(
+        stats_sink, Envoy::ProtobufMessage::getStrictValidationVisitor(), factory);
+    stats_sinks.emplace_back(factory.createStatsSink(*message, store_root_.symbolTable(), tls_,
+                                                     options_.statsSinkTags()));
   }
   for (std::unique_ptr<Envoy::Stats::Sink>& sink : stats_sinks) {
     store_root_.addSink(*sink);

--- a/source/common/BUILD
+++ b/source/common/BUILD
@@ -111,6 +111,30 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "statsd_sink_lib",
+    srcs = ["statsd_sink.cc"],
+    hdrs = ["statsd_sink.h"],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":nighthawk_common_lib",
+        "//include/nighthawk/common:base_includes",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@envoy//envoy/network:socket_interface_interface",
+        "@envoy//envoy/registry",
+        "@envoy//source/common/buffer:buffer_lib_with_external_headers",
+        "@envoy//source/common/common:assert_lib_with_external_headers",
+        "@envoy//source/common/network:address_lib_with_external_headers",
+        "@envoy//source/common/network:resolver_lib_with_external_headers",
+        "@envoy//source/common/network:socket_interface_lib_with_external_headers",
+        "@envoy//source/common/network:utility_lib_with_external_headers",
+        "@envoy//source/common/protobuf:utility_lib_with_external_headers",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "nighthawk_common_lib",
     srcs = [
         "phase_impl.cc",

--- a/source/common/statsd_sink.cc
+++ b/source/common/statsd_sink.cc
@@ -1,0 +1,346 @@
+#include "source/common/statsd_sink.h"
+
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <algorithm>
+#include <cstdio>
+
+#include "envoy/network/socket_interface.h"
+#include "envoy/registry/registry.h"
+
+#include "external/envoy/source/common/buffer/buffer_impl.h"
+#include "external/envoy/source/common/common/assert.h"
+#include "external/envoy/source/common/network/address_impl.h"
+#include "external/envoy/source/common/network/resolver_impl.h"
+#include "external/envoy/source/common/network/utility.h"
+#include "external/envoy/source/common/protobuf/utility.h"
+
+#include "source/common/statistic_impl.h"
+
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
+
+namespace Nighthawk {
+
+namespace {
+constexpr absl::string_view kDefaultPrefix = "nighthawk";
+
+std::string formatDouble(double value) {
+  char buffer[64];
+  const int n = std::snprintf(buffer, sizeof(buffer), "%.3f", value);
+  RELEASE_ASSERT(n > 0 && n < static_cast<int>(sizeof(buffer)), "formatting failed");
+  return std::string(buffer, n);
+}
+} // namespace
+
+StatsdSink::StatsdSink(Envoy::Network::Address::InstanceConstSharedPtr address,
+                       absl::string_view prefix, bool use_tags,
+                       std::optional<uint64_t> max_bytes_per_datagram,
+                       const std::vector<std::string>& extra_tags)
+    : address_(std::move(address)), io_handle_(Envoy::Network::ioHandleForAddr(
+                                        Envoy::Network::Socket::Type::Datagram, address_, {})),
+      prefix_(prefix.empty() ? std::string(kDefaultPrefix) : std::string(prefix)),
+      use_tags_(use_tags), max_bytes_per_datagram_(max_bytes_per_datagram),
+      extra_tags_(use_tags && !extra_tags.empty()
+                      ? absl::StrCat(",", absl::StrJoin(extra_tags, ","))
+                      : "") {
+  RELEASE_ASSERT(address_ != nullptr, "statsd sink needs an address");
+  if (!use_tags && !extra_tags.empty()) {
+    ENVOY_LOG(warn, "stats sink tags are ignored by the plain statsd sink; use dog_statsd");
+  }
+}
+
+StatsdSink::~StatsdSink() { flushAllSamples(); }
+
+std::pair<std::string, std::optional<int>> StatsdSink::splitWorkerPrefix(absl::string_view name) {
+  // Nighthawk scopes per-worker stats as "cluster.<n>.<rest>" and "worker.<n>.<rest>".
+  std::vector<absl::string_view> parts = absl::StrSplit(name, absl::MaxSplits('.', 2));
+  if (parts.size() == 3 && (parts[0] == "cluster" || parts[0] == "worker")) {
+    int worker_id;
+    if (absl::SimpleAtoi(parts[1], &worker_id)) {
+      return {std::string(parts[2]), worker_id};
+    }
+  }
+  return {std::string(name), std::nullopt};
+}
+
+std::string StatsdSink::buildMessage(absl::string_view store_name, absl::string_view value,
+                                     absl::string_view type, std::optional<int> worker_id) const {
+  std::string name(store_name);
+  if (!worker_id.has_value()) {
+    std::tie(name, worker_id) = splitWorkerPrefix(store_name);
+  }
+  if (!use_tags_ && worker_id.has_value()) {
+    name = absl::StrCat("worker.", worker_id.value(), ".", name);
+  }
+  std::string message = absl::StrCat(prefix_, ".", name, ":", value, "|", type);
+  if (use_tags_) {
+    if (worker_id.has_value()) {
+      absl::StrAppend(&message, "|#worker:", worker_id.value(), extra_tags_);
+    } else if (!extra_tags_.empty()) {
+      absl::StrAppend(&message, "|#", absl::string_view(extra_tags_).substr(1));
+    }
+  }
+  return message;
+}
+
+std::string StatsdSink::formatNanosAsMillis(uint64_t nanos) {
+  return formatDouble(static_cast<double>(nanos) / 1e6);
+}
+
+void StatsdSink::send(absl::string_view message) {
+  Envoy::Buffer::RawSlice slice{const_cast<char*>(message.data()), message.size()};
+  absl::MutexLock lock(&socket_mutex_);
+  Envoy::Network::Utility::writeToSocket(*io_handle_, &slice, 1, nullptr, *address_);
+}
+
+void StatsdSink::enqueueSample(std::string message) {
+  if (!max_bytes_per_datagram_.has_value()) {
+    send(message);
+    return;
+  }
+  std::shared_ptr<SampleBatch> batch;
+  {
+    absl::MutexLock lock(&batches_mutex_);
+    std::shared_ptr<SampleBatch>& slot = batches_[std::this_thread::get_id()];
+    if (slot == nullptr) {
+      slot = std::make_shared<SampleBatch>();
+    }
+    batch = slot;
+  }
+  // Only this thread appends to its batch; flushAllSamples() runs after the threads stopped.
+  if (!batch->data.empty() &&
+      batch->data.size() + 1 + message.size() > max_bytes_per_datagram_.value()) {
+    send(batch->data);
+    batch->data.clear();
+  }
+  if (!batch->data.empty()) {
+    batch->data.push_back('\n');
+  }
+  batch->data.append(message);
+}
+
+void StatsdSink::flushSamples() {
+  std::shared_ptr<SampleBatch> batch;
+  {
+    absl::MutexLock lock(&batches_mutex_);
+    auto it = batches_.find(std::this_thread::get_id());
+    if (it == batches_.end()) {
+      return;
+    }
+    batch = it->second;
+  }
+  if (!batch->data.empty()) {
+    send(batch->data);
+    batch->data.clear();
+  }
+}
+
+void StatsdSink::flushAllSamples() {
+  std::vector<std::shared_ptr<SampleBatch>> batches;
+  {
+    absl::MutexLock lock(&batches_mutex_);
+    for (auto& entry : batches_) {
+      batches.push_back(entry.second);
+    }
+  }
+  for (const std::shared_ptr<SampleBatch>& batch : batches) {
+    if (!batch->data.empty()) {
+      send(batch->data);
+      batch->data.clear();
+    }
+  }
+}
+
+void StatsdSink::sendBatch(const std::vector<std::string>& messages) {
+  if (!max_bytes_per_datagram_.has_value()) {
+    for (const std::string& message : messages) {
+      send(message);
+    }
+    return;
+  }
+  const uint64_t max_bytes = max_bytes_per_datagram_.value();
+  std::string datagram;
+  for (const std::string& message : messages) {
+    if (!datagram.empty() && datagram.size() + 1 + message.size() > max_bytes) {
+      send(datagram);
+      datagram.clear();
+    }
+    if (!datagram.empty()) {
+      datagram.push_back('\n');
+    }
+    datagram.append(message);
+  }
+  if (!datagram.empty()) {
+    send(datagram);
+  }
+}
+
+void StatsdSink::flush(Envoy::Stats::MetricSnapshot& snapshot) {
+  flushSamples();
+  std::vector<std::string> messages;
+  for (const auto& counter : snapshot.counters()) {
+    if (counter.delta_ > 0) {
+      messages.push_back(buildMessage(counter.counter_.get().name(), absl::StrCat(counter.delta_),
+                                      "c", std::nullopt));
+    }
+  }
+  for (const auto& counter : snapshot.hostCounters()) {
+    if (counter.delta() > 0) {
+      messages.push_back(
+          buildMessage(counter.name(), absl::StrCat(counter.delta()), "c", std::nullopt));
+    }
+  }
+  for (const auto& gauge : snapshot.gauges()) {
+    messages.push_back(
+        buildMessage(gauge.get().name(), absl::StrCat(gauge.get().value()), "g", std::nullopt));
+  }
+  for (const auto& gauge : snapshot.hostGauges()) {
+    messages.push_back(buildMessage(gauge.name(), absl::StrCat(gauge.value()), "g", std::nullopt));
+  }
+  sendBatch(messages);
+}
+
+void StatsdSink::onHistogramComplete(const Envoy::Stats::Histogram& histogram, uint64_t value) {
+  // Nighthawk's own statistics record nanoseconds and report Unit::Unspecified; Envoy histograms
+  // carry their unit. statsd only knows millisecond timings ("|ms") and raw values ("|h").
+  std::optional<int> worker_id;
+  if (const auto* sinkable = dynamic_cast<const SinkableStatistic*>(&histogram);
+      sinkable != nullptr) {
+    worker_id = sinkable->worker_id();
+  }
+  std::string message;
+  switch (histogram.unit()) {
+  case Envoy::Stats::Histogram::Unit::Unspecified:
+    message = buildMessage(histogram.name(), formatNanosAsMillis(value), "ms", worker_id);
+    break;
+  case Envoy::Stats::Histogram::Unit::Microseconds:
+    message = buildMessage(histogram.name(), formatDouble(static_cast<double>(value) / 1e3), "ms",
+                           worker_id);
+    break;
+  case Envoy::Stats::Histogram::Unit::Milliseconds:
+    message = buildMessage(histogram.name(), absl::StrCat(value), "ms", worker_id);
+    break;
+  case Envoy::Stats::Histogram::Unit::Percent:
+    message = buildMessage(
+        histogram.name(),
+        formatDouble(static_cast<double>(value) / Envoy::Stats::Histogram::PercentScale), "h",
+        worker_id);
+    break;
+  case Envoy::Stats::Histogram::Unit::Bytes:
+  default:
+    message = buildMessage(histogram.name(), absl::StrCat(value), "h", worker_id);
+    break;
+  }
+  enqueueSample(std::move(message));
+}
+
+namespace {
+// Resolves a host name synchronously (sinks are created once, at startup).
+Envoy::Network::Address::InstanceConstSharedPtr resolveHostName(const std::string& host,
+                                                                uint32_t port) {
+  addrinfo hints{};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_DGRAM;
+  addrinfo* results = nullptr;
+  const int rc = ::getaddrinfo(host.c_str(), nullptr, &hints, &results);
+  if (rc != 0 || results == nullptr) {
+    throw Envoy::EnvoyException(
+        absl::StrCat("statsd sink: could not resolve host '", host, "': ", gai_strerror(rc)));
+  }
+  Envoy::Network::Address::InstanceConstSharedPtr address;
+  for (addrinfo* entry = results; entry != nullptr && address == nullptr; entry = entry->ai_next) {
+    sockaddr_storage storage{};
+    if (entry->ai_addrlen > sizeof(storage)) {
+      continue;
+    }
+    std::copy_n(reinterpret_cast<const uint8_t*>(entry->ai_addr), entry->ai_addrlen,
+                reinterpret_cast<uint8_t*>(&storage));
+    if (storage.ss_family == AF_INET) {
+      reinterpret_cast<sockaddr_in*>(&storage)->sin_port = htons(port);
+    } else if (storage.ss_family == AF_INET6) {
+      reinterpret_cast<sockaddr_in6*>(&storage)->sin6_port = htons(port);
+    } else {
+      continue;
+    }
+    absl::StatusOr<Envoy::Network::Address::InstanceConstSharedPtr> parsed =
+        Envoy::Network::Address::addressFromSockAddr(storage, entry->ai_addrlen,
+                                                     /*v6only=*/false);
+    if (parsed.ok()) {
+      address = parsed.value();
+    }
+  }
+  ::freeaddrinfo(results);
+  if (address == nullptr) {
+    throw Envoy::EnvoyException(
+        absl::StrCat("statsd sink: host '", host, "' has no usable IP address"));
+  }
+  return address;
+}
+
+Envoy::Network::Address::InstanceConstSharedPtr
+resolveUdpAddress(const envoy::config::core::v3::Address& address) {
+  absl::StatusOr<Envoy::Network::Address::InstanceConstSharedPtr> resolved =
+      Envoy::Network::Address::resolveProtoAddress(address);
+  if (!resolved.ok()) {
+    // resolveProtoAddress only accepts IP literals; fall back to resolving a host name.
+    if (address.has_socket_address() && address.socket_address().resolver_name().empty() &&
+        address.socket_address().port_specifier_case() ==
+            envoy::config::core::v3::SocketAddress::PortSpecifierCase::kPortValue) {
+      return resolveHostName(address.socket_address().address(),
+                             address.socket_address().port_value());
+    }
+    throw Envoy::EnvoyException(
+        absl::StrCat("statsd sink: invalid address: ", resolved.status().message()));
+  }
+  if (resolved.value()->type() != Envoy::Network::Address::Type::Ip) {
+    throw Envoy::EnvoyException("statsd sink: an IP address (UDP) is required");
+  }
+  return resolved.value();
+}
+} // namespace
+
+std::unique_ptr<Envoy::Stats::Sink> StatsdSinkFactory::createStatsSink(
+    const Envoy::Protobuf::Message& config, Envoy::Stats::SymbolTable&,
+    Envoy::ThreadLocal::SlotAllocator& /*tls*/, const std::vector<std::string>& tags) {
+  const auto& sink_config = dynamic_cast<const envoy::config::metrics::v3::StatsdSink&>(config);
+  if (sink_config.statsd_specifier_case() !=
+      envoy::config::metrics::v3::StatsdSink::StatsdSpecifierCase::kAddress) {
+    throw Envoy::EnvoyException(
+        "statsd sink: only the UDP 'address' form is supported (tcp_cluster_name is not)");
+  }
+  return std::make_unique<StatsdSink>(resolveUdpAddress(sink_config.address()),
+                                      sink_config.prefix(), /*use_tags=*/false, std::nullopt, tags);
+}
+
+Envoy::ProtobufTypes::MessagePtr StatsdSinkFactory::createEmptyConfigProto() {
+  return std::make_unique<envoy::config::metrics::v3::StatsdSink>();
+}
+
+std::unique_ptr<Envoy::Stats::Sink> DogStatsdSinkFactory::createStatsSink(
+    const Envoy::Protobuf::Message& config, Envoy::Stats::SymbolTable&,
+    Envoy::ThreadLocal::SlotAllocator& /*tls*/, const std::vector<std::string>& tags) {
+  const auto& sink_config = dynamic_cast<const envoy::config::metrics::v3::DogStatsdSink&>(config);
+  if (!sink_config.has_address()) {
+    throw Envoy::EnvoyException("dog_statsd sink: 'address' is required");
+  }
+  std::optional<uint64_t> max_bytes;
+  if (sink_config.has_max_bytes_per_datagram()) {
+    max_bytes = sink_config.max_bytes_per_datagram().value();
+  }
+  return std::make_unique<StatsdSink>(resolveUdpAddress(sink_config.address()),
+                                      sink_config.prefix(), /*use_tags=*/true, max_bytes, tags);
+}
+
+Envoy::ProtobufTypes::MessagePtr DogStatsdSinkFactory::createEmptyConfigProto() {
+  return std::make_unique<envoy::config::metrics::v3::DogStatsdSink>();
+}
+
+REGISTER_FACTORY(StatsdSinkFactory, NighthawkStatsSinkFactory);
+REGISTER_FACTORY(DogStatsdSinkFactory, NighthawkStatsSinkFactory);
+
+} // namespace Nighthawk

--- a/source/common/statsd_sink.h
+++ b/source/common/statsd_sink.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "envoy/config/metrics/v3/stats.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/network/io_handle.h"
+#include "envoy/stats/sink.h"
+#include "envoy/thread_local/thread_local.h"
+
+#include "nighthawk/common/factories.h"
+
+#include "external/envoy/source/common/common/logger.h"
+
+#include "absl/synchronization/mutex.h"
+
+namespace Nighthawk {
+
+/**
+ * Stats sink that pushes Nighthawk's counters, gauges and latency samples to a statsd (or
+ * DogStatsD) receiver over UDP. Metric names are prefixed (default "nighthawk"). Counters are
+ * sent as deltas ("|c") on every flush, gauges as values ("|g"). Each latency sample recorded in
+ * a sinkable Nighthawk statistic (e.g. benchmark_http_client.latency_2xx,
+ * benchmark_stream.message_latency) is sent as a timing in milliseconds with sub-millisecond
+ * precision ("|ms"), Envoy's own byte histograms as "|h".
+ *
+ * Nighthawk keeps per-worker stats under "cluster.<n>." / "worker.<n>." prefixes. With tags
+ * enabled (DogStatsD) that prefix is stripped and emitted as a "worker:<n>" tag; without tags all
+ * per-worker metrics, latency samples included, are named "worker.<n>.<rest>".
+ */
+class StatsdSink : public Envoy::Stats::Sink,
+                   public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
+public:
+  /**
+   * @param address the UDP address of the statsd receiver. One UDP socket is shared by all
+   * threads (the receiver keys aggregation by client address, so one client per process).
+   * @param prefix metric name prefix; "nighthawk" when empty.
+   * @param use_tags emit DogStatsD tags ("|#worker:0") instead of name prefixes.
+   * @param max_bytes_per_datagram batch messages into newline-separated datagrams of up to this
+   * size; one message per datagram when unset. Counters and gauges are batched per flush;
+   * latency samples are batched per recording thread and sent whenever the batch is full, on
+   * the next stats flush, and when the sink is destroyed.
+   * @param extra_tags "key:value" tags appended to every message when use_tags is set.
+   */
+  StatsdSink(Envoy::Network::Address::InstanceConstSharedPtr address, absl::string_view prefix,
+             bool use_tags, std::optional<uint64_t> max_bytes_per_datagram,
+             const std::vector<std::string>& extra_tags = {});
+  ~StatsdSink() override;
+
+  // Envoy::Stats::Sink
+  void flush(Envoy::Stats::MetricSnapshot& snapshot) override;
+  void onHistogramComplete(const Envoy::Stats::Histogram& histogram, uint64_t value) override;
+
+  /**
+   * Builds the statsd message for a metric, exposed for tests.
+   * @param store_name the metric name as known to the stats store.
+   * @param value formatted value, e.g. "12" or "1.234".
+   * @param type statsd type suffix, e.g. "c", "g", "ms".
+   * @param worker_id worker the metric belongs to, if it is a per-worker metric.
+   */
+  std::string buildMessage(absl::string_view store_name, absl::string_view value,
+                           absl::string_view type, std::optional<int> worker_id) const;
+
+  /**
+   * Formats a Nighthawk latency (nanoseconds) as milliseconds with microsecond precision.
+   */
+  static std::string formatNanosAsMillis(uint64_t nanos);
+
+  const std::string& prefix() const { return prefix_; }
+  bool useTags() const { return use_tags_; }
+
+private:
+  // A per-thread accumulator of latency-sample messages, flushed as one datagram.
+  struct SampleBatch {
+    std::string data;
+  };
+
+  // Splits "cluster.<n>.rest" / "worker.<n>.rest" into (rest, n).
+  static std::pair<std::string, std::optional<int>> splitWorkerPrefix(absl::string_view name);
+  void send(absl::string_view message);
+  void sendBatch(const std::vector<std::string>& messages);
+  // Appends a sample message to the calling thread's batch, sending when it is full.
+  void enqueueSample(std::string message);
+  // Sends the calling thread's pending batch, if any.
+  void flushSamples();
+  // Sends every thread's pending batch; called on destruction, after the worker threads stopped.
+  void flushAllSamples();
+
+  const Envoy::Network::Address::InstanceConstSharedPtr address_;
+  Envoy::Network::IoHandlePtr io_handle_;
+  absl::Mutex socket_mutex_;
+  // Batches keyed by the recording thread, guarded by batches_mutex_. Each thread only ever
+  // touches its own entry while running; flushAllSamples() walks all of them at shutdown.
+  absl::Mutex batches_mutex_;
+  std::map<std::thread::id, std::shared_ptr<SampleBatch>> batches_ ABSL_GUARDED_BY(batches_mutex_);
+  const std::string prefix_;
+  const bool use_tags_;
+  const std::optional<uint64_t> max_bytes_per_datagram_;
+  // Pre-rendered ",key:value,..." suffix appended after the worker tag (empty without tags).
+  const std::string extra_tags_;
+};
+
+/**
+ * Factory for "envoy.stat_sinks.statsd" (envoy.config.metrics.v3.StatsdSink). Only the UDP
+ * `address` form is supported; `tcp_cluster_name` is rejected.
+ */
+class StatsdSinkFactory : public NighthawkStatsSinkFactory {
+public:
+  std::unique_ptr<Envoy::Stats::Sink>
+  createStatsSink(const Envoy::Protobuf::Message& config, Envoy::Stats::SymbolTable& symbol_table,
+                  Envoy::ThreadLocal::SlotAllocator& tls,
+                  const std::vector<std::string>& tags) override;
+  Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+  std::string name() const override { return "envoy.stat_sinks.statsd"; }
+};
+
+/**
+ * Factory for "envoy.stat_sinks.dog_statsd" (envoy.config.metrics.v3.DogStatsdSink): the same
+ * sink with DogStatsD tags enabled and optional datagram batching.
+ */
+class DogStatsdSinkFactory : public NighthawkStatsSinkFactory {
+public:
+  std::unique_ptr<Envoy::Stats::Sink>
+  createStatsSink(const Envoy::Protobuf::Message& config, Envoy::Stats::SymbolTable& symbol_table,
+                  Envoy::ThreadLocal::SlotAllocator& tls,
+                  const std::vector<std::string>& tags) override;
+  Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+  std::string name() const override { return "envoy.stat_sinks.dog_statsd"; }
+};
+
+} // namespace Nighthawk

--- a/test/BUILD
+++ b/test/BUILD
@@ -34,6 +34,23 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "statsd_sink_test",
+    srcs = ["statsd_sink_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/common:nighthawk_common_lib",
+        "//source/common:statsd_sink_lib",
+        "@envoy//source/common/config:utility_lib_with_external_headers",
+        "@envoy//source/common/network:address_lib_with_external_headers",
+        "@envoy//source/common/stats:isolated_store_lib_with_external_headers",
+        "@envoy//test/mocks/stats:stats_mocks",
+        "@envoy//test/mocks/thread_local:thread_local_mocks",
+        "@envoy//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
     name = "client_test",
     srcs = ["client_test.cc"],
     repository = "@envoy",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -155,6 +155,12 @@ py_library(
 )
 
 py_library(
+    name = "test_stats_sinks_lib",
+    srcs = ["test_stats_sinks.py"],
+    deps = [":integration_test_base"],
+)
+
+py_library(
     name = "test_rate_limiter_plugin_lib",
     srcs = ["test_rate_limiter_plugin.py"],
     deps = [":integration_test_base"],
@@ -187,6 +193,7 @@ py_binary(
         ":test_rate_limiter_plugin_lib",
         ":test_remote_execution_lib",
         ":test_request_source_plugin_lib",
+        ":test_stats_sinks_lib",
         ":test_user_defined_output_plugins_lib",
     ],
 )

--- a/test/integration/test_stats_sinks.py
+++ b/test/integration/test_stats_sinks.py
@@ -1,0 +1,105 @@
+"""Tests for the statsd stats sink (--stats-sinks)."""
+
+import socket
+import threading
+
+from test.integration.integration_test_fixtures import (http_test_server_fixture, server_config)
+from test.integration import asserts
+from test.integration.common import IpVersion
+
+
+class UdpCollector:
+  """Collects statsd datagrams on a loopback UDP socket in a background thread."""
+
+  def __init__(self, ip_version):
+    """Bind a UDP socket on the loopback address for ip_version and start receiving."""
+    family = socket.AF_INET6 if ip_version == IpVersion.IPV6 else socket.AF_INET
+    self.address = "::1" if ip_version == IpVersion.IPV6 else "127.0.0.1"
+    self._socket = socket.socket(family, socket.SOCK_DGRAM)
+    self._socket.bind((self.address, 0))
+    self._socket.settimeout(0.2)
+    self.port = self._socket.getsockname()[1]
+    self.lines = []
+    self._stop = False
+    self._thread = threading.Thread(target=self._run, daemon=True)
+    self._thread.start()
+
+  def _run(self):
+    while not self._stop:
+      try:
+        data, _ = self._socket.recvfrom(65536)
+      except socket.timeout:
+        continue
+      self.lines.extend(data.decode("utf-8").split("\n"))
+
+  def stop(self):
+    """Stop the receiver thread and close the socket."""
+    self._stop = True
+    self._thread.join()
+    self._socket.close()
+
+
+def _sink_config(name, type_name, address, port):
+  return ("{name:\"%s\",typed_config:{\"@type\":\"type.googleapis.com/"
+          "envoy.config.metrics.v3.%s\",address:{socket_address:{address:\"%s\","
+          "port_value:%d}}}}") % (name, type_name, address, port)
+
+
+def test_statsd_sink_receives_counters_and_latencies(http_test_server_fixture):
+  """Run with a statsd sink and check counters and latency timings arrive over UDP."""
+  collector = UdpCollector(http_test_server_fixture.ip_version)
+  try:
+    parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+        http_test_server_fixture.getTestServerRootUri(), "--rps", "50", "--duration", "3",
+        "--stats-flush-interval", "1", "--stats-sinks",
+        _sink_config("envoy.stat_sinks.statsd", "StatsdSink", collector.address, collector.port)
+    ])
+  finally:
+    collector.stop()
+  counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
+  asserts.assertCounterGreaterEqual(counters, "benchmark.http_2xx", 100)
+
+  counter_lines = [
+      line for line in collector.lines if line.startswith("nighthawk.worker.0.benchmark.http_2xx:")
+  ]
+  asserts.assertGreaterEqual(len(counter_lines), 1)
+  for line in counter_lines:
+    asserts.assertIn("|c", line)
+  # Counter deltas across flushes add up to (at most) the final counter value.
+  total = sum(int(line.split(":")[1].split("|")[0]) for line in counter_lines)
+  asserts.assertGreater(total, 0)
+  asserts.assertLessEqual(total, int(counters["benchmark.http_2xx"]))
+
+  latency_lines = [
+      line for line in collector.lines
+      if line.startswith("nighthawk.worker.0.benchmark_http_client.latency_2xx:")
+  ]
+  asserts.assertGreaterEqual(len(latency_lines), 100)
+  for line in latency_lines[:10]:
+    asserts.assertIn("|ms", line)
+    millis = float(line.split(":")[1].split("|")[0])
+    # Loopback latencies: sub-millisecond up to a few hundred milliseconds, never raw nanoseconds.
+    asserts.assertBetweenInclusive(millis, 0.0, 1000.0)
+
+
+def test_dog_statsd_sink_emits_worker_tags(http_test_server_fixture):
+  """The DogStatsD variant strips the per-worker prefix and tags instead."""
+  collector = UdpCollector(http_test_server_fixture.ip_version)
+  try:
+    http_test_server_fixture.runNighthawkClient([
+        http_test_server_fixture.getTestServerRootUri(), "--rps", "50", "--duration", "2",
+        "--stats-flush-interval", "1", "--stats-sinks",
+        _sink_config("envoy.stat_sinks.dog_statsd", "DogStatsdSink", collector.address,
+                     collector.port), "--stats-sink-tag", "run:it"
+    ])
+  finally:
+    collector.stop()
+  tagged = [line for line in collector.lines if line.startswith("nighthawk.benchmark.http_2xx:")]
+  asserts.assertGreaterEqual(len(tagged), 1)
+  for line in tagged:
+    asserts.assertIn("|c|#worker:0,run:it", line)
+  asserts.assertGreaterEqual(
+      len([
+          line for line in collector.lines
+          if "benchmark_http_client.latency_2xx:" in line and "|ms|#worker:0,run:it" in line
+      ]), 50)

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -77,6 +77,7 @@ public:
   MOCK_METHOD(std::string, multiTargetPath, (), (const, override));
   MOCK_METHOD(bool, multiTargetUseHttps, (), (const, override));
   MOCK_METHOD(std::vector<std::string>, labels, (), (const, override));
+  MOCK_METHOD(std::vector<std::string>, statsSinkTags, (), (const, override));
   MOCK_METHOD(bool, simpleWarmup, (), (const, override));
   MOCK_METHOD(bool, noDuration, (), (const, override));
   MOCK_METHOD(std::vector<envoy::config::metrics::v3::StatsSink>, statsSinks, (),

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -382,6 +382,22 @@ TEST_F(OptionsImplTest, AlmostAll) {
 
 // We test RequestSource here and not in All above because it is exclusive to some of the other
 // options.
+TEST_F(OptionsImplTest, StatsSinkTagsRoundTripAndValidate) {
+  std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(
+      fmt::format("{} --stats-sink-tag run:phase-c --stats-sink-tag pod:driver-1 {}", client_name_,
+                  good_test_uri_));
+  const std::vector<std::string> expected{"run:phase-c", "pod:driver-1"};
+  EXPECT_EQ(expected, options->statsSinkTags());
+  CommandLineOptionsPtr cmd = options->toCommandLineOptions();
+  ASSERT_EQ(2, cmd->stats_sink_tags_size());
+  EXPECT_EQ("run:phase-c", cmd->stats_sink_tags(0));
+  OptionsImpl round_trip(*cmd);
+  EXPECT_EQ(expected, round_trip.statsSinkTags());
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(fmt::format(
+                              "{} --stats-sink-tag novalue {}", client_name_, good_test_uri_)),
+                          MalformedArgvException, "must be in key:value form");
+}
+
 TEST_F(OptionsImplTest, RequestSource) {
   Envoy::MessageUtil util;
   const std::string request_source = "127.9.9.4:32323";

--- a/test/process_test.cc
+++ b/test/process_test.cc
@@ -68,7 +68,10 @@ public:
 // FakeStatsSinkFactory creates FakeStatsSink.
 class FakeStatsSinkFactory : public NighthawkStatsSinkFactory {
 public:
-  std::unique_ptr<Envoy::Stats::Sink> createStatsSink(Envoy::Stats::SymbolTable&) override {
+  std::unique_ptr<Envoy::Stats::Sink> createStatsSink(const Envoy::Protobuf::Message&,
+                                                      Envoy::Stats::SymbolTable&,
+                                                      Envoy::ThreadLocal::SlotAllocator&,
+                                                      const std::vector<std::string>&) override {
     return std::make_unique<FakeStatsSink>();
   }
 

--- a/test/statsd_sink_test.cc
+++ b/test/statsd_sink_test.cc
@@ -1,0 +1,252 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#include "envoy/config/metrics/v3/stats.pb.h"
+
+#include "external/envoy/source/common/config/utility.h"
+#include "external/envoy/source/common/network/address_impl.h"
+#include "external/envoy/source/common/stats/isolated_store_impl.h"
+#include "external/envoy/test/mocks/stats/mocks.h"
+#include "external/envoy/test/mocks/thread_local/mocks.h"
+
+#include "source/common/statistic_impl.h"
+#include "source/common/statsd_sink.h"
+
+#include "absl/strings/str_split.h"
+#include "gtest/gtest.h"
+
+using namespace testing;
+
+namespace Nighthawk {
+
+// Minimal loopback UDP receiver.
+class UdpReceiver {
+public:
+  UdpReceiver() {
+    fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+    EXPECT_GE(fd_, 0);
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    EXPECT_EQ(0, ::bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)));
+    socklen_t len = sizeof(addr);
+    EXPECT_EQ(0, ::getsockname(fd_, reinterpret_cast<sockaddr*>(&addr), &len));
+    port_ = ntohs(addr.sin_port);
+  }
+  ~UdpReceiver() { ::close(fd_); }
+
+  uint32_t port() const { return port_; }
+  Envoy::Network::Address::InstanceConstSharedPtr address() const {
+    return std::make_shared<Envoy::Network::Address::Ipv4Instance>("127.0.0.1", port_);
+  }
+
+  // Returns the next datagram, or an empty string after a 2s timeout.
+  std::string receive() {
+    pollfd pfd{fd_, POLLIN, 0};
+    if (::poll(&pfd, 1, 2000) <= 0) {
+      return "";
+    }
+    char buffer[65536];
+    const ssize_t n = ::recv(fd_, buffer, sizeof(buffer), 0);
+    return n > 0 ? std::string(buffer, n) : "";
+  }
+
+private:
+  int fd_{-1};
+  uint32_t port_{0};
+};
+
+class StatsdSinkTest : public Test {
+public:
+  std::unique_ptr<StatsdSink> makeSink(bool use_tags, std::optional<uint64_t> max_bytes = {},
+                                       absl::string_view prefix = "",
+                                       std::vector<std::string> extra_tags = {}) {
+    return std::make_unique<StatsdSink>(receiver_.address(), prefix, use_tags, max_bytes,
+                                        extra_tags);
+  }
+
+  UdpReceiver receiver_;
+  NiceMock<Envoy::ThreadLocal::MockInstance> tls_;
+  Envoy::Stats::IsolatedStoreImpl store_;
+};
+
+TEST_F(StatsdSinkTest, MessageNamingWithoutTags) {
+  auto sink = makeSink(false);
+  EXPECT_EQ("nighthawk", sink->prefix());
+  // Both "cluster.<n>." and "worker.<n>." store prefixes are normalized to "worker.<n>.".
+  EXPECT_EQ("nighthawk.worker.0.benchmark.http_2xx:5|c",
+            sink->buildMessage("cluster.0.benchmark.http_2xx", "5", "c", std::nullopt));
+  EXPECT_EQ("nighthawk.worker.2.sequencer.failed_terminations:1|c",
+            sink->buildMessage("worker.2.sequencer.failed_terminations", "1", "c", std::nullopt));
+  EXPECT_EQ("nighthawk.worker.3.benchmark_http_client.latency_2xx:1.500|ms",
+            sink->buildMessage("benchmark_http_client.latency_2xx", "1.500", "ms", 3));
+  EXPECT_EQ("nighthawk.server.total_connections:7|g",
+            sink->buildMessage("server.total_connections", "7", "g", std::nullopt));
+}
+
+TEST_F(StatsdSinkTest, MessageNamingWithTagsAndPrefix) {
+  auto sink = makeSink(true, {}, "lg");
+  EXPECT_EQ("lg.benchmark.http_2xx:5|c|#worker:0",
+            sink->buildMessage("cluster.0.benchmark.http_2xx", "5", "c", std::nullopt));
+  EXPECT_EQ("lg.benchmark_stream.message_latency:0.004|ms|#worker:1",
+            sink->buildMessage("benchmark_stream.message_latency", "0.004", "ms", 1));
+  EXPECT_EQ("lg.server.total_connections:7|g",
+            sink->buildMessage("server.total_connections", "7", "g", std::nullopt));
+}
+
+TEST_F(StatsdSinkTest, ExtraTagsAreAppendedWithTagsAndIgnoredWithout) {
+  auto tagged = makeSink(true, {}, "", {"run:phase-c", "pod:driver-1"});
+  EXPECT_EQ("nighthawk.benchmark.http_2xx:5|c|#worker:0,run:phase-c,pod:driver-1",
+            tagged->buildMessage("cluster.0.benchmark.http_2xx", "5", "c", std::nullopt));
+  EXPECT_EQ("nighthawk.server.total_connections:7|g|#run:phase-c,pod:driver-1",
+            tagged->buildMessage("server.total_connections", "7", "g", std::nullopt));
+  auto plain = makeSink(false, {}, "", {"run:phase-c"});
+  EXPECT_EQ("nighthawk.worker.0.benchmark.http_2xx:5|c",
+            plain->buildMessage("cluster.0.benchmark.http_2xx", "5", "c", std::nullopt));
+}
+
+TEST_F(StatsdSinkTest, FormatsNanosecondsAsMilliseconds) {
+  EXPECT_EQ("1.500", StatsdSink::formatNanosAsMillis(1500000));
+  EXPECT_EQ("0.001", StatsdSink::formatNanosAsMillis(1000));
+  EXPECT_EQ("1234.568", StatsdSink::formatNanosAsMillis(1234567890));
+  EXPECT_EQ("0.000", StatsdSink::formatNanosAsMillis(0));
+}
+
+TEST_F(StatsdSinkTest, HistogramValuesAreSentAsMillisecondTimings) {
+  auto sink = makeSink(false);
+  SinkableHdrStatistic statistic(*store_.rootScope(), /*worker_id=*/3);
+  statistic.setId("benchmark_http_client.latency_2xx");
+  sink->onHistogramComplete(statistic, 2500000); // 2.5 ms in nanoseconds
+  EXPECT_EQ("nighthawk.worker.3.benchmark_http_client.latency_2xx:2.500|ms", receiver_.receive());
+
+  auto tagged = makeSink(true);
+  tagged->onHistogramComplete(statistic, 750000);
+  EXPECT_EQ("nighthawk.benchmark_http_client.latency_2xx:0.750|ms|#worker:3", receiver_.receive());
+}
+
+TEST_F(StatsdSinkTest, HistogramSamplesAreBatchedAndFlushedOnDestruction) {
+  SinkableHdrStatistic statistic(*store_.rootScope(), /*worker_id=*/0);
+  statistic.setId("benchmark_stream.message_latency");
+  {
+    auto sink = makeSink(true, /*max_bytes=*/130);
+    for (uint64_t i = 1; i <= 3; i++) {
+      sink->onHistogramComplete(statistic, i * 1000000); // 1, 2, 3 ms
+    }
+    // Three 61-byte messages: the first two fit one 130-byte datagram, the third starts a new
+    // batch that is still pending.
+    EXPECT_EQ(
+        std::vector<std::string>({"nighthawk.benchmark_stream.message_latency:1.000|ms|#worker:0",
+                                  "nighthawk.benchmark_stream.message_latency:2.000|ms|#worker:0"}),
+        std::vector<std::string>(absl::StrSplit(receiver_.receive(), '\n')));
+    // Nothing else arrives until the sink flushes.
+    NiceMock<Envoy::Stats::MockMetricSnapshot> snapshot;
+    std::vector<Envoy::Stats::MetricSnapshot::CounterSnapshot> counters;
+    std::vector<std::reference_wrapper<const Envoy::Stats::Gauge>> gauges;
+    EXPECT_CALL(snapshot, counters()).WillRepeatedly(ReturnRef(counters));
+    EXPECT_CALL(snapshot, gauges()).WillRepeatedly(ReturnRef(gauges));
+    sink->flush(snapshot);
+    EXPECT_EQ("nighthawk.benchmark_stream.message_latency:3.000|ms|#worker:0", receiver_.receive());
+    sink->onHistogramComplete(statistic, 4000000);
+  }
+  // Destroying the sink sends the pending batch.
+  EXPECT_EQ("nighthawk.benchmark_stream.message_latency:4.000|ms|#worker:0", receiver_.receive());
+}
+
+TEST_F(StatsdSinkTest, FlushSendsCounterDeltasAndGauges) {
+  auto sink = makeSink(false);
+  Envoy::Stats::Counter& counter = store_.counterFromString("cluster.0.benchmark.http_2xx");
+  counter.add(5);
+  Envoy::Stats::Counter& idle = store_.counterFromString("cluster.0.benchmark.http_5xx");
+  Envoy::Stats::Gauge& gauge = store_.gaugeFromString("cluster.0.upstream_cx_active",
+                                                      Envoy::Stats::Gauge::ImportMode::Accumulate);
+  gauge.set(2);
+  NiceMock<Envoy::Stats::MockMetricSnapshot> snapshot;
+  std::vector<Envoy::Stats::MetricSnapshot::CounterSnapshot> counters{
+      {/*delta=*/5, std::cref(counter)}, {/*delta=*/0, std::cref(idle)}};
+  std::vector<std::reference_wrapper<const Envoy::Stats::Gauge>> gauges{std::cref(gauge)};
+  EXPECT_CALL(snapshot, counters()).WillRepeatedly(ReturnRef(counters));
+  EXPECT_CALL(snapshot, gauges()).WillRepeatedly(ReturnRef(gauges));
+  sink->flush(snapshot);
+  // Zero deltas are skipped, so exactly two datagrams arrive.
+  EXPECT_EQ("nighthawk.worker.0.benchmark.http_2xx:5|c", receiver_.receive());
+  EXPECT_EQ("nighthawk.worker.0.upstream_cx_active:2|g", receiver_.receive());
+  EXPECT_EQ("", receiver_.receive());
+}
+
+TEST_F(StatsdSinkTest, FlushBatchesIntoDatagramsWhenConfigured) {
+  auto sink = makeSink(true, /*max_bytes=*/100);
+  Envoy::Stats::Counter& a = store_.counterFromString("cluster.0.benchmark.http_2xx");
+  Envoy::Stats::Counter& b = store_.counterFromString("cluster.0.benchmark.grpc_error");
+  Envoy::Stats::Counter& c = store_.counterFromString("cluster.1.benchmark.http_2xx");
+  NiceMock<Envoy::Stats::MockMetricSnapshot> snapshot;
+  std::vector<Envoy::Stats::MetricSnapshot::CounterSnapshot> counters{
+      {1, std::cref(a)}, {2, std::cref(b)}, {3, std::cref(c)}};
+  std::vector<std::reference_wrapper<const Envoy::Stats::Gauge>> gauges;
+  EXPECT_CALL(snapshot, counters()).WillRepeatedly(ReturnRef(counters));
+  EXPECT_CALL(snapshot, gauges()).WillRepeatedly(ReturnRef(gauges));
+  sink->flush(snapshot);
+  const std::string first = receiver_.receive();
+  const std::string second = receiver_.receive();
+  EXPECT_LE(first.size(), 100);
+  EXPECT_EQ(std::vector<std::string>({"nighthawk.benchmark.http_2xx:1|c|#worker:0",
+                                      "nighthawk.benchmark.grpc_error:2|c|#worker:0"}),
+            std::vector<std::string>(absl::StrSplit(first, '\n')));
+  EXPECT_EQ("nighthawk.benchmark.http_2xx:3|c|#worker:1", second);
+}
+
+TEST_F(StatsdSinkTest, FactoriesAreRegisteredUnderEnvoysSinkNames) {
+  auto& statsd = Envoy::Config::Utility::getAndCheckFactoryByName<NighthawkStatsSinkFactory>(
+      "envoy.stat_sinks.statsd");
+  envoy::config::metrics::v3::StatsdSink config;
+  config.mutable_address()->mutable_socket_address()->set_address("127.0.0.1");
+  config.mutable_address()->mutable_socket_address()->set_port_value(receiver_.port());
+  config.set_prefix("nh");
+  std::unique_ptr<Envoy::Stats::Sink> sink =
+      statsd.createStatsSink(config, store_.symbolTable(), tls_, {});
+  ASSERT_NE(nullptr, sink);
+  auto* typed = dynamic_cast<StatsdSink*>(sink.get());
+  ASSERT_NE(nullptr, typed);
+  EXPECT_EQ("nh", typed->prefix());
+  EXPECT_FALSE(typed->useTags());
+
+  envoy::config::metrics::v3::StatsdSink tcp;
+  tcp.set_tcp_cluster_name("statsd");
+  EXPECT_THROW_WITH_REGEX(statsd.createStatsSink(tcp, store_.symbolTable(), tls_, {}),
+                          Envoy::EnvoyException, "only the UDP 'address' form");
+
+  auto& dog = Envoy::Config::Utility::getAndCheckFactoryByName<NighthawkStatsSinkFactory>(
+      "envoy.stat_sinks.dog_statsd");
+  envoy::config::metrics::v3::DogStatsdSink dog_config;
+  dog_config.mutable_address()->mutable_socket_address()->set_address("127.0.0.1");
+  dog_config.mutable_address()->mutable_socket_address()->set_port_value(receiver_.port());
+  std::unique_ptr<Envoy::Stats::Sink> dog_sink =
+      dog.createStatsSink(dog_config, store_.symbolTable(), tls_, {"run:x"});
+  auto* dog_typed = dynamic_cast<StatsdSink*>(dog_sink.get());
+  ASSERT_NE(nullptr, dog_typed);
+  EXPECT_TRUE(dog_typed->useTags());
+  EXPECT_EQ("nighthawk", dog_typed->prefix());
+
+  // Host names are resolved at creation time.
+  envoy::config::metrics::v3::DogStatsdSink by_name;
+  by_name.mutable_address()->mutable_socket_address()->set_address("localhost");
+  by_name.mutable_address()->mutable_socket_address()->set_port_value(receiver_.port());
+  EXPECT_NE(nullptr, dog.createStatsSink(by_name, store_.symbolTable(), tls_, {}));
+  envoy::config::metrics::v3::DogStatsdSink unresolvable;
+  unresolvable.mutable_address()->mutable_socket_address()->set_address("no.such.host.invalid");
+  unresolvable.mutable_address()->mutable_socket_address()->set_port_value(1);
+  EXPECT_THROW_WITH_REGEX(dog.createStatsSink(unresolvable, store_.symbolTable(), tls_, {}),
+                          Envoy::EnvoyException, "could not resolve host");
+
+  envoy::config::metrics::v3::DogStatsdSink no_address;
+  EXPECT_THROW_WITH_REGEX(dog.createStatsSink(no_address, store_.symbolTable(), tls_, {}),
+                          Envoy::EnvoyException, "'address' is required");
+}
+
+} // namespace Nighthawk


### PR DESCRIPTION
**Description**

This PR is related to #1607

`--stats-sinks` is documented in the README with a statsd example, but no `NighthawkStatsSinkFactory` implementation is linked into the binaries, so any `--stats-sinks` value aborts at startup with `Didn't find a registered implementation for 'envoy.stat_sinks.statsd'`. This adds a UDP statsd sink and registers it under Envoy's sink names so the documented configs work as written.

Behavior:
- `envoy.stat_sinks.statsd` (`envoy.config.metrics.v3.StatsdSink`, UDP `address` form, IP literal or host name resolved at startup; `tcp_cluster_name` is rejected) and `envoy.stat_sinks.dog_statsd` (`envoy.config.metrics.v3.DogStatsdSink`: DogStatsD tags, optional `max_bytes_per_datagram` batching).
- Counters are sent as deltas (`|c`) on every flush, gauges as values (`|g`). Nighthawk's sinkable latency statistics record nanoseconds, so every sample is sent as a millisecond timing with microsecond precision (`|ms`); Envoy histograms are converted per their unit.
- Per-worker metrics are named `worker.<n>.<rest>` (covering both the `cluster.<n>.` and `worker.<n>.` store scopes), or carry a `worker:<n>` tag with DogStatsD.
- New `--stats-sink-tag key:value` (repeatable; `CommandLineOptions.stats_sink_tags`) adds tags to every message of tag-capable sinks, e.g. to identify a run or pod.
- Default metric prefix `nighthawk` (override with `prefix`).

**Notes for Reviewers**

- Envoy's `UdpStatsdSink` was not reusable as-is: it keeps a thread-local writer, and Nighthawk's flush worker thread registers with TLS after sinks are created, which trips Envoy's `currentThreadRegisteredWorker` assert; it also forwards histogram values verbatim as `|ms`, wrong for Nighthawk's nanosecond statistics. The sink here shares one UDP socket across threads and batches latency samples per recording thread (sent when the batch fills, on the next flush, and at shutdown).
- `NighthawkStatsSinkFactory::createStatsSink` now receives the translated typed config (it previously had no access to it), a `ThreadLocal::SlotAllocator` and the configured tags; `include/` is documented as not a public API, and the only in-tree implementation (the test fake) is updated.
- Testing: `//test:statsd_sink_test` (naming with/without tags, ns to ms conversion, counter deltas and gauges, batching and end-of-run flush against a real loopback UDP receiver, factory registration, host name resolution and config validation); `test/integration/test_stats_sinks.py` (full `nighthawk_client` runs with each sink, capturing the datagrams); `//test:options_test`, `//test:process_test`, `//test:factories_test`. README usage regenerated; `docs/root/statistics.md` and version history updated.
- Verified end to end against an OpenTelemetry Collector statsd receiver: per-worker counts in Prometheus matched the client's JSON exactly.