### PR TITLE
client: add --request-body-file to send a file's bytes as the request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ bazel-bin/nighthawk_client  [--user-defined-plugin-config <string>] ...
 <uint32_t>] [--transport-socket <string>]
 [--upstream-bind-config <string>]
 [--tls-context <string>]
+[--request-body-file <string>]
 [--request-body-size <uint32_t>]
 [--request-header <string>] ...
 [--request-method <GET|HEAD|POST|PUT|DELETE
@@ -373,6 +374,12 @@ DEPRECATED, use --transport-socket instead. TlS context configuration
 in json. Mutually exclusive with --transport-socket. Example (json):
 {common_tls_context:{tls_params:{cipher_suites:["-ALL:ECDHE-RSA-AES128
 -SHA"]}}}
+
+--request-body-file <string>
+Path to a file whose bytes are sent verbatim as the request body on
+every request (binary safe). No Content-Type is set for it; pass one
+with --request-header if needed. Mutually exclusive with
+--request-body-size.
 
 --request-body-size <uint32_t>
 Size of the request body to send. NH will send a number of consecutive

--- a/api/client/options.proto
+++ b/api/client/options.proto
@@ -26,6 +26,10 @@ message RequestOptions {
   // If this isn't provided, Nighthawk sends its built-in request body (the character 'a'
   // repeated n times to the specified request size).
   string json_body = 4;
+  // Optional raw request body, sent verbatim (binary safe). Populated by --request-body-file.
+  // Nighthawk does not set a Content-Type for this body; supply one with request_headers.
+  // Mutually exclusive with request_body_size and json_body.
+  bytes request_body = 5;
 }
 
 // Used for providing multiple request options, especially for RequestSourcePlugins.

--- a/docs/root/version_history.md
+++ b/docs/root/version_history.md
@@ -14,6 +14,7 @@ Version history
 
 ### Changelist
 
+- `--request-body-file` sends a file's bytes verbatim as the request body (binary safe; no Content-Type is set). The `RequestOptions.request_body` (bytes) field carries it over the gRPC service API. Mutually exclusive with `--request-body-size`.
 - Introducing termination predicates (https://github.com/envoyproxy/nighthawk/pull/167) and https://github.com/envoyproxy/nighthawk/pull/176
 
 0.2 (July 16, 2019)

--- a/include/nighthawk/client/options.h
+++ b/include/nighthawk/client/options.h
@@ -64,6 +64,10 @@ public:
   virtual envoy::config::core::v3::RequestMethod requestMethod() const PURE;
   virtual std::vector<std::string> requestHeaders() const PURE;
   virtual uint32_t requestBodySize() const PURE;
+  /**
+   * @return const std::string& raw request body bytes (empty when not configured).
+   */
+  virtual const std::string& requestBody() const PURE;
   virtual const envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&
   tlsContext() const PURE;
   virtual const std::optional<envoy::config::core::v3::BindConfig>& upstreamBindConfig() const PURE;

--- a/source/client/factories_impl.cc
+++ b/source/client/factories_impl.cc
@@ -207,9 +207,14 @@ RequestSourceFactoryImpl::create(const Envoy::Upstream::ClusterManagerPtr& clust
   }
 
   header->setMethod(envoy::config::core::v3::RequestMethod_Name(options_.requestMethod()));
-  const uint32_t content_length = options_.requestBodySize();
-  if (content_length > 0) {
-    header->setContentLength(content_length);
+  std::string body = options_.requestBody();
+  if (!body.empty()) {
+    header->setContentLength(body.size());
+  } else {
+    const uint32_t content_length = options_.requestBodySize();
+    if (content_length > 0) {
+      header->setContentLength(content_length);
+    }
   }
 
   auto request_options = options_.toCommandLineOptions()->request_options();
@@ -235,7 +240,8 @@ RequestSourceFactoryImpl::create(const Envoy::Upstream::ClusterManagerPtr& clust
     RequestSourcePtr request_source = std::move(plugin_or.value());
     return request_source;
   } else {
-    return std::make_unique<StaticRequestSourceImpl>(std::move(header));
+    return std::make_unique<StaticRequestSourceImpl>(std::move(header), UINT64_MAX,
+                                                     std::move(body));
   }
 }
 absl::StatusOr<RequestSourcePtr> RequestSourceFactoryImpl::LoadRequestSourcePlugin(

--- a/source/client/options_impl.cc
+++ b/source/client/options_impl.cc
@@ -3,8 +3,11 @@
 #include <cerrno>
 #include <cstdint>
 #include <exception>
+#include <fstream>
+#include <iterator>
 #include <optional>
 
+#include "external/envoy/source/common/common/utility.h"
 #include "external/envoy/source/common/protobuf/message_validator_impl.h"
 #include "external/envoy/source/common/protobuf/protobuf.h"
 #include "external/envoy/source/common/protobuf/utility.h"
@@ -192,6 +195,12 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "Size of the request body to send. NH will send a number of consecutive 'a' characters equal "
       "to the number specified here. (default: 0, no data).",
       false, 0, "uint32_t", cmd);
+  TCLAP::ValueArg<std::string> request_body_file(
+      "", "request-body-file",
+      "Path to a file whose bytes are sent verbatim as the request body on every request (binary "
+      "safe). No Content-Type is set for it; pass one with --request-header if needed. Mutually "
+      "exclusive with --request-body-size.",
+      false, "", "string", cmd);
 
   TCLAP::ValueArg<std::string> tls_context(
       "", "tls-context",
@@ -533,6 +542,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   }
   TCLAP_SET_IF_SPECIFIED(request_headers, request_headers_);
   TCLAP_SET_IF_SPECIFIED(request_body_size, request_body_size_);
+  if (request_body_file.isSet()) {
+    request_body_ = readRequestBodyFile(request_body_file.getValue());
+  }
   TCLAP_SET_IF_SPECIFIED(max_pending_requests, max_pending_requests_);
   TCLAP_SET_IF_SPECIFIED(max_active_requests, max_active_requests_);
   TCLAP_SET_IF_SPECIFIED(max_requests_per_connection, max_requests_per_connection_);
@@ -895,6 +907,7 @@ OptionsImpl::OptionsImpl(const nighthawk::client::CommandLineOptions& options) {
     }
     request_body_size_ =
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(request_options, request_body_size, request_body_size_);
+    request_body_ = request_options.request_body();
   } else if (options.has_request_source()) {
     const auto& request_source_options = options.request_source();
     request_source_ = request_source_options.uri();
@@ -1012,7 +1025,29 @@ void OptionsImpl::setNonTrivialDefaults() {
   jitter_uniform_ = std::chrono::nanoseconds(0);
 }
 
+std::string OptionsImpl::readRequestBodyFile(const std::string& path) {
+  std::ifstream file(path, std::ios::in | std::ios::binary);
+  if (!file) {
+    throw MalformedArgvException(fmt::format("Failed to open --request-body-file '{}': {}", path,
+                                             Envoy::errorDetails(errno)));
+  }
+  std::string contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  if (file.bad()) {
+    throw MalformedArgvException(fmt::format("Failed to read --request-body-file '{}'", path));
+  }
+  if (contents.size() > largest_acceptable_uint32_option_value) {
+    throw MalformedArgvException(fmt::format(
+        "--request-body-file '{}' is larger than the maximum request body size of {} bytes", path,
+        largest_acceptable_uint32_option_value));
+  }
+  return contents;
+}
+
 void OptionsImpl::validate() const {
+  if (!request_body_.empty() && request_body_size_ > 0) {
+    throw MalformedArgvException(
+        "--request-body-file and --request-body-size are mutually exclusive");
+  }
   if (h2_use_multiple_connections_) {
     throw MalformedArgvException(
         "The experimental_h2_use_multiple_connections option is deprecated, set "
@@ -1138,6 +1173,9 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptionsInternal() const {
         throw MalformedArgvException("A ':' is required in a header.");
       }
       request_options->mutable_request_body_size()->set_value(requestBodySize());
+    }
+    if (!request_body_.empty()) {
+      request_options->set_request_body(request_body_);
     }
   }
 

--- a/source/client/options_impl.h
+++ b/source/client/options_impl.h
@@ -66,6 +66,7 @@ public:
   envoy::config::core::v3::RequestMethod requestMethod() const override { return request_method_; };
   std::vector<std::string> requestHeaders() const override { return request_headers_; };
   uint32_t requestBodySize() const override { return request_body_size_; };
+  const std::string& requestBody() const override { return request_body_; };
   const envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&
   tlsContext() const override {
     return tls_context_;
@@ -170,6 +171,14 @@ private:
       envoy::config::core::v3::RequestMethod::GET};
   std::vector<std::string> request_headers_;
   uint32_t request_body_size_{0};
+  std::string request_body_;
+
+  /**
+   * Reads the whole file at path into a string (binary safe).
+   * @throws MalformedArgvException when the file cannot be opened or read, or exceeds the
+   * maximum request body size.
+   */
+  static std::string readRequestBodyFile(const std::string& path);
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context_;
   std::optional<envoy::config::core::v3::BindConfig> upstream_bind_config_;
   std::optional<envoy::config::core::v3::TransportSocket> transport_socket_;

--- a/source/common/request_source_impl.cc
+++ b/source/common/request_source_impl.cc
@@ -17,15 +17,15 @@ using EnvoyException = Envoy::EnvoyException;
 } // namespace
 
 StaticRequestSourceImpl::StaticRequestSourceImpl(Envoy::Http::RequestHeaderMapPtr&& header,
-                                                 const uint64_t max_yields)
-    : header_(std::move(header)), yields_left_(max_yields) {
+                                                 const uint64_t max_yields, std::string body)
+    : header_(std::move(header)), yields_left_(max_yields), body_(std::move(body)) {
   RELEASE_ASSERT(header_ != nullptr, "header can't equal nullptr");
 }
 
 RequestGenerator StaticRequestSourceImpl::get() {
   return [this]() -> RequestPtr {
     while (yields_left_--) {
-      return std::make_unique<RequestImpl>(header_);
+      return std::make_unique<RequestImpl>(header_, body_);
     }
     return nullptr;
   };

--- a/source/common/request_source_impl.h
+++ b/source/common/request_source_impl.h
@@ -22,9 +22,10 @@ public:
   /**
    * @param max_yields the number of request specifiers to yield. The source will start yielding
    * nullptr when exceeded.
+   * @param body optional request body bytes, sent verbatim with every request.
    */
   StaticRequestSourceImpl(Envoy::Http::RequestHeaderMapPtr&&,
-                          const uint64_t max_yields = UINT64_MAX);
+                          const uint64_t max_yields = UINT64_MAX, std::string body = "");
   RequestGenerator get() override;
   void initOnThread() override {};
   void destroyOnThread() override {};
@@ -32,6 +33,7 @@ public:
 private:
   const HeaderMapPtr header_;
   uint64_t yields_left_;
+  const std::string body_;
 };
 
 /**

--- a/test/factories_test.cc
+++ b/test/factories_test.cc
@@ -32,6 +32,7 @@ public:
   Envoy::Event::MockDispatcher dispatcher_;
   MockOptions options_;
   Envoy::Tracing::TracerSharedPtr tracer_;
+  const std::string empty_body_;
 };
 
 TEST_F(FactoriesTest, CreateBenchmarkClient) {
@@ -73,6 +74,7 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithWorkingJsonReturnsWorkingRequ
                                    Envoy::ProtobufMessage::getStrictValidationVisitor());
   EXPECT_CALL(options_, requestMethod());
   EXPECT_CALL(options_, requestBodySize());
+  EXPECT_CALL(options_, requestBody()).WillRepeatedly(ReturnRef(empty_body_));
   EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/"));
   EXPECT_CALL(options_, requestSource());
   EXPECT_CALL(options_, requestSourcePluginConfig())
@@ -113,6 +115,7 @@ TEST_F(FactoriesTest, CreateRequestSourcePluginWithNonWorkingJsonThrowsError) {
                                    Envoy::ProtobufMessage::getStrictValidationVisitor());
   EXPECT_CALL(options_, requestMethod());
   EXPECT_CALL(options_, requestBodySize());
+  EXPECT_CALL(options_, requestBody()).WillRepeatedly(ReturnRef(empty_body_));
   EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/"));
   EXPECT_CALL(options_, requestSource());
   EXPECT_CALL(options_, requestSourcePluginConfig())
@@ -137,6 +140,7 @@ TEST_F(FactoriesTest, CreateRequestSource) {
   std::optional<envoy::config::core::v3::TypedExtensionConfig> request_source_plugin_config;
   EXPECT_CALL(options_, requestMethod());
   EXPECT_CALL(options_, requestBodySize());
+  EXPECT_CALL(options_, requestBody()).WillRepeatedly(ReturnRef(empty_body_));
   EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/"));
   EXPECT_CALL(options_, requestSource());
   EXPECT_CALL(options_, requestSourcePluginConfig())
@@ -155,10 +159,34 @@ TEST_F(FactoriesTest, CreateRequestSource) {
   EXPECT_NE(nullptr, request_generator.get());
 }
 
+TEST_F(FactoriesTest, CreateRequestSourceWithBodyFileSetsContentLengthOnly) {
+  std::optional<envoy::config::core::v3::TypedExtensionConfig> request_source_plugin_config;
+  const std::string body("\x00\x01raw\xff", 6);
+  EXPECT_CALL(options_, requestMethod())
+      .WillRepeatedly(Return(envoy::config::core::v3::RequestMethod::POST));
+  EXPECT_CALL(options_, requestBody()).WillRepeatedly(ReturnRef(body));
+  EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/bar"));
+  EXPECT_CALL(options_, requestSource());
+  EXPECT_CALL(options_, requestSourcePluginConfig())
+      .WillRepeatedly(ReturnRef(request_source_plugin_config));
+  EXPECT_CALL(options_, toCommandLineOptions())
+      .WillOnce(Return(ByMove(std::make_unique<nighthawk::client::CommandLineOptions>())));
+  RequestSourceFactoryImpl factory(options_, *api_);
+  Envoy::Upstream::ClusterManagerPtr cluster_manager;
+  RequestSourcePtr request_source = factory.create(
+      cluster_manager, dispatcher_, *stats_scope_.createScope("foo."), "requestsource");
+  Nighthawk::RequestPtr request = request_source->get()();
+  EXPECT_EQ(body, request->body());
+  EXPECT_EQ("6", request->header()->getContentLengthValue());
+  EXPECT_EQ("", request->header()->getContentTypeValue());
+  EXPECT_EQ("POST", request->header()->getMethodValue());
+}
+
 TEST_F(FactoriesTest, CreateRemoteRequestSource) {
   std::optional<envoy::config::core::v3::TypedExtensionConfig> request_source_plugin_config;
   EXPECT_CALL(options_, requestMethod());
   EXPECT_CALL(options_, requestBodySize());
+  EXPECT_CALL(options_, requestBody()).WillRepeatedly(ReturnRef(empty_body_));
   EXPECT_CALL(options_, uri()).Times(2).WillRepeatedly(Return("http://foo/"));
   EXPECT_CALL(options_, requestSource()).WillOnce(Return("http://bar/"));
   EXPECT_CALL(options_, requestsPerSecond()).WillOnce(Return(5));

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -155,6 +155,12 @@ py_library(
 )
 
 py_library(
+    name = "test_request_body_file_lib",
+    srcs = ["test_request_body_file.py"],
+    deps = [":integration_test_base"],
+)
+
+py_library(
     name = "test_rate_limiter_plugin_lib",
     srcs = ["test_rate_limiter_plugin.py"],
     deps = [":integration_test_base"],
@@ -186,6 +192,7 @@ py_binary(
         ":test_output_transform_lib",
         ":test_rate_limiter_plugin_lib",
         ":test_remote_execution_lib",
+        ":test_request_body_file_lib",
         ":test_request_source_plugin_lib",
         ":test_user_defined_output_plugins_lib",
     ],

--- a/test/integration/test_request_body_file.py
+++ b/test/integration/test_request_body_file.py
@@ -1,0 +1,20 @@
+"""Tests for --request-body-file."""
+
+from test.integration.integration_test_fixtures import (http_test_server_fixture, server_config)
+from test.integration import asserts
+
+
+def test_request_body_file_is_sent(http_test_server_fixture, tmp_path):
+  """Send a binary body file over HTTP/1.1 and check the requests succeed."""
+  payload = tmp_path / "body.bin"
+  # Deliberately binary, with a NUL byte and non-UTF-8 content.
+  payload.write_bytes(b"\x0a\x05world\x00\xff")
+  parsed_json, _ = http_test_server_fixture.runNighthawkClient([
+      http_test_server_fixture.getTestServerRootUri(), "--request-method", "POST",
+      "--request-body-file",
+      str(payload), "--request-header", "content-type: application/octet-stream", "--duration",
+      "100", "--termination-predicate", "benchmark.http_2xx:9"
+  ])
+  counters = http_test_server_fixture.getNighthawkCounterMapFromJson(parsed_json)
+  asserts.assertCounterEqual(counters, "benchmark.http_2xx", 10)
+  asserts.assertCounterEqual(counters, "upstream_rq_total", 10)

--- a/test/mocks/client/mock_options.h
+++ b/test/mocks/client/mock_options.h
@@ -44,6 +44,7 @@ public:
   MOCK_METHOD(envoy::config::core::v3::RequestMethod, requestMethod, (), (const, override));
   MOCK_METHOD(std::vector<std::string>, requestHeaders, (), (const, override));
   MOCK_METHOD(uint32_t, requestBodySize, (), (const, override));
+  MOCK_METHOD(const std::string&, requestBody, (), (const, override));
   MOCK_METHOD(envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext&, tlsContext, (),
               (const, override));
   MOCK_METHOD(std::optional<envoy::config::core::v3::BindConfig>&, upstreamBindConfig, (),

--- a/test/options_test.cc
+++ b/test/options_test.cc
@@ -382,6 +382,35 @@ TEST_F(OptionsImplTest, AlmostAll) {
 
 // We test RequestSource here and not in All above because it is exclusive to some of the other
 // options.
+TEST_F(OptionsImplTest, RequestBodyFileIsReadVerbatimAndRoundTrips) {
+  const std::string body("\x00\x01{\"name\":\"world\"}\xff\n", 20);
+  const std::string path = TestEnvironment::writeStringToFileForTest("request_body.bin", body);
+  std::unique_ptr<OptionsImpl> options = TestUtility::createOptionsImpl(
+      fmt::format("{} --request-body-file {} {}", client_name_, path, good_test_uri_));
+  EXPECT_EQ(body, options->requestBody());
+  EXPECT_EQ(0, options->requestBodySize());
+
+  CommandLineOptionsPtr cmd = options->toCommandLineOptions();
+  EXPECT_EQ(body, cmd->request_options().request_body());
+  OptionsImpl round_trip(*cmd);
+  EXPECT_EQ(body, round_trip.requestBody());
+}
+
+TEST_F(OptionsImplTest, RequestBodyFileMissing) {
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::createOptionsImpl(fmt::format("{} --request-body-file {} {}", client_name_,
+                                                 "/does/not/exist.bin", good_test_uri_)),
+      MalformedArgvException, "Failed to open --request-body-file");
+}
+
+TEST_F(OptionsImplTest, RequestBodyFileAndRequestBodySizeAreMutuallyExclusive) {
+  const std::string path = TestEnvironment::writeStringToFileForTest("request_body2.bin", "abc");
+  EXPECT_THROW_WITH_REGEX(TestUtility::createOptionsImpl(
+                              fmt::format("{} --request-body-file {} --request-body-size 3 {}",
+                                          client_name_, path, good_test_uri_)),
+                          MalformedArgvException, "mutually exclusive");
+}
+
 TEST_F(OptionsImplTest, RequestSource) {
   Envoy::MessageUtil util;
   const std::string request_source = "127.9.9.4:32323";


### PR DESCRIPTION
**Description**

This PR is related to #1608

Nighthawk can only send a synthetic body (`'a'` repeated `--request-body-size` times) or, through a request source plugin, a `json_body`, which is a proto3 `string` and therefore must be UTF-8. That rules out sending an arbitrary payload such as a serialized protobuf.

This adds `--request-body-file <path>`: the file's bytes are sent verbatim on every request (binary safe). Over the gRPC service API the body travels in the new `RequestOptions.request_body` (`bytes`) field. `Content-Length` is set from the body size; no `Content-Type` is assumed, pass one with `--request-header`. `--request-body-size` behavior is unchanged, and the two are mutually exclusive.

**Notes for Reviewers**

- `OptionsImpl` reads the file at parse time (size cap, clear errors for unreadable files); `StaticRequestSourceImpl` gains an optional body; `RequestSourceFactoryImpl` passes it through. Plugin and remote request sources are unchanged.
- Testing: `//test:options_test` (verbatim binary content and proto round trip, missing file, mutual exclusion), `//test:factories_test` (body, `Content-Length`, no `Content-Type`), `test/integration/test_request_body_file.py` (full run posting a binary file to the test server). README usage regenerated; version history updated.
- Prerequisite for #1602 (gRPC unary mode, #24).