### PR TITLE
client: do not fork a child process unless a tunnel is configured

### DIFF
--- a/docs/root/version_history.md
+++ b/docs/root/version_history.md
@@ -14,6 +14,7 @@ Version history
 
 ### Changelist
 
+- `nighthawk_client` no longer forks a child process unless `--tunnel-uri` is configured. The fork of the already multithreaded client could deadlock the child before it signaled the parent, leaving the client hung at startup without sending any request.
 - Introducing termination predicates (https://github.com/envoyproxy/nighthawk/pull/167) and https://github.com/envoyproxy/nighthawk/pull/176
 
 0.2 (July 16, 2019)

--- a/source/client/process_impl.cc
+++ b/source/client/process_impl.cc
@@ -1076,8 +1076,17 @@ bool ProcessImpl::runInternal(OutputCollector& collector, const UriPtr& tracing_
       }
     }
   };
-  encap_runner_ = std::make_shared<EncapsulationSubProcessRunner>(nigthawk_fn, envoy_routine);
-  auto status = encap_runner_->Run();
+  absl::Status status = absl::OkStatus();
+  if (!options_.tunnelUri().empty()) {
+    encap_runner_ = std::make_shared<EncapsulationSubProcessRunner>(nigthawk_fn, envoy_routine);
+    status = encap_runner_->Run();
+  } else {
+    // Without a tunnel there is nothing for a child process to do, so do not fork: the parent is
+    // already multithreaded here (the signal handler thread at least), and a fork of a
+    // multithreaded process can deadlock the child on a lock owned by a thread that does not
+    // exist in it, before it ever signals the parent.
+    nigthawk_fn();
+  }
 
   if (!result) {
     return result;


### PR DESCRIPTION
**Description**

This PR is related to #1609

`ProcessImpl::run()` always goes through `EncapsulationSubProcessRunner`, which `fork()`s a child even when no `--tunnel-uri` is configured. In that case the child does nothing but `sem_post()` a process-shared semaphore and `_exit()`, while the parent blocks in `sem_wait()` until it does. The parent is already multithreaded at that point (at least the `SignalHandler` thread; in `-c opt` builds also the allocator's state), so the child can deadlock on a lock owned by a thread that does not exist in it before it ever reaches `sem_post()`, and the client hangs at startup without sending a request. This runs the load in-process unless a tunnel is actually requested; the fork is still used for the tunneling path, where the child runs the encapsulating Envoy.

**Notes for Reviewers**

- The runner's terminate/cancel paths already null-check `encap_runner_`, so no other change is needed.
- Testing: `//test:process_test` and `//test:python_test` (which includes the tunneling integration tests) pass. Version history updated.